### PR TITLE
Java versions CI task

### DIFF
--- a/.github/workflows/ci_macos_windows.yml
+++ b/.github/workflows/ci_macos_windows.yml
@@ -26,7 +26,3 @@ jobs:
 
       - name: Build, Test
         run: ./gradlew build --info
-
-
-
-

--- a/.github/workflows/java_versions.yml
+++ b/.github/workflows/java_versions.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - java-versions-ci
 
   pull_request:
     branches:
@@ -14,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ '8', '11', '16', '17' ]
+        java: [ '8', '11', '16' ] # default is 17. See ci.yml
     name: Java version ${{ matrix.java }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/java_versions.yml
+++ b/.github/workflows/java_versions.yml
@@ -1,16 +1,27 @@
-name: CI
+name: Java versions
 on:
   push:
+    branches:
+      - main
+      - java-versions-ci
+
+  pull_request:
+    branches:
+      - main
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java: [ '8', '11', '16', '17' ]
+    name: Java version ${{ matrix.java }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v3
         with:
           distribution: temurin
-          java-version: 17
+          java-version: ${{ matrix.java }}
 
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2


### PR DESCRIPTION
You can see an example build using the matrix strategy here: https://github.com/growthbook/growthbook-sdk-java/actions/runs/3413437022

<img width="371" alt="image" src="https://user-images.githubusercontent.com/113377031/200398873-39b62992-903c-496d-854e-e57a5c4557e4.png">

Since the above screenshot I've removed version 17 from the matrix because it's redundant—it's the default.
