### PR TITLE
Rename Context to GBContext

### DIFF
--- a/lib/src/main/java/growthbook/sdk/java/GrowthBook.java
+++ b/lib/src/main/java/growthbook/sdk/java/GrowthBook.java
@@ -12,12 +12,12 @@ import java.util.Map;
 
 /**
  * GrowthBook SDK class.
- * Build a context with {@link Context#builder()} or {@link Context#create(String, String, Boolean, Boolean, String, Map, TrackingCallback)}
+ * Build a context with {@link GBContext#builder()} or {@link GBContext#create(String, String, Boolean, Boolean, String, Map, TrackingCallback)}
  * and pass it as an argument to the class constructor.
  */
 public class GrowthBook implements IGrowthBook {
 
-    private final Context context;
+    private final GBContext context;
 
     // dependencies
     private final FeatureEvaluator featureEvaluator;
@@ -29,10 +29,10 @@ public class GrowthBook implements IGrowthBook {
     private ArrayList<ExperimentRunCallback> callbacks = new ArrayList<>();
 
     /**
-     * Initialize the GrowthBook SDK with a provided {@link Context}
-     * @param context {@link Context}
+     * Initialize the GrowthBook SDK with a provided {@link GBContext}
+     * @param context {@link GBContext}
      */
-    public GrowthBook(Context context) {
+    public GrowthBook(GBContext context) {
         this.context = context;
 
         this.featureEvaluator = new FeatureEvaluator();
@@ -41,11 +41,11 @@ public class GrowthBook implements IGrowthBook {
     }
 
     /**
-     * No-args constructor. A {@link Context} with default values is created.
-     * It's recommended to create your own context with {@link Context#builder()} or {@link Context#create(String, String, Boolean, Boolean, String, Map, TrackingCallback)}
+     * No-args constructor. A {@link GBContext} with default values is created.
+     * It's recommended to create your own context with {@link GBContext#builder()} or {@link GBContext#create(String, String, Boolean, Boolean, String, Map, TrackingCallback)}
      */
     public GrowthBook() {
-        this.context = Context.builder().build();
+        this.context = GBContext.builder().build();
 
         // dependencies
         this.featureEvaluator = new FeatureEvaluator();
@@ -61,7 +61,7 @@ public class GrowthBook implements IGrowthBook {
      * @param conditionEvaluator ConditionEvaluator
      * @param experimentEvaluator ExperimentEvaluator
      */
-    GrowthBook(Context context, FeatureEvaluator featureEvaluator, ConditionEvaluator conditionEvaluator, ExperimentEvaluator experimentEvaluator) {
+    GrowthBook(GBContext context, FeatureEvaluator featureEvaluator, ConditionEvaluator conditionEvaluator, ExperimentEvaluator experimentEvaluator) {
         this.featureEvaluator = featureEvaluator;
         this.conditionEvaluator = conditionEvaluator;
         this.experimentEvaluatorEvaluator = experimentEvaluator;

--- a/lib/src/main/java/growthbook/sdk/java/internal/services/ExperimentEvaluator.java
+++ b/lib/src/main/java/growthbook/sdk/java/internal/services/ExperimentEvaluator.java
@@ -18,7 +18,7 @@ public class ExperimentEvaluator implements IExperimentEvaluator {
     private final ConditionEvaluator conditionEvaluator = new ConditionEvaluator();
 
     @Override
-    public <ValueType> ExperimentResult<ValueType> evaluateExperiment(Experiment<ValueType> experiment, Context context, @Nullable String featureId) {
+    public <ValueType> ExperimentResult<ValueType> evaluateExperiment(Experiment<ValueType> experiment, GBContext context, @Nullable String featureId) {
         // If less than 2 variations, return immediately (not in experiment, variation 0)
         // If not enabled, return immediately (not in experiment, variation 0)
         ArrayList<ValueType> experimentVariations = experiment.getVariations();
@@ -146,7 +146,7 @@ public class ExperimentEvaluator implements IExperimentEvaluator {
 
     private <ValueType> ExperimentResult<ValueType> getExperimentResult(
             Experiment<ValueType> experiment,
-            Context context,
+            GBContext context,
             Integer variationIndex,
             Boolean inExperiment,
             Boolean hashUsed,

--- a/lib/src/main/java/growthbook/sdk/java/internal/services/FeatureEvaluator.java
+++ b/lib/src/main/java/growthbook/sdk/java/internal/services/FeatureEvaluator.java
@@ -2,7 +2,6 @@ package growthbook.sdk.java.internal.services;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import growthbook.sdk.java.models.FeatureRule;
 import growthbook.sdk.java.models.*;
 
 /**
@@ -15,7 +14,7 @@ public class FeatureEvaluator implements IFeatureEvaluator {
     private final ExperimentEvaluator experimentEvaluator = new ExperimentEvaluator();
 
     @Override
-    public <ValueType> FeatureResult<ValueType> evaluateFeature(String key, Context context) throws ClassCastException {
+    public <ValueType> FeatureResult<ValueType> evaluateFeature(String key, GBContext context) throws ClassCastException {
         FeatureResult<ValueType> emptyFeature = FeatureResult
                 .<ValueType>builder()
                 .value(null)

--- a/lib/src/main/java/growthbook/sdk/java/internal/services/IExperimentEvaluator.java
+++ b/lib/src/main/java/growthbook/sdk/java/internal/services/IExperimentEvaluator.java
@@ -1,11 +1,11 @@
 package growthbook.sdk.java.internal.services;
 
-import growthbook.sdk.java.models.Context;
+import growthbook.sdk.java.models.GBContext;
 import growthbook.sdk.java.models.Experiment;
 import growthbook.sdk.java.models.ExperimentResult;
 
 import javax.annotation.Nullable;
 
 interface IExperimentEvaluator {
-    <ValueType> ExperimentResult<ValueType> evaluateExperiment(Experiment<ValueType> experiment, Context context, @Nullable String featureId);
+    <ValueType> ExperimentResult<ValueType> evaluateExperiment(Experiment<ValueType> experiment, GBContext context, @Nullable String featureId);
 }

--- a/lib/src/main/java/growthbook/sdk/java/internal/services/IFeatureEvaluator.java
+++ b/lib/src/main/java/growthbook/sdk/java/internal/services/IFeatureEvaluator.java
@@ -1,6 +1,6 @@
 package growthbook.sdk.java.internal.services;
 
-import growthbook.sdk.java.models.Context;
+import growthbook.sdk.java.models.GBContext;
 import growthbook.sdk.java.models.FeatureResult;
 
 interface IFeatureEvaluator {
@@ -13,5 +13,5 @@ interface IFeatureEvaluator {
      * @return feature result
      * @throws ClassCastException When a value type fails to cast to the provided type, this can throw an exception
      */
-    <ValueType> FeatureResult<ValueType> evaluateFeature(String key, Context context);
+    <ValueType> FeatureResult<ValueType> evaluateFeature(String key, GBContext context);
 }

--- a/lib/src/main/java/growthbook/sdk/java/models/ExperimentResult.java
+++ b/lib/src/main/java/growthbook/sdk/java/models/ExperimentResult.java
@@ -13,7 +13,7 @@ import javax.annotation.Nullable;
 import java.lang.reflect.Type;
 
 /**
- * The result of running an {@link Experiment} given a specific {@link Context}
+ * The result of running an {@link Experiment} given a specific {@link GBContext}
  *
  * <ul>
  * <li>inExperiment (boolean) - Whether or not the user is part of the experiment</li>

--- a/lib/src/main/java/growthbook/sdk/java/models/FeatureResult.java
+++ b/lib/src/main/java/growthbook/sdk/java/models/FeatureResult.java
@@ -12,7 +12,7 @@ import javax.annotation.Nullable;
 import java.lang.reflect.Type;
 
 /**
- * Results for a {@link FeatureEvaluator#evaluateFeature(String, Context)}
+ * Results for a {@link FeatureEvaluator#evaluateFeature(String, GBContext)}
  *
  * <ul>
  * <li>value (any) - The assigned value of the feature</li>

--- a/lib/src/main/java/growthbook/sdk/java/models/GBContext.java
+++ b/lib/src/main/java/growthbook/sdk/java/models/GBContext.java
@@ -12,14 +12,14 @@ import java.util.Map;
 
 /**
  * Context object passed into the GrowthBook constructor.
- * The {@link Context#builder()} is recommended for constructing a Context.
+ * The {@link GBContext#builder()} is recommended for constructing a Context.
  * Alternatively, you can use the static {@link #create(String, String, Boolean, Boolean, String, Map, TrackingCallback)} method.
  */
 @Data @Builder
-public class Context {
+public class GBContext {
 
     /**
-     * The {@link Context.ContextBuilder} is recommended for constructing a Context.
+     * The {@link GBContextBuilder} is recommended for constructing a Context.
      * Alternatively, you can use this static method instead of the builder.
      * @param attributesJson User attributes as JSON string
      * @param featuresJson Features response as JSON string
@@ -30,7 +30,7 @@ public class Context {
      * @param trackingCallback A function that takes {@link Experiment} and {@link ExperimentResult} as arguments.
      * @return created context
      */
-    public static Context create(
+    public static GBContext create(
             @Nullable String attributesJson,
             @Nullable String featuresJson,
             @Nullable Boolean isEnabled,
@@ -39,7 +39,7 @@ public class Context {
             @Nullable Map<String, Integer> forcedVariationsMap,
             @Nullable TrackingCallback trackingCallback
     ) {
-        return Context
+        return GBContext
                 .builder()
                 .attributesJson(attributesJson)
                 .featuresJson(featuresJson)
@@ -82,7 +82,7 @@ public class Context {
     public void setAttributesJson(String attributesJson) {
         this.attributesJson = attributesJson;
         if (attributesJson != null) {
-            this.setAttributes(Context.transformAttributes(attributesJson));
+            this.setAttributes(GBContext.transformAttributes(attributesJson));
         }
     }
 
@@ -105,7 +105,7 @@ public class Context {
     public void setFeaturesJson(String featuresJson) {
         this.featuresJson = featuresJson;
         if (featuresJson != null) {
-            this.setFeatures(Context.transformFeatures(featuresJson));
+            this.setFeatures(GBContext.transformFeatures(featuresJson));
         }
     }
 
@@ -114,25 +114,25 @@ public class Context {
     private Map<String, Integer> forcedVariationsMap = new HashMap<>();
 
     /**
-     * The builder class to help create a context. You can use {@link #builder()} or {@link #create(String, String, Boolean, Boolean, String, Map, TrackingCallback)} to create a {@link Context}
+     * The builder class to help create a context. You can use {@link #builder()} or {@link #create(String, String, Boolean, Boolean, String, Map, TrackingCallback)} to create a {@link GBContext}
      */
-    public static class ContextBuilder {} // This stub is required for JavaDoc and is filled by Lombuk
+    public static class GBContextBuilder {} // This stub is required for JavaDoc and is filled by Lombuk
 
     /**
-     * The builder class to help create a context. You can use this or {@link #create(String, String, Boolean, Boolean, String, Map, TrackingCallback)} to create a {@link Context}
-     * @return {@link CustomContextBuilder}
+     * The builder class to help create a context. You can use this or {@link #create(String, String, Boolean, Boolean, String, Map, TrackingCallback)} to create a {@link GBContext}
+     * @return {@link CustomGBContextBuilder}
      */
-    public static ContextBuilder builder() {
-        return new CustomContextBuilder();
+    public static GBContextBuilder builder() {
+        return new CustomGBContextBuilder();
     }
 
-    static class CustomContextBuilder extends ContextBuilder {
+    static class CustomGBContextBuilder extends GBContextBuilder {
         @Override
-        public Context build() {
-            Context context = super.build();
+        public GBContext build() {
+            GBContext context = super.build();
 
             if (context.featuresJson != null) {
-                context.setFeatures(Context.transformFeatures(context.featuresJson));
+                context.setFeatures(GBContext.transformFeatures(context.featuresJson));
             }
 
             context.setAttributesJson(context.attributesJson);

--- a/lib/src/test/java/growthbook/sdk/java/GrowthBookTest.java
+++ b/lib/src/test/java/growthbook/sdk/java/GrowthBookTest.java
@@ -54,7 +54,7 @@ class GrowthBookTest {
 //            System.out.printf("\n features: %s", featuresJson);
 //            System.out.printf("\n attributesJson: %s", attributesJson);
 
-            Context context = Context
+            GBContext context = GBContext
                     .builder()
                     .featuresJson(featuresJson)
                     .attributesJson(attributesJson)
@@ -135,7 +135,7 @@ class GrowthBookTest {
 
             TestContext testContext = jsonUtils.gson.fromJson(testCase.get("context").getAsJsonObject(), TestContext.class);
 
-            Context context = Context
+            GBContext context = GBContext
                     .builder()
                     .featuresJson(testContext.features)
                     .attributesJson(testContext.attributes)
@@ -195,7 +195,7 @@ class GrowthBookTest {
         String attributes = "{ \"user_group\": \"subscriber\", \"beta_users\": true }";
         String features = TestCasesJsonHelper.getInstance().getDemoFeaturesJson();
 
-        Context context = Context
+        GBContext context = GBContext
                 .builder()
                 .featuresJson(features)
                 .attributesJson(attributes)
@@ -212,7 +212,7 @@ class GrowthBookTest {
         String attributes = "{ \"user_group\": \"standard\", \"beta_users\": false }";
         String features = TestCasesJsonHelper.getInstance().getDemoFeaturesJson();
 
-        Context context = Context
+        GBContext context = GBContext
                 .builder()
                 .featuresJson(features)
                 .attributesJson(attributes)
@@ -229,7 +229,7 @@ class GrowthBookTest {
         String attributes = "{ \"user_group\": \"subscriber\", \"beta_users\": true }";
         String features = TestCasesJsonHelper.getInstance().getDemoFeaturesJson();
 
-        Context context = Context
+        GBContext context = GBContext
                 .builder()
                 .featuresJson(features)
                 .attributesJson(attributes)
@@ -247,7 +247,7 @@ class GrowthBookTest {
         String attributes = "{ \"user_group\": \"subscriber\", \"beta_users\": true }";
         String features = TestCasesJsonHelper.getInstance().getDemoFeaturesJson();
 
-        Context context = Context
+        GBContext context = GBContext
                 .builder()
                 .featuresJson(features)
                 .attributesJson(attributes)
@@ -265,7 +265,7 @@ class GrowthBookTest {
         String attributes = "{ \"user_group\": \"subscriber\", \"beta_users\": false }";
         String features = TestCasesJsonHelper.getInstance().getDemoFeaturesJson();
 
-        Context context = Context
+        GBContext context = GBContext
                 .builder()
                 .featuresJson(features)
                 .attributesJson(attributes)
@@ -283,7 +283,7 @@ class GrowthBookTest {
         String attributes = "{ \"admin\": true }";
         String features = TestCasesJsonHelper.getInstance().getDemoFeaturesJson();
 
-        Context context = Context
+        GBContext context = GBContext
                 .builder()
                 .featuresJson(features)
                 .attributesJson(attributes)
@@ -301,7 +301,7 @@ class GrowthBookTest {
         String attributes = "{ \"admin\": true }";
         String features = TestCasesJsonHelper.getInstance().getDemoFeaturesJson();
 
-        Context context = Context
+        GBContext context = GBContext
                 .builder()
                 .featuresJson(features)
                 .attributesJson(attributes)
@@ -319,7 +319,7 @@ class GrowthBookTest {
         String attributes = "{ \"user\": \"standard\" }";
         String features = TestCasesJsonHelper.getInstance().getDemoFeaturesJson();
 
-        Context context = Context
+        GBContext context = GBContext
                 .builder()
                 .featuresJson(features)
                 .attributesJson(attributes)
@@ -337,7 +337,7 @@ class GrowthBookTest {
         String attributes = "{ \"user\": \"standard\" }";
         String features = TestCasesJsonHelper.getInstance().getDemoFeaturesJson();
 
-        Context context = Context
+        GBContext context = GBContext
                 .builder()
                 .featuresJson(features)
                 .attributesJson(attributes)
@@ -361,7 +361,7 @@ class GrowthBookTest {
         String attributes = "{ \"user\": \"standard\" }";
         String features = TestCasesJsonHelper.getInstance().getDemoFeaturesJson();
 
-        Context context = Context
+        GBContext context = GBContext
                 .builder()
                 .featuresJson(features)
                 .attributesJson(attributes)
@@ -380,7 +380,7 @@ class GrowthBookTest {
         ConditionEvaluator mockConditionEvaluator = mock(ConditionEvaluator.class);
         ExperimentEvaluator mockExperimentEvaluator = mock(ExperimentEvaluator.class);
         FeatureEvaluator mockFeatureEvaluator = mock(FeatureEvaluator.class);
-        Context context = Context.builder().build();
+        GBContext context = GBContext.builder().build();
 
         String attrJson = "{ id: 1 }";
         String conditionJson = "{}";
@@ -423,7 +423,7 @@ class GrowthBookTest {
         String features = "{}";
         String attributes = "{}";
 
-        Context context = Context
+        GBContext context = GBContext
                 .builder()
                 .featuresJson(features)
                 .attributesJson(attributes)
@@ -442,7 +442,7 @@ class GrowthBookTest {
         String features = "{}";
         String attributes = "{}";
 
-        Context context = Context
+        GBContext context = GBContext
                 .builder()
                 .featuresJson(features)
                 .attributesJson(attributes)
@@ -461,7 +461,7 @@ class GrowthBookTest {
         String features = "{}";
         String attributes = "{}";
 
-        Context context = Context
+        GBContext context = GBContext
                 .builder()
                 .featuresJson(features)
                 .attributesJson(attributes)
@@ -480,7 +480,7 @@ class GrowthBookTest {
         String features = "{}";
         String attributes = "{}";
 
-        Context context = Context
+        GBContext context = GBContext
                 .builder()
                 .featuresJson(features)
                 .attributesJson(attributes)
@@ -499,7 +499,7 @@ class GrowthBookTest {
         String features = "{}";
         String attributes = "{}";
 
-        Context context = Context
+        GBContext context = GBContext
                 .builder()
                 .featuresJson(features)
                 .attributesJson(attributes)

--- a/lib/src/test/java/growthbook/sdk/java/models/GBContextTest.java
+++ b/lib/src/test/java/growthbook/sdk/java/models/GBContextTest.java
@@ -11,7 +11,7 @@ import java.util.HashMap;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.verify;
 
-class ContextTest {
+class GBContextTest {
     private AutoCloseable closeable;
     @Mock
     private TrackingCallback trackingCallback;
@@ -38,7 +38,7 @@ class ContextTest {
         forcedVariations.put("other-test", 1);
         String featuresJson = "{}";
 
-        Context subject = Context.create(
+        GBContext subject = GBContext.create(
                 sampleUserAttributes,
                 featuresJson,
                 isEnabled,
@@ -57,7 +57,7 @@ class ContextTest {
         Boolean isQaMode = false;
         String url = "http://localhost:3000";
 
-        Context subject = Context
+        GBContext subject = GBContext
                 .builder()
                 .enabled(isEnabled)
                 .attributesJson(sampleUserAttributes)
@@ -85,7 +85,7 @@ class ContextTest {
 
     @Test
     void canExecuteATrackingCallback() {
-        Context subject = Context
+        GBContext subject = GBContext
                 .builder()
                 .trackingCallback(trackingCallback)
                 .build();


### PR DESCRIPTION
These changes rename the `Context` class to `GBContext`. This is to avoid possible naming conflicts, considering the class name is commonly used in some Java frameworks, e.g. Android. While developers could use the fully-qualified package path instead of importing the class, e.g. `growthbook.sdk.java.models.Context context = growthbook.sdk.java.models.Context.builder().build();` it would be less verbose to import the class under a different name and write `GBContext context = GBContext.builder().build();`