### PR TITLE
Support for decryption

### DIFF
--- a/lib/src/main/java/growthbook/sdk/java/DecryptionUtils.java
+++ b/lib/src/main/java/growthbook/sdk/java/DecryptionUtils.java
@@ -25,15 +25,12 @@ public class DecryptionUtils {
             String cipherText = parts[1];
 
             byte[] decodedIv = Base64.getDecoder().decode(iv.getBytes(StandardCharsets.UTF_8));
-
             IvParameterSpec ivParameterSpec = new IvParameterSpec(decodedIv);
 
             Cipher cipher = Cipher.getInstance("AES/CBC/NOPADDING");
-
             cipher.init(Cipher.DECRYPT_MODE, DecryptionUtils.keyFromSecret(encryptionKey), ivParameterSpec);
 
             byte[] decodedCipher = Base64.getDecoder().decode(cipherText.getBytes(StandardCharsets.UTF_8));
-
             byte[] plainText = cipher.doFinal(decodedCipher);
 
             return new String(plainText);

--- a/lib/src/main/java/growthbook/sdk/java/DecryptionUtils.java
+++ b/lib/src/main/java/growthbook/sdk/java/DecryptionUtils.java
@@ -37,14 +37,15 @@ public class DecryptionUtils {
             byte[] plainText = cipher.doFinal(decodedCipher);
 
             return new String(plainText);
+        } catch (InvalidAlgorithmParameterException e) {
+            throw new IllegalArgumentException("Invalid payload");
         } catch (InvalidKeyException e) {
             throw new IllegalArgumentException("Invalid encryption key");
         } catch (
                 NoSuchAlgorithmException
                 | NoSuchPaddingException
                 | IllegalBlockSizeException
-                | BadPaddingException
-                | InvalidAlgorithmParameterException e
+                | BadPaddingException e
         ) {
             e.printStackTrace();
             throw new RuntimeException(e);

--- a/lib/src/main/java/growthbook/sdk/java/DecryptionUtils.java
+++ b/lib/src/main/java/growthbook/sdk/java/DecryptionUtils.java
@@ -1,0 +1,60 @@
+package growthbook.sdk.java;
+
+import javax.crypto.BadPaddingException;
+import javax.crypto.Cipher;
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.NoSuchPaddingException;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+
+public class DecryptionUtils {
+    public static String decrypt(String payload, String encryptionKey) {
+        if (!payload.contains(".")) {
+            throw new IllegalArgumentException("Invalid payload");
+        }
+
+        try {
+            String[] parts = payload.split("\\.");
+
+            String iv = parts[0];
+            String cipherText = parts[1];
+
+            byte[] decodedIv = Base64.getDecoder().decode(iv.getBytes(StandardCharsets.UTF_8));
+
+            IvParameterSpec ivParameterSpec = new IvParameterSpec(decodedIv);
+
+            Cipher cipher = Cipher.getInstance("AES/CBC/NOPADDING");
+
+            cipher.init(Cipher.DECRYPT_MODE, DecryptionUtils.keyFromSecret(encryptionKey), ivParameterSpec);
+
+            byte[] decodedCipher = Base64.getDecoder().decode(cipherText.getBytes(StandardCharsets.UTF_8));
+
+            byte[] plainText = cipher.doFinal(decodedCipher);
+
+            return new String(plainText);
+        } catch (InvalidKeyException e) {
+            throw new IllegalArgumentException("Invalid encryption key");
+        } catch (
+                NoSuchAlgorithmException
+                | NoSuchPaddingException
+                | IllegalBlockSizeException
+                | BadPaddingException
+                | InvalidAlgorithmParameterException e
+        ) {
+            e.printStackTrace();
+            throw new RuntimeException(e);
+        }
+    }
+
+
+    private static SecretKeySpec keyFromSecret(String encryptionKey) {
+        byte[] encodedKeyBytes = encryptionKey.getBytes(StandardCharsets.UTF_8);
+        byte[] keyBytes = Base64.getDecoder().decode(encodedKeyBytes);
+        return new SecretKeySpec(keyBytes, "AES");
+    }
+}

--- a/lib/src/test/java/growthbook/sdk/java/DecryptionUtilsTest.java
+++ b/lib/src/test/java/growthbook/sdk/java/DecryptionUtilsTest.java
@@ -1,0 +1,55 @@
+package growthbook.sdk.java;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class DecryptionUtilsTest {
+    @Test
+    void test_canDecryptEncryptedPayload_1() {
+        String payload = "7rvPA94JEsqRo9yPZsdsXg==.bJ8vtYvX+ur3cEUFVkYo1OyWb98oLnMlpeoO0Hs4YPc0EVb7oKX4KNz+Yt6GUMBsieXqtL7oaYzX+kMayZEtV+3bhyDYnS9QBrvalnfxbLExjtnsy8g0pPQHU/P/DPIzO0F+pphcahRfi+3AMTnIreqvkqrcX+MyOwHN56lqEs23Vp4Rsq2qDow/LZmn5kpwMNhMY0DBq7jC+lh2Oyly0g==";
+        String encryptionKey = "BhB1wORFmZLTDjbvstvS8w==";
+
+        String expected = "{\"greeting\":{\"defaultValue\":\"hello\",\"rules\":[{\"condition\":{\"country\":\"france\"},\"force\":\"bonjour\"},{\"condition\":{\"country\":\"mexico\"},\"force\":\"hola\"}]}}";
+
+        String actual = DecryptionUtils.decrypt(payload, encryptionKey);
+
+        assertEquals(expected, actual.trim());
+    }
+
+    @Test
+    void test_canDecryptEncryptedPayload_2() {
+        String payload = "t58u96klH/wWz7bDILc7Fg==.9B3oXpLmsp0zxNsvOAbRVu1/fuyNyTDyJlXCNZWN42uEHagW/1KV/RbWZyDYWNpcxhKGmiUqJl1Pf7FR2I756c8MSSkrwBVg9vdkKqKlRCRh2NSg7ypeWIuLoo97OtwA0lgzbh7G/N6ESc85kmbr2JA4nMRAJYazPN9o4pqTzhl4d+C2yzyz19H+VhZGirjQxgtMhDsfF95i6EvwkenGKGYcJvx+vXWukyMvhXs0gOvNIXqoYsN6qgJ+bZgFmsIyset1FmnyYWf09/tjTr51D8C7PRF60e5sG2ub72ym0miVyD3BCRgU1lGi/p+dH5G6vm4Sb95pRzCsWQxh1++2cHgclFGs+Uan3JgR75KcPGuTJnmJ+Vo6FejLacqnt1pDDDYjx8U6HPxWZ8EfOkuKH6n4MrICzm4D0zwIZv/FueTo2kc8Uk1ce5Ht9qeNEJfwV0Px1D9ld29wQesV+dKskHXhEvDY/sj1GwbvKnLoXy0cfw07yZisnhP/6z1yOk4YivN+jwy7r++5/9ZQuZWUdZn+QPd3Vn4BqZU+exvYQCQsbgHqYTMI0NTsatxBXPB7mgTS4evukXY9kyQj+MuDg52CXy79FQNdVP9B1GJItyztxUqJgzpbCJFpCwula7GK6VUAQ2xTgZqHXXZIiCHnbIxA2Rezt2noecnl23N92Z+RwZc/6tGnhysomR7TSif8Qss4ityWRUX9E5T2+HIfUBdZ6LDf5TvLMi45X3d6tMX9iVTa6gKt1jmbmwB2aJ0qfEhcg7aKkH0nmn8OAYPeq2rwSKAbQ15P7eneNjv2H3TJk6asgbwOsXYwe0LUosWCPKjeNhPIhi755zzzsUvPpR9PiwKqAcAUoxiYWG+HVgZWns13KpRXV9py1cl3GjkX04DgeoVuEiMAvblBxaz6S1zgxUgaTrHPb6GT1JJ3CcWmKThdGOmE+9OMmPkTJNDWD9F1zAKnNmLmhEyzpSfNrQnG3NyBVVS8ickOjMnLP40ks4aqjO5A3qkq7y4jKgdX2V+0nuwdTPLqX6YYJ/wVode7U9Dale0ky6Izbln5ZenpkTZHpXKwkJ4i74l4Bxgqf83nbo0oVTafkidahQLNpY/e93f1of+G16HtoL5cw5FAKllNqg2GlJ1AJHWZsu1oHdFlxquNQss8d/A48xdm/ieJn/2Rj1EARvPvGGRp1BIPG1Ugu3tGfAzklNueKLKHy+mV5BR7g5F3Dlt3L1vCYZxs29whhyP3O2t/oZppEYfrXxOmZmmqqdUbVh+Mh+J/wm/lI8AAJ0Ht/zcG1M9DJ1vavpK6TJyDCo/Gn981pQ1MuPerNQbYEfEurJGGCWc6BS/ftib73nQOQz6odeYSrCmfXAxHovBPeLGQGIwKP0Lq/DcmzP/KpC16skWm/msD6RpIlhG6EWYv2LBWJx9PnVrtc9UI9TXgW6oUZ2x3IAAK+ASN7dKBC3unVt7JZ2KyVbyOmSV6b8TNJP51WjlOBPZ0FsytoMZIs4MkrAhOYuurVcC8tSbflrhKjQRpsgTW95lF9ompQgtfwzgdN11i2JINC3xZNIFStCYGKhelD8aEPlMc4y41hL332/XBciRGR9ekH52LOjeLIXOrfyTqda8qM2PuWbMolVUAlXe4hgU6M07vB5uPfzpGr+EkNyIvINEpQiITkTnYOXIRUCAbWoJxNHcL9qJOwqsrDvOkai1S+4Z2zI6UTjgy63W5Hjw+iVgf04DCMEYHv2y76pLohzY/RrQ/Xwn1FwUGHAMWtfka0PKZSmpVGMR6H10IhBO7wUuWMU8TUYFKPZGdhMr01pOnot7nTdBI0Qlw3Y7/KEa1lcekAn2RSbP3JbMFLT6Vh6rTvWIMIjD/aSUZ0L0CGnw6/FbQ4joQsUFPQB/r4SP9/EAkoAvc01ZysjN4TZFPnbwH1gfC5gWK55mHGmgdadcFpGDvyzTQIBKyOSJ3ZEzjyDxOFsf/Q+fSZinjKkqAfwCjpfLd5KQz8XT0nIVEd51j1XrQZ9rIrsQJg+PwWitBwcpZiARJ+WGz80dh1IRq970x+y6aV6GqQHwXky1b3rRFwQo7/TZghTLL4lALBiEZ+WOPMsgNMShEqZovqF8CaabBXCwenv8t43dzRuTBUHmvCCFNq+X47aPktAFNmGr4JSlU3MCq2cC29IdvUC+rrScagbNjtBaECcEMUiOhS9cgQh1Zs+V4/d+WoPQBRsSXt04/iMYCxV65h4TOCWpYPTgNMFFuVwOWL/b4GN+apNFEEuHzI4j3CD1FUxH5+Dn+yLdJ+69//C+STBddxhrW4MhKtEr5dEOz7VYIOTIz9WQjEXr1vngVsWnDoErS1mJzhPRrh5QXl6treh866YWBAieg2Y6i4AyYzVEqMvHU0bubho/0TEzeNNUVR5DvFVmFZ+Kv1rySUswzr3q9L2sLZ4EeNZomJBSur6Ya88dmLhL5rA6beFHxJjvfO6Q2U+qQIM82NedL/O5xsOQX3+m9e53AvFgOoSoRzkoY2YAVmXuWeEJiXgbibOXcnbwfiLTnUjb1tguHo2hxzcDg9bZgvjCpi8MduVR3gKvTxTNDi9IuIkgie3uFO7iNcMX6iWtOIKJt8zoIYILim9DRBw08J24hEIfIgTWp8uB0nklm12mgeF6km+KA2Kdmu7pGXPMwPFedH3PMaycjCA9P/NQt88qts7y/TXJQKGaL8e6EC1NYK14YODI76OiFT1WZE+Bbp1BQ6vdQ3tOL3tgVkAD4W+T4Q+F909+KZDu1M6EWtIyYgtVj2RcxbqrM7SiexS4fNTZAwVaf4NS7ND5uS3rBaPPQJb2aUEm6Mt+VBa82eRRWsRJktm7DRKPkrb3Jy3sHp9zIBXLRRuHY8iCkNt4BhsJ8av1sE7eHNjWl28jF1paMu5aq/nvfQ1Tsn2s3BefJzRwnRS334saFSMNbgq9rImgGW2M7wLRKHfg7BDrQhPlICnA5Gt9MkyRfw5qweNVDCE7NfzYLMs2vU2YYxRkHoNP3nsC+XlTwvFODqsUg53eR4fBGm5CvEXTkm7cZv8FynovOwC4Z0aLBa4QGg5EJTdApHYxK4LDhS1sLu8CfXtPLA41sZTgzkzL5po0tAT2gWtdkuD3SW9AcOdcwb6A2EC/BrG0EJDQMzNjoTRIItaGRYgaIkBZTcUAywp5Ti+p//UXnQzfoE6DbXD56ruD1bXplwTxGxL/D68VcGu4O2oaggw9ACsaaK2qJIVxnVWcqTK3oOwKbxtZvPWtGvlGlI2zYFxDd0vAoi3yQKN2efQPDinvljOmEKMYYH/pRa4WBiqZmPVm0X3ZNjLOyE1v8KMrqvk/WVN4+5sKSmbDAeDOPfBn0+a3suSEWLpqUopxtI0b7HLemNZ6SkN9ZF/8ya+dXlAi53MteTGyJTiHEW+CrbG82EF/qJI5npRZPhu/GZ8/k7EQ4O6PUZUAym7KEptYiuZVuQgJkrIBJQIMuqqa3XNGBaHiyiOkBeWMjzF5bb4nFJVOEg47hjfEBB/AmLLorIFlGCpZnWJeyHHfsgl83sQq0rGxY+ss6Rn/XkYv1D0MrWEifzQRNLJ1sdOTwO8k8PJG2W5b9ZVYK/yqsIDTR9mcJRhAuufjaNyxLv9anold3GesBMvxlRCyfcfgy6g3w5AT/oiVyknJzY/WjNzTqurxQS92xQUchB2C1ldX67e3AI9EFJ9fs7jskXuyOHTjDF7sZvNCPDFp08myXdcrkCGWuoiRKu2VFtX0yKZU=";
+        String encryptionKey = "5FVDjWF4ThInixRmwbMaLA==";
+
+        String expected = "{\"testfeatureabc\":{\"defaultValue\":false,\"rules\":[{\"condition\":{\"id\":\"123\"},\"force\":true},{\"condition\":{\"id\":\"123\"},\"force\":true},{\"condition\":{\"id\":\"123\"},\"force\":true},{\"force\":true},{\"condition\":{\"id\":\"test\"},\"force\":true}]},\"savedgroupfeature\":{\"defaultValue\":true,\"rules\":[{\"condition\":{\"id\":{\"$in\":[\"1\",\"2\",\"3\",\"4\"]}},\"force\":false}]},\"anotherfeatureusingsavedgroup\":{\"defaultValue\":false,\"rules\":[{\"condition\":{\"id\":{\"$in\":[\"1\",\"2\",\"3\",\"4\"]}},\"force\":true}]},\"feature-with-test-saved-group\":{\"defaultValue\":false,\"rules\":[{\"condition\":{\"id\":{\"$in\":[\"1\",\"2\",\"3\",\"4\",\"5\",\"6\",\"7\"]}},\"force\":true}]},\"testexperiment\":{\"defaultValue\":\"bar\",\"rules\":[{\"variations\":[\"bar\",\"foo\",\"foo\"],\"coverage\":1,\"weights\":[0.334,0.333,0.333],\"key\":\"testexperiment\",\"hashAttribute\":\"id\"}]},\"test\":{\"defaultValue\":true,\"rules\":[{\"condition\":{\"id\":\"1234\"},\"force\":false}]},\"bug-test\":{\"defaultValue\":true},\"experiment-with-variations\":{\"defaultValue\":0,\"rules\":[{\"condition\":{\"id\":\"test\"},\"force\":1},{\"variations\":[1,1,0],\"coverage\":1,\"weights\":[0.333,0.333,0.333],\"hashAttribute\":\"id\"},{\"variations\":[1,0,1,1,1],\"coverage\":1,\"weights\":[0.2,0.2,0.2,0.2,0.2],\"hashAttribute\":\"id\"},{\"variations\":[1,0,1,1],\"coverage\":1,\"weights\":[0.25,0.25,0.25,0.25],\"hashAttribute\":\"id\"},{\"variations\":[0,1,1,1,1],\"coverage\":1,\"weights\":[0.2,0.2,0.2,0.2,0.2],\"hashAttribute\":\"id\"}]},\"test-experiment\":{\"defaultValue\":0,\"rules\":[{\"variations\":[0,1],\"coverage\":1,\"weights\":[0.5,0.5],\"key\":\"test-experiment\",\"hashAttribute\":\"id\"}]},\"test-experiement-2\":{\"defaultValue\":0,\"rules\":[{\"variations\":[0,1],\"coverage\":1,\"weights\":[0.5,0.5],\"key\":\"test-experiement-2\",\"hashAttribute\":\"id\"}]},\"test-with-stashed-changes\":{\"defaultValue\":0,\"rules\":[{\"variations\":[0,1,1],\"coverage\":1,\"weights\":[0.333,0.333,0.333],\"key\":\"test-with-stashed-changes\",\"hashAttribute\":\"id\"}]},\"test-123\":{\"defaultValue\":0,\"rules\":[{\"variations\":[0,1,1,1],\"coverage\":1,\"weights\":[0.25,0.25,0.25,0.25],\"key\":\"test-123\",\"hashAttribute\":\"id\"}]},\"test-with-usememo\":{\"defaultValue\":0,\"rules\":[{\"variations\":[1,0,0,1],\"coverage\":1,\"weights\":[0.25,0.25,0.25,0.25],\"key\":\"test-with-usememo\",\"hashAttribute\":\"id\"}]},\"test-from-scratch\":{\"defaultValue\":0,\"rules\":[{\"variations\":[0,1,1],\"coverage\":1,\"weights\":[0.333,0.333,0.333],\"key\":\"test-from-scratch\",\"hashAttribute\":\"id\"}]},\"test1234\":{\"defaultValue\":0,\"rules\":[{\"variations\":[0,1,1,1],\"coverage\":1,\"weights\":[0.25,0.25,0.25,0.25],\"key\":\"test1234\",\"hashAttribute\":\"id\"}]},\"my-feature\":{\"defaultValue\":true},\"test-with-changes\":{\"defaultValue\":{},\"rules\":[{\"variations\":[{},{},{}],\"coverage\":1,\"weights\":[0.333,0.333,0.333],\"key\":\"test-with-changes\",\"hashAttribute\":\"id\"}]},\"test-with-adnan\":{\"defaultValue\":false,\"rules\":[{\"variations\":[false,true],\"coverage\":1,\"weights\":[0.5,0.5],\"key\":\"test-with-adnan\",\"hashAttribute\":\"id\"}]}}";
+
+        String actual = DecryptionUtils.decrypt(payload, encryptionKey);
+
+        assertEquals(expected, actual.trim());
+    }
+
+    @Test
+    void test_throwsArgumentExceptionWhenPayloadInvalid() {
+        String payload = "foobar";
+        String encryptionKey = "BhB1wORFmZLTDjbvstvS8w==";
+
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+            DecryptionUtils.decrypt(payload, encryptionKey);
+        });
+
+        assertTrue(exception.getMessage().contains("Invalid payload"));
+    }
+
+    @Test
+    void test_throwsArgumentExceptionWhenEncryptionKeyInvalid() {
+        String payload = "7rvPA94JEsqRo9yPZsdsXg==.bJ8vtYvX+ur3cEUFVkYo1OyWb98oLnMlpeoO0Hs4YPc0EVb7oKX4KNz+Yt6GUMBsieXqtL7oaYzX+kMayZEtV+3bhyDYnS9QBrvalnfxbLExjtnsy8g0pPQHU/P/DPIzO0F+pphcahRfi+3AMTnIreqvkqrcX+MyOwHN56lqEs23Vp4Rsq2qDow/LZmn5kpwMNhMY0DBq7jC+lh2Oyly0g==";
+        String encryptionKey = "foobar";
+
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+            DecryptionUtils.decrypt(payload, encryptionKey);
+        });
+
+        assertTrue(exception.getMessage().contains("Invalid encryption key"));
+    }
+}

--- a/lib/src/test/java/growthbook/sdk/java/DecryptionUtilsTest.java
+++ b/lib/src/test/java/growthbook/sdk/java/DecryptionUtilsTest.java
@@ -42,6 +42,18 @@ class DecryptionUtilsTest {
     }
 
     @Test
+    void test_throwsArgumentExceptionWhenPayloadInvalid_decodingIv() {
+        String payload = "foobar.bar";
+        String encryptionKey = "BhB1wORFmZLTDjbvstvS8w==";
+
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+            DecryptionUtils.decrypt(payload, encryptionKey);
+        });
+
+        assertTrue(exception.getMessage().contains("Invalid payload"));
+    }
+
+    @Test
     void test_throwsArgumentExceptionWhenEncryptionKeyInvalid() {
         String payload = "7rvPA94JEsqRo9yPZsdsXg==.bJ8vtYvX+ur3cEUFVkYo1OyWb98oLnMlpeoO0Hs4YPc0EVb7oKX4KNz+Yt6GUMBsieXqtL7oaYzX+kMayZEtV+3bhyDYnS9QBrvalnfxbLExjtnsy8g0pPQHU/P/DPIzO0F+pphcahRfi+3AMTnIreqvkqrcX+MyOwHN56lqEs23Vp4Rsq2qDow/LZmn5kpwMNhMY0DBq7jC+lh2Oyly0g==";
         String encryptionKey = "foobar";

--- a/lib/src/test/java/growthbook/sdk/java/GBContextTest.java
+++ b/lib/src/test/java/growthbook/sdk/java/GBContextTest.java
@@ -41,6 +41,7 @@ class GBContextTest {
         GBContext subject = new GBContext(
                 sampleUserAttributes,
                 featuresJson,
+                null,
                 isEnabled,
                 isQaMode,
                 url,
@@ -98,5 +99,61 @@ class GBContextTest {
         subject.getTrackingCallback().onTrack(experiment, result);
 
         verify(trackingCallback).onTrack(experiment, result);
+    }
+
+    @Test
+    void supportsEncryptedFeaturesUsingConstructor() {
+        Boolean isEnabled = true;
+        Boolean isQaMode = false;
+        String url = "http://localhost:3000";
+        HashMap<String, Integer> forcedVariations = new HashMap<String, Integer>();
+        forcedVariations.put("my-test", 0);
+        forcedVariations.put("other-test", 1);
+        String encryptedFeaturesJson = "7rvPA94JEsqRo9yPZsdsXg==.bJ8vtYvX+ur3cEUFVkYo1OyWb98oLnMlpeoO0Hs4YPc0EVb7oKX4KNz+Yt6GUMBsieXqtL7oaYzX+kMayZEtV+3bhyDYnS9QBrvalnfxbLExjtnsy8g0pPQHU/P/DPIzO0F+pphcahRfi+3AMTnIreqvkqrcX+MyOwHN56lqEs23Vp4Rsq2qDow/LZmn5kpwMNhMY0DBq7jC+lh2Oyly0g==";
+        String encryptionKey = "BhB1wORFmZLTDjbvstvS8w==";
+
+        GBContext subject = new GBContext(
+                sampleUserAttributes,
+                encryptedFeaturesJson,
+                encryptionKey,
+                isEnabled,
+                isQaMode,
+                url,
+                forcedVariations,
+                trackingCallback
+        );
+        String expectedFeaturesJson = "{\"greeting\":{\"defaultValue\":\"hello\",\"rules\":[{\"condition\":{\"country\":\"france\"},\"force\":\"bonjour\"},{\"condition\":{\"country\":\"mexico\"},\"force\":\"hola\"}]}}";
+
+        assertNotNull(subject);
+        assertEquals(expectedFeaturesJson.trim(), subject.getFeaturesJson().trim());
+    }
+
+    @Test
+    void supportsEncryptedFeaturesUsingBuilder() {
+        Boolean isEnabled = true;
+        Boolean isQaMode = false;
+        String url = "http://localhost:3000";
+        HashMap<String, Integer> forcedVariations = new HashMap<String, Integer>();
+        forcedVariations.put("my-test", 0);
+        forcedVariations.put("other-test", 1);
+        String encryptedFeaturesJson = "7rvPA94JEsqRo9yPZsdsXg==.bJ8vtYvX+ur3cEUFVkYo1OyWb98oLnMlpeoO0Hs4YPc0EVb7oKX4KNz+Yt6GUMBsieXqtL7oaYzX+kMayZEtV+3bhyDYnS9QBrvalnfxbLExjtnsy8g0pPQHU/P/DPIzO0F+pphcahRfi+3AMTnIreqvkqrcX+MyOwHN56lqEs23Vp4Rsq2qDow/LZmn5kpwMNhMY0DBq7jC+lh2Oyly0g==";
+        String encryptionKey = "BhB1wORFmZLTDjbvstvS8w==";
+
+        GBContext subject = GBContext
+                .builder()
+                .enabled(isEnabled)
+                .attributesJson(sampleUserAttributes)
+                .url(url)
+                .featuresJson(encryptedFeaturesJson)
+                .encryptionKey(encryptionKey)
+                .forcedVariationsMap(new HashMap<>())
+                .isQaMode(isQaMode)
+                .trackingCallback(trackingCallback)
+                .build();
+
+        String expectedFeaturesJson = "{\"greeting\":{\"defaultValue\":\"hello\",\"rules\":[{\"condition\":{\"country\":\"france\"},\"force\":\"bonjour\"},{\"condition\":{\"country\":\"mexico\"},\"force\":\"hola\"}]}}";
+
+        assertNotNull(subject);
+        assertEquals(expectedFeaturesJson.trim(), subject.getFeaturesJson().trim());
     }
 }

--- a/lib/src/test/java/growthbook/sdk/java/GBContextTest.java
+++ b/lib/src/test/java/growthbook/sdk/java/GBContextTest.java
@@ -146,7 +146,7 @@ class GBContextTest {
                 .url(url)
                 .featuresJson(encryptedFeaturesJson)
                 .encryptionKey(encryptionKey)
-                .forcedVariationsMap(new HashMap<>())
+                .forcedVariationsMap(forcedVariations)
                 .isQaMode(isQaMode)
                 .trackingCallback(trackingCallback)
                 .build();

--- a/lib/src/test/java/growthbook/sdk/java/GrowthBookTest.java
+++ b/lib/src/test/java/growthbook/sdk/java/GrowthBookTest.java
@@ -371,6 +371,26 @@ class GrowthBookTest {
     }
 
     @Test
+    void test_getFeatureValue_returnsFeatureValueFromEncryptedFeatures() {
+        String encryptedFeaturesJson = "7rvPA94JEsqRo9yPZsdsXg==.bJ8vtYvX+ur3cEUFVkYo1OyWb98oLnMlpeoO0Hs4YPc0EVb7oKX4KNz+Yt6GUMBsieXqtL7oaYzX+kMayZEtV+3bhyDYnS9QBrvalnfxbLExjtnsy8g0pPQHU/P/DPIzO0F+pphcahRfi+3AMTnIreqvkqrcX+MyOwHN56lqEs23Vp4Rsq2qDow/LZmn5kpwMNhMY0DBq7jC+lh2Oyly0g==";
+        String encryptionKey = "BhB1wORFmZLTDjbvstvS8w==";
+        String sampleUserAttributes = "{\"country\": \"mexico\", \"device\": \"android\"}";
+
+        GBContext context = GBContext
+                .builder()
+                .attributesJson(sampleUserAttributes)
+                .featuresJson(encryptedFeaturesJson)
+                .encryptionKey(encryptionKey)
+                .build();
+        GrowthBook subject = new GrowthBook(context);
+
+        String result = subject.getFeatureValue("greeting", "hello");
+        String expected = "hola";
+
+        assertEquals(expected, result);
+    }
+
+    @Test
     void test_evaluateCondition_callsConditionEvaluator() {
         ConditionEvaluator mockConditionEvaluator = mock(ConditionEvaluator.class);
         ExperimentEvaluator mockExperimentEvaluator = mock(ExperimentEvaluator.class);

--- a/lib/src/test/java/growthbook/sdk/java/testhelpers/TestCasesJsonHelperTest.java
+++ b/lib/src/test/java/growthbook/sdk/java/testhelpers/TestCasesJsonHelperTest.java
@@ -21,6 +21,6 @@ class TestCasesJsonHelperTest {
         JsonObject testCases = TestCasesJsonHelper.getInstance().getTestCases();
 
         assertNotNull(testCases);
-        assertEquals("0.2.2", testCases.get("specVersion").getAsString());
+        assertEquals("0.2.3", testCases.get("specVersion").getAsString());
     }
 }

--- a/lib/src/test/resources/test-cases.json
+++ b/lib/src/test/resources/test-cases.json
@@ -1,5 +1,5 @@
 {
-  "specVersion": "0.2.2",
+  "specVersion": "0.2.3",
   "evalFeature": [
     {
       "name": "unknown feature key",
@@ -1062,6 +1062,19 @@
         "url": null
       },
       "experiment": "{\"key\":\"my-test\",\"variations\":[0,1],\"namespace\":[\"namespace\",0,0.1]}",
+      "result": {"value": 0, "inExperiment": false, "hashUsed": false}
+    },
+    {
+      "name": "Experiment coverage - Works when 0",
+      "type": "integer",
+      "context": {
+        "attributes": "{\"id\":\"1\"}",
+        "enabled": null,
+        "forcedVariations": null,
+        "qaMode": null,
+        "url": null
+      },
+      "experiment": "{\"key\": \"no-coverage\", \"variations\": [0, 1], \"coverage\": 0}",
       "result": {"value": 0, "inExperiment": false, "hashUsed": false}
     }
   ],


### PR DESCRIPTION
These changes add support for decrypting the encrypted SDK endpoint responses.

I've also bumped the spec to the latest 0.2.3, adding support for the missing test, which doesn't appear to have had an impact on the results.

- Closes #13 