### PR TITLE
Force feature values using the URL

### DIFF
--- a/lib/src/main/java/growthbook/sdk/java/FeatureEvaluator.java
+++ b/lib/src/main/java/growthbook/sdk/java/FeatureEvaluator.java
@@ -13,7 +13,7 @@ class FeatureEvaluator implements IFeatureEvaluator {
     private final ExperimentEvaluator experimentEvaluator = new ExperimentEvaluator();
 
     @Override
-    public <ValueType> FeatureResult<ValueType> evaluateFeature(String key, GBContext context) throws ClassCastException {
+    public <ValueType> FeatureResult<ValueType> evaluateFeature(String key, GBContext context, Class<ValueType> valueTypeClass) throws ClassCastException {
         FeatureResult<ValueType> emptyFeature = FeatureResult
                 .<ValueType>builder()
                 .value(null)

--- a/lib/src/main/java/growthbook/sdk/java/FeatureEvaluator.java
+++ b/lib/src/main/java/growthbook/sdk/java/FeatureEvaluator.java
@@ -209,12 +209,10 @@ class FeatureEvaluator implements IFeatureEvaluator {
                 return (ValueType) GrowthBookUtils.getForcedDoubleValueFromUrl(key, url);
             }
 
-            // TODO: JSON and Object?
+            return GrowthBookUtils.getForcedSerializableValueFromUrl(key, url, valueTypeClass, jsonUtils.gson);
         } catch (MalformedURLException | ClassCastException e) {
             e.printStackTrace();
             return null;
         }
-
-        return null;
     }
 }

--- a/lib/src/main/java/growthbook/sdk/java/FeatureEvaluator.java
+++ b/lib/src/main/java/growthbook/sdk/java/FeatureEvaluator.java
@@ -26,9 +26,7 @@ class FeatureEvaluator implements IFeatureEvaluator {
 
         try {
             // Check for feature values forced by URL
-            // TODO: Add enabled flag check
-            Boolean urlCheckingEnabled = true;
-            if (urlCheckingEnabled) {
+            if (context.getAllowUrlOverride()) {
                 ValueType forcedValue = evaluateForcedFeatureValueFromUrl(key, context.getUrl(), valueTypeClass);
                 if (forcedValue != null) {
                     return FeatureResult

--- a/lib/src/main/java/growthbook/sdk/java/FeatureRefreshCallback.java
+++ b/lib/src/main/java/growthbook/sdk/java/FeatureRefreshCallback.java
@@ -1,5 +1,13 @@
 package growthbook.sdk.java;
 
+/**
+ * See {@link GBFeaturesRepository#onFeaturesRefresh(FeatureRefreshCallback)}
+ */
 public interface FeatureRefreshCallback {
+
+    /**
+     * See {@link GBFeaturesRepository#onFeaturesRefresh(FeatureRefreshCallback)}
+     * @param featuresJson  Features as JSON string
+     */
     void onRefresh(String featuresJson);
 }

--- a/lib/src/main/java/growthbook/sdk/java/FeatureResult.java
+++ b/lib/src/main/java/growthbook/sdk/java/FeatureResult.java
@@ -10,7 +10,7 @@ import javax.annotation.Nullable;
 import java.lang.reflect.Type;
 
 /**
- * Results for a {@link FeatureEvaluator#evaluateFeature(String, GBContext)}
+ * Results for a {@link FeatureEvaluator#evaluateFeature(String, GBContext, Class)}
  *
  * <ul>
  * <li>value (any) - The assigned value of the feature</li>

--- a/lib/src/main/java/growthbook/sdk/java/FeatureResultSource.java
+++ b/lib/src/main/java/growthbook/sdk/java/FeatureResultSource.java
@@ -24,6 +24,11 @@ public enum FeatureResultSource {
     @SerializedName("force") FORCE("force"),
 
     /**
+     * When the value is assigned due to forced feature assignment via the URL
+     */
+    @SerializedName("urlOverride") URL_OVERRIDE("urlOverride"),
+
+    /**
      * When the value is assigned due to an experiment condition
      */
     @SerializedName("experiment") EXPERIMENT("experiment"),

--- a/lib/src/main/java/growthbook/sdk/java/GBContext.java
+++ b/lib/src/main/java/growthbook/sdk/java/GBContext.java
@@ -25,9 +25,10 @@ public class GBContext {
      * @param attributesJson User attributes as JSON string
      * @param featuresJson Features response as JSON string, or the encrypted payload. Encrypted payload requires `encryptionKey`
      * @param encryptionKey Optional encryption key. If this is not null, featuresJson should be an encrypted payload.
-     * @param enabled Whether globally all experiments are enabled. Defaults to true.
+     * @param enabled Whether globally all experiments are enabled (default: true)
      * @param isQaMode If true, random assignment is disabled and only explicitly forced variations are used.
      * @param url A URL string that is used for experiment evaluation, as well as forcing feature values.
+     * @param allowUrlOverrides Boolean flag to allow URL overrides (default: false)
      * @param forcedVariationsMap Force specific experiments to always assign a specific variation (used for QA)
      * @param trackingCallback A function that takes {@link Experiment} and {@link ExperimentResult} as arguments.
      */

--- a/lib/src/main/java/growthbook/sdk/java/GBContext.java
+++ b/lib/src/main/java/growthbook/sdk/java/GBContext.java
@@ -27,7 +27,7 @@ public class GBContext {
      * @param encryptionKey Optional encryption key. If this is not null, featuresJson should be an encrypted payload.
      * @param enabled Whether globally all experiments are enabled. Defaults to true.
      * @param isQaMode If true, random assignment is disabled and only explicitly forced variations are used.
-     * @param url A URL string
+     * @param url A URL string that is used for experiment evaluation, as well as forcing feature values.
      * @param forcedVariationsMap Force specific experiments to always assign a specific variation (used for QA)
      * @param trackingCallback A function that takes {@link Experiment} and {@link ExperimentResult} as arguments.
      */
@@ -39,6 +39,7 @@ public class GBContext {
             @Nullable Boolean enabled,
             Boolean isQaMode,
             @Nullable String url,
+            Boolean allowUrlOverrides,
             @Nullable Map<String, Integer> forcedVariationsMap,
             @Nullable TrackingCallback trackingCallback
     ) {
@@ -56,6 +57,7 @@ public class GBContext {
 
         this.enabled = enabled == null ? true : enabled;
         this.isQaMode = isQaMode == null ? false : isQaMode;
+        this.allowUrlOverride = allowUrlOverrides == null ? false : allowUrlOverrides;
         this.url = url;
         this.forcedVariationsMap = forcedVariationsMap == null ? new HashMap<>() : forcedVariationsMap;
         this.trackingCallback = trackingCallback;
@@ -76,6 +78,8 @@ public class GBContext {
     private String url;
 
     private Boolean isQaMode;
+
+    private Boolean allowUrlOverride;
 
     @Nullable
     private TrackingCallback trackingCallback;

--- a/lib/src/main/java/growthbook/sdk/java/GBFeaturesRepository.java
+++ b/lib/src/main/java/growthbook/sdk/java/GBFeaturesRepository.java
@@ -96,6 +96,13 @@ public class GBFeaturesRepository implements IGBFeaturesRepository {
         return this.featuresJson;
     }
 
+    /**
+     * Subscribe to feature refresh events
+     * This callback is called when the features are successfully refreshed.
+     * This is called even if the features have not changed.
+     * This will not be called if fetching the features results in a failure.
+     * @param callback  This callback will be called when features are refreshed
+     */
     @Override
     public void onFeaturesRefresh(FeatureRefreshCallback callback) {
         this.refreshCallbacks.add(callback);

--- a/lib/src/main/java/growthbook/sdk/java/GrowthBook.java
+++ b/lib/src/main/java/growthbook/sdk/java/GrowthBook.java
@@ -63,8 +63,8 @@ public class GrowthBook implements IGrowthBook {
 
     @Nullable
     @Override
-    public <ValueType> FeatureResult<ValueType> evalFeature(String key) {
-        return featureEvaluator.evaluateFeature(key, this.context);
+    public <ValueType> FeatureResult<ValueType> evalFeature(String key, Class<ValueType> valueTypeClass) {
+        return featureEvaluator.evaluateFeature(key, this.context, valueTypeClass);
     }
 
     @Override
@@ -90,18 +90,18 @@ public class GrowthBook implements IGrowthBook {
 
     @Override
     public Boolean isOn(String featureKey) {
-        return this.featureEvaluator.evaluateFeature(featureKey, context).isOn();
+        return this.featureEvaluator.evaluateFeature(featureKey, context, Object.class).isOn();
     }
 
     @Override
     public Boolean isOff(String featureKey) {
-        return this.featureEvaluator.evaluateFeature(featureKey, context).isOff();
+        return this.featureEvaluator.evaluateFeature(featureKey, context, Object.class).isOff();
     }
 
     @Override
     public Boolean getFeatureValue(String featureKey, Boolean defaultValue) {
         try {
-            Boolean maybeValue = (Boolean) this.featureEvaluator.evaluateFeature(featureKey, context).getValue();
+            Boolean maybeValue = (Boolean) this.featureEvaluator.evaluateFeature(featureKey, context, defaultValue.getClass()).getValue();
             return maybeValue == null ? defaultValue : maybeValue;
         } catch (Exception e) {
             e.printStackTrace();
@@ -112,7 +112,7 @@ public class GrowthBook implements IGrowthBook {
     @Override
     public String getFeatureValue(String featureKey, String defaultValue) {
         try {
-            String maybeValue = (String) this.featureEvaluator.evaluateFeature(featureKey, context).getValue();
+            String maybeValue = (String) this.featureEvaluator.evaluateFeature(featureKey, context, defaultValue.getClass()).getValue();
             return maybeValue == null ? defaultValue : maybeValue;
         } catch (Exception e) {
             e.printStackTrace();
@@ -145,7 +145,7 @@ public class GrowthBook implements IGrowthBook {
     @Override
     public Object getFeatureValue(String featureKey, Object defaultValue) {
         try {
-            Object maybeValue = this.featureEvaluator.evaluateFeature(featureKey, context).getValue();
+            Object maybeValue = this.featureEvaluator.evaluateFeature(featureKey, context, defaultValue.getClass()).getValue();
             return maybeValue == null ? defaultValue : maybeValue;
         } catch (Exception e) {
             e.printStackTrace();
@@ -156,7 +156,7 @@ public class GrowthBook implements IGrowthBook {
     @Override
     public <ValueType> ValueType getFeatureValue(String featureKey, ValueType defaultValue, Class<ValueType> gsonDeserializableClass) {
         try {
-            Object maybeValue = this.featureEvaluator.evaluateFeature(featureKey, context).getValue();
+            Object maybeValue = this.featureEvaluator.evaluateFeature(featureKey, context, gsonDeserializableClass).getValue();
             if (maybeValue == null) {
                 return defaultValue;
             }
@@ -178,7 +178,7 @@ public class GrowthBook implements IGrowthBook {
     @Override
     public Double getFeatureValue(String featureKey, Double defaultValue) {
         try {
-            Double maybeValue = (Double) this.featureEvaluator.evaluateFeature(featureKey, context).getValue();
+            Double maybeValue = (Double) this.featureEvaluator.evaluateFeature(featureKey, context, defaultValue.getClass()).getValue();
             return maybeValue == null ? defaultValue : maybeValue;
         } catch (Exception e) {
             e.printStackTrace();

--- a/lib/src/main/java/growthbook/sdk/java/GrowthBook.java
+++ b/lib/src/main/java/growthbook/sdk/java/GrowthBook.java
@@ -101,7 +101,7 @@ public class GrowthBook implements IGrowthBook {
     @Override
     public Boolean getFeatureValue(String featureKey, Boolean defaultValue) {
         try {
-            Boolean maybeValue = (Boolean) this.featureEvaluator.evaluateFeature(featureKey, context, defaultValue.getClass()).getValue();
+            Boolean maybeValue = (Boolean) this.featureEvaluator.evaluateFeature(featureKey, context, Boolean.class).getValue();
             return maybeValue == null ? defaultValue : maybeValue;
         } catch (Exception e) {
             e.printStackTrace();
@@ -112,7 +112,7 @@ public class GrowthBook implements IGrowthBook {
     @Override
     public String getFeatureValue(String featureKey, String defaultValue) {
         try {
-            String maybeValue = (String) this.featureEvaluator.evaluateFeature(featureKey, context, defaultValue.getClass()).getValue();
+            String maybeValue = (String) this.featureEvaluator.evaluateFeature(featureKey, context, String.class).getValue();
             return maybeValue == null ? defaultValue : maybeValue;
         } catch (Exception e) {
             e.printStackTrace();
@@ -123,8 +123,18 @@ public class GrowthBook implements IGrowthBook {
     @Override
     public Float getFeatureValue(String featureKey, Float defaultValue) {
         try {
-            Double maybeValue = getFeatureValue(featureKey, Double.valueOf(defaultValue));
-            return maybeValue == null ? defaultValue : maybeValue.floatValue();
+            // Type erasure occurs so a Double ends up being returned
+            Double maybeValue = (Double) this.featureEvaluator.evaluateFeature(featureKey, context, Double.class).getValue();
+
+            if (maybeValue == null) {
+                return defaultValue;
+            }
+
+            try {
+                return maybeValue.floatValue();
+            } catch (NumberFormatException e) {
+                return defaultValue;
+            }
         } catch (Exception e) {
             e.printStackTrace();
             return defaultValue;
@@ -134,8 +144,18 @@ public class GrowthBook implements IGrowthBook {
     @Override
     public Integer getFeatureValue(String featureKey, Integer defaultValue) {
         try {
-            Double maybeValue = getFeatureValue(featureKey, Double.valueOf(defaultValue));
-            return maybeValue == null ? defaultValue : maybeValue.intValue();
+            // Type erasure occurs so a Double ends up being returned
+            Double maybeValue = (Double) this.featureEvaluator.evaluateFeature(featureKey, context, Double.class).getValue();
+
+            if (maybeValue == null) {
+                return defaultValue;
+            }
+
+            try {
+                return maybeValue.intValue();
+            } catch (NumberFormatException e) {
+                return defaultValue;
+            }
         } catch (Exception e) {
             e.printStackTrace();
             return defaultValue;
@@ -178,7 +198,7 @@ public class GrowthBook implements IGrowthBook {
     @Override
     public Double getFeatureValue(String featureKey, Double defaultValue) {
         try {
-            Double maybeValue = (Double) this.featureEvaluator.evaluateFeature(featureKey, context, defaultValue.getClass()).getValue();
+            Double maybeValue = (Double) this.featureEvaluator.evaluateFeature(featureKey, context, Double.class).getValue();
             return maybeValue == null ? defaultValue : maybeValue;
         } catch (Exception e) {
             e.printStackTrace();

--- a/lib/src/main/java/growthbook/sdk/java/GrowthBookUtils.java
+++ b/lib/src/main/java/growthbook/sdk/java/GrowthBookUtils.java
@@ -1,5 +1,7 @@
 package growthbook.sdk.java;
 
+import com.google.gson.Gson;
+
 import javax.annotation.Nullable;
 import java.math.BigInteger;
 import java.net.MalformedURLException;
@@ -292,6 +294,24 @@ class GrowthBookUtils {
     }
 
     // endregion Forced feature for URL -> Integer
+
+    // region Forced feature for URL -> Objects
+
+    @Nullable
+    public static <ValueType> ValueType getForcedSerializableValueFromUrl(String featureKey, URL url, Class<ValueType> valueTypeClass, Gson gson) {
+        String value = getForcedFeatureRawValueForKeyFromUrl(featureKey, url);
+
+        if (value == null) return null;
+
+        try {
+            return gson.fromJson(value, valueTypeClass);
+        } catch (Exception e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+
+    // endregion Forced feature for URL -> Objects
 
     // endregion Forced feature for URL
 

--- a/lib/src/main/java/growthbook/sdk/java/GrowthBookUtils.java
+++ b/lib/src/main/java/growthbook/sdk/java/GrowthBookUtils.java
@@ -78,6 +78,8 @@ class GrowthBookUtils {
         return new ArrayList<Float>(Collections.nCopies(size, weight));
     }
 
+    // region Experiment for query string
+
     /**
      * This checks if an experiment variation is being forced via a URL query string.
      * This may not be applicable for all SDKs (e.g. mobile).
@@ -152,6 +154,86 @@ class GrowthBookUtils {
             return null;
         }
     }
+
+    // endregion Experiment for query string
+
+
+
+    // region Forced feature for URL
+
+    /**
+     * Given a URL and a feature key, will find the raw value in the URL if it exists, otherwise returns null
+     * @param featureKey  Feature ID/key (not prefixed with gb~)
+     * @param url  Page URL to evaluate for forced feature values
+     * @return forced feature value
+     */
+    private static @Nullable String getForcedFeatureRawValueForKeyFromUrl(String featureKey, URL url) {
+        String prefixedKey = "gb~" + featureKey;
+        Map<String, String> queryMap = UrlUtils.parseQueryString(url.getQuery());
+
+        if (!queryMap.containsKey(prefixedKey)) {
+            return null;
+        }
+
+        return queryMap.get(prefixedKey);
+    }
+
+    // region Forced feature for URL -> Boolean
+
+    // TODO: Add test
+    /**
+     * Evaluate a forced boolean value from a URL. If the provided key is not present in the URL, return null.
+     * @param featureKey    feature ID/key (not prefixed with gb~)
+     * @param url    Page URL to evaluate for forced feature values
+     * @return  boolean value or null
+     */
+    @Nullable
+    public static Boolean getForcedValueFromUrl(String featureKey, URL url) {
+        String value = getForcedFeatureRawValueForKeyFromUrl(featureKey, url);
+
+        if (value == null) return null;
+
+        value = value.toLowerCase();
+
+        if (value.equals("true") || value.equals("1") || value.equals("on")) {
+            return true;
+        }
+
+        if (value.equals("false") || value.equals("0") || value.equals("off")) {
+            return false;
+        }
+
+        return null;
+    }
+
+    /**
+     * See {@link #getForcedValueFromUrl(String, URL)}
+     */
+    @Nullable
+    public static Boolean getForcedValueFromUrl(String featureKey, String urlString) {
+        try {
+            URL url = new URL(urlString);
+            return getForcedValueFromUrl(featureKey, url);
+        } catch (MalformedURLException e) {
+            return null;
+        }
+    }
+
+    // endregion Forced feature for URL -> Boolean
+
+    // region Forced feature for URL -> String
+    // TODO:
+    // endregion Forced feature for URL -> String
+
+    // region Forced feature for URL -> Float
+    // TODO:
+    // endregion Forced feature for URL -> Float
+
+    // region Forced feature for URL -> Integer
+    // TODO:
+    // endregion Forced feature for URL -> Integer
+
+    // endregion Forced feature for URL
 
     /**
      * This converts and experiment's coverage and variation weights into an array of bucket ranges.

--- a/lib/src/main/java/growthbook/sdk/java/GrowthBookUtils.java
+++ b/lib/src/main/java/growthbook/sdk/java/GrowthBookUtils.java
@@ -180,15 +180,14 @@ class GrowthBookUtils {
 
     // region Forced feature for URL -> Boolean
 
-    // TODO: Add test
     /**
      * Evaluate a forced boolean value from a URL. If the provided key is not present in the URL, return null.
      * @param featureKey    feature ID/key (not prefixed with gb~)
      * @param url    Page URL to evaluate for forced feature values
-     * @return  boolean value or null
+     * @return  value or null
      */
     @Nullable
-    public static Boolean getForcedValueFromUrl(String featureKey, URL url) {
+    public static Boolean getForcedBooleanValueFromUrl(String featureKey, URL url) {
         String value = getForcedFeatureRawValueForKeyFromUrl(featureKey, url);
 
         if (value == null) return null;
@@ -206,31 +205,92 @@ class GrowthBookUtils {
         return null;
     }
 
+    // endregion Forced feature for URL -> Boolean
+
+    // region Forced feature for URL -> String
+
     /**
-     * See {@link #getForcedValueFromUrl(String, URL)}
+     * Evaluate a forced string value from a URL. If the provided key is not present in the URL, return null.
+     * @param featureKey    feature ID/key (not prefixed with gb~)
+     * @param url    Page URL to evaluate for forced feature values
+     * @return  value or null
      */
     @Nullable
-    public static Boolean getForcedValueFromUrl(String featureKey, String urlString) {
+    public static String getForcedStringValueFromUrl(String featureKey, URL url) {
+        return getForcedFeatureRawValueForKeyFromUrl(featureKey, url);
+    }
+
+    // endregion Forced feature for URL -> String
+
+    // region Forced feature for URL -> Float
+
+    /**
+     * Evaluate a forced float value from a URL. If the provided key is not present in the URL, return null.
+     * @param featureKey    feature ID/key (not prefixed with gb~)
+     * @param url    Page URL to evaluate for forced feature values
+     * @return  value or null
+     */
+    @Nullable
+    public static Float getForcedFloatValueFromUrl(String featureKey, URL url) {
+        String value = getForcedFeatureRawValueForKeyFromUrl(featureKey, url);
+
+        if (value == null) return null;
+
         try {
-            URL url = new URL(urlString);
-            return getForcedValueFromUrl(featureKey, url);
-        } catch (MalformedURLException e) {
+            return Float.parseFloat(value);
+        } catch (NumberFormatException e) {
             return null;
         }
     }
 
-    // endregion Forced feature for URL -> Boolean
-
-    // region Forced feature for URL -> String
-    // TODO:
-    // endregion Forced feature for URL -> String
-
-    // region Forced feature for URL -> Float
-    // TODO:
     // endregion Forced feature for URL -> Float
 
+
+    // region Forced feature for URL -> Double
+
+    /**
+     * Evaluate a forced float value from a URL. If the provided key is not present in the URL, return null.
+     * @param featureKey    feature ID/key (not prefixed with gb~)
+     * @param url    Page URL to evaluate for forced feature values
+     * @return  value or null
+     */
+    @Nullable
+    public static Double getForcedDoubleValueFromUrl(String featureKey, URL url) {
+        String value = getForcedFeatureRawValueForKeyFromUrl(featureKey, url);
+
+        if (value == null) return null;
+
+        try {
+            return Double.parseDouble(value);
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    // endregion Forced feature for URL -> Double
+
+
     // region Forced feature for URL -> Integer
-    // TODO:
+
+    /**
+     * Evaluate a forced integer value from a URL. If the provided key is not present in the URL, return null.
+     * @param featureKey    feature ID/key (not prefixed with gb~)
+     * @param url    Page URL to evaluate for forced feature values
+     * @return  value or null
+     */
+    @Nullable
+    public static Integer getForcedIntegerValueFromUrl(String featureKey, URL url) {
+        String value = getForcedFeatureRawValueForKeyFromUrl(featureKey, url);
+
+        if (value == null) return null;
+
+        try {
+            return Integer.parseInt(value);
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
     // endregion Forced feature for URL -> Integer
 
     // endregion Forced feature for URL

--- a/lib/src/main/java/growthbook/sdk/java/IFeatureEvaluator.java
+++ b/lib/src/main/java/growthbook/sdk/java/IFeatureEvaluator.java
@@ -10,5 +10,5 @@ interface IFeatureEvaluator {
      * @return feature result
      * @throws ClassCastException When a value type fails to cast to the provided type, this can throw an exception
      */
-    <ValueType> FeatureResult<ValueType> evaluateFeature(String key, GBContext context);
+    <ValueType> FeatureResult<ValueType> evaluateFeature(String key, GBContext context, Class<ValueType> valueTypeClass);
 }

--- a/lib/src/main/java/growthbook/sdk/java/IGrowthBook.java
+++ b/lib/src/main/java/growthbook/sdk/java/IGrowthBook.java
@@ -11,7 +11,7 @@ interface IGrowthBook {
 
     // region Features
 
-    <ValueType> FeatureResult<ValueType> evalFeature(String key);
+    <ValueType> FeatureResult<ValueType> evalFeature(String key, Class<ValueType> valueTypeClass);
 
     /**
      * Call this with the JSON string returned from API.

--- a/lib/src/main/java/growthbook/sdk/java/UrlUtils.java
+++ b/lib/src/main/java/growthbook/sdk/java/UrlUtils.java
@@ -26,8 +26,8 @@ class UrlUtils {
                 if (Objects.equals(name, "")) {
                     continue;
                 }
-                String value = keyValuePair.length > 1 ? URLDecoder.decode(
-                        keyValuePair[1], "UTF-8") : "";
+                String value = keyValuePair.length > 1 ? URLDecoder.decode(keyValuePair[1], "UTF-8") : "";
+
                 map.put(name, value);
             } catch (UnsupportedEncodingException e) {
                 e.printStackTrace();

--- a/lib/src/test/java/growthbook/sdk/java/GBContextTest.java
+++ b/lib/src/test/java/growthbook/sdk/java/GBContextTest.java
@@ -32,6 +32,7 @@ class GBContextTest {
     void canBeConstructed() {
         Boolean isEnabled = true;
         Boolean isQaMode = false;
+        Boolean allowUrlOverride = false;
         String url = "http://localhost:3000";
         HashMap<String, Integer> forcedVariations = new HashMap<String, Integer>();
         forcedVariations.put("my-test", 0);
@@ -45,6 +46,7 @@ class GBContextTest {
                 isEnabled,
                 isQaMode,
                 url,
+                allowUrlOverride,
                 forcedVariations,
                 trackingCallback
         );
@@ -105,6 +107,7 @@ class GBContextTest {
     void supportsEncryptedFeaturesUsingConstructor() {
         Boolean isEnabled = true;
         Boolean isQaMode = false;
+        Boolean allowUrlOverride = false;
         String url = "http://localhost:3000";
         HashMap<String, Integer> forcedVariations = new HashMap<String, Integer>();
         forcedVariations.put("my-test", 0);
@@ -119,6 +122,7 @@ class GBContextTest {
                 isEnabled,
                 isQaMode,
                 url,
+                allowUrlOverride,
                 forcedVariations,
                 trackingCallback
         );
@@ -132,6 +136,7 @@ class GBContextTest {
     void supportsEncryptedFeaturesUsingBuilder() {
         Boolean isEnabled = true;
         Boolean isQaMode = false;
+        Boolean allowUrlOverride = false;
         String url = "http://localhost:3000";
         HashMap<String, Integer> forcedVariations = new HashMap<String, Integer>();
         forcedVariations.put("my-test", 0);
@@ -144,6 +149,7 @@ class GBContextTest {
                 .enabled(isEnabled)
                 .attributesJson(sampleUserAttributes)
                 .url(url)
+                .allowUrlOverrides(allowUrlOverride)
                 .featuresJson(encryptedFeaturesJson)
                 .encryptionKey(encryptionKey)
                 .forcedVariationsMap(forcedVariations)

--- a/lib/src/test/java/growthbook/sdk/java/GrowthBookTest.java
+++ b/lib/src/test/java/growthbook/sdk/java/GrowthBookTest.java
@@ -546,6 +546,7 @@ class GrowthBookTest {
             .featuresJson(featuresJson)
             .attributesJson(attributes)
             .url(url)
+            .allowUrlOverrides(true)
             .build();
         GrowthBook subject = new GrowthBook(context);
 
@@ -565,6 +566,7 @@ class GrowthBookTest {
             .featuresJson(featuresJson)
             .attributesJson(attributes)
             .url(url)
+            .allowUrlOverrides(true)
             .build();
         GrowthBook subject = new GrowthBook(context);
 
@@ -584,6 +586,7 @@ class GrowthBookTest {
             .featuresJson(featuresJson)
             .attributesJson(attributes)
             .url(url)
+            .allowUrlOverrides(true)
             .build();
         GrowthBook subject = new GrowthBook(context);
 
@@ -603,6 +606,7 @@ class GrowthBookTest {
             .featuresJson(featuresJson)
             .attributesJson(attributes)
             .url(url)
+            .allowUrlOverrides(true)
             .build();
         GrowthBook subject = new GrowthBook(context);
 
@@ -622,6 +626,7 @@ class GrowthBookTest {
             .featuresJson(featuresJson)
             .attributesJson(attributes)
             .url(url)
+            .allowUrlOverrides(true)
             .build();
         GrowthBook subject = new GrowthBook(context);
 
@@ -641,6 +646,7 @@ class GrowthBookTest {
             .featuresJson(featuresJson)
             .attributesJson(attributes)
             .url(url)
+            .allowUrlOverrides(true)
             .build();
         GrowthBook subject = new GrowthBook(context);
 
@@ -660,6 +666,7 @@ class GrowthBookTest {
             .featuresJson(featuresJson)
             .attributesJson(attributes)
             .url(url)
+            .allowUrlOverrides(true)
             .build();
         GrowthBook subject = new GrowthBook(context);
 
@@ -678,6 +685,7 @@ class GrowthBookTest {
             .featuresJson(featuresJson)
             .attributesJson(attributes)
             .url(url)
+            .allowUrlOverrides(true)
             .build();
         GrowthBook subject = new GrowthBook(context);
 
@@ -696,6 +704,7 @@ class GrowthBookTest {
             .featuresJson(featuresJson)
             .attributesJson(attributes)
             .url(url)
+            .allowUrlOverrides(true)
             .build();
         GrowthBook subject = new GrowthBook(context);
 
@@ -703,6 +712,7 @@ class GrowthBookTest {
         assertEquals("Hello, everyone! I hope you are all doing well!", result);
     }
 
+    // TODO: Support JSON
 //    @Test
 //    void test_withUrl_getFeatureValue_forcesJsonValue() {
 //        String featuresJson = "{\"status\":200,\"features\":{\"banner_text\":{\"defaultValue\":\"Welcome to Acme Donuts!\",\"rules\":[{\"condition\":{\"country\":\"france\"},\"force\":\"Bienvenue au Beignets Acme !\"},{\"condition\":{\"country\":\"spain\"},\"force\":\"¡Bienvenidos y bienvenidas a Donas Acme!\"}]},\"dark_mode\":{\"defaultValue\":false,\"rules\":[{\"condition\":{\"loggedIn\":true},\"force\":true,\"coverage\":0.5,\"hashAttribute\":\"id\"}]},\"donut_price\":{\"defaultValue\":2.5,\"rules\":[{\"condition\":{\"employee\":true},\"force\":0}]},\"meal_overrides_gluten_free\":{\"defaultValue\":{\"meal_type\":\"standard\",\"dessert\":\"Strawberry Cheesecake\"},\"rules\":[{\"condition\":{\"dietaryRestrictions\":{\"$elemMatch\":{\"$eq\":\"gluten_free\"}}},\"force\":{\"meal_type\":\"gf\",\"dessert\":\"French Vanilla Ice Cream\"}}]}},\"dateUpdated\":\"2023-01-11T00:26:01.745Z\"}";
@@ -724,6 +734,7 @@ class GrowthBookTest {
             .featuresJson(featuresJson)
             .attributesJson(attributes)
             .url(url)
+            .allowUrlOverrides(true)
             .build();
         GrowthBook subject = new GrowthBook(context);
 
@@ -743,6 +754,7 @@ class GrowthBookTest {
             .featuresJson(featuresJson)
             .attributesJson(attributes)
             .url(url)
+            .allowUrlOverrides(true)
             .build();
         GrowthBook subject = new GrowthBook(context);
 
@@ -762,6 +774,7 @@ class GrowthBookTest {
             .featuresJson(featuresJson)
             .attributesJson(attributes)
             .url(url)
+            .allowUrlOverrides(true)
             .build();
         GrowthBook subject = new GrowthBook(context);
 
@@ -781,6 +794,7 @@ class GrowthBookTest {
             .featuresJson(featuresJson)
             .attributesJson(attributes)
             .url(url)
+            .allowUrlOverrides(true)
             .build();
         GrowthBook subject = new GrowthBook(context);
 

--- a/lib/src/test/java/growthbook/sdk/java/GrowthBookTest.java
+++ b/lib/src/test/java/growthbook/sdk/java/GrowthBookTest.java
@@ -432,6 +432,8 @@ class GrowthBookTest {
         verify(mockCallback2, times(1)).onRun(result2);
     }
 
+    // region getFeatureValue
+
     @Test
     void test_getFeatureValue_string_nullValueUsesDefaultValue() {
         String featureKey = "some-unknown-feature-key";
@@ -527,4 +529,187 @@ class GrowthBookTest {
         assertNotNull(result);
         assertEquals(defaultConfig, result);
     }
+
+    // endregion getFeatureValue
+
+
+    // region URL -> force features
+
+    @Test
+    void test_withUrl_getFeatureValue_forcesBooleanValue_true() {
+        String featuresJson = "{\"status\":200,\"features\":{\"banner_text\":{\"defaultValue\":\"Welcome to Acme Donuts!\",\"rules\":[{\"condition\":{\"country\":\"france\"},\"force\":\"Bienvenue au Beignets Acme !\"},{\"condition\":{\"country\":\"spain\"},\"force\":\"¡Bienvenidos y bienvenidas a Donas Acme!\"}]},\"dark_mode\":{\"defaultValue\":false,\"rules\":[{\"condition\":{\"loggedIn\":true},\"force\":true,\"coverage\":0.5,\"hashAttribute\":\"id\"}]},\"donut_price\":{\"defaultValue\":2.5,\"rules\":[{\"condition\":{\"employee\":true},\"force\":0}]},\"meal_overrides_gluten_free\":{\"defaultValue\":{\"meal_type\":\"standard\",\"dessert\":\"Strawberry Cheesecake\"},\"rules\":[{\"condition\":{\"dietaryRestrictions\":{\"$elemMatch\":{\"$eq\":\"gluten_free\"}}},\"force\":{\"meal_type\":\"gf\",\"dessert\":\"French Vanilla Ice Cream\"}}]}},\"dateUpdated\":\"2023-01-11T00:26:01.745Z\"}";
+        String attributes = "{}";
+        String url = "http://localhost:8080/url-feature-force?gb~meal_overrides_gluten_free=%7B%22gb~meal_type%22%3A%20%22gf%22%2C%20%22dessert%22%3A%20%22French%20Vanilla%20Ice%20Cream%22%7D&gb~dark_mode=true&donut_price=3.33&gb~banner_text=Hello%2C%20everyone!%20I%20hope%20you%20are%20all%20doing%20well!";
+
+        GBContext context = GBContext
+            .builder()
+            .featuresJson(featuresJson)
+            .attributesJson(attributes)
+            .url(url)
+            .build();
+        GrowthBook subject = new GrowthBook(context);
+
+        Boolean result = subject.getFeatureValue("dark_mode", false);
+
+        assertEquals(true, result);
+    }
+
+    @Test
+    void test_withUrl_getFeatureValue_forcesBooleanValue_on() {
+        String featuresJson = "{\"status\":200,\"features\":{\"banner_text\":{\"defaultValue\":\"Welcome to Acme Donuts!\",\"rules\":[{\"condition\":{\"country\":\"france\"},\"force\":\"Bienvenue au Beignets Acme !\"},{\"condition\":{\"country\":\"spain\"},\"force\":\"¡Bienvenidos y bienvenidas a Donas Acme!\"}]},\"dark_mode\":{\"defaultValue\":false,\"rules\":[{\"condition\":{\"loggedIn\":true},\"force\":true,\"coverage\":0.5,\"hashAttribute\":\"id\"}]},\"donut_price\":{\"defaultValue\":2.5,\"rules\":[{\"condition\":{\"employee\":true},\"force\":0}]},\"meal_overrides_gluten_free\":{\"defaultValue\":{\"meal_type\":\"standard\",\"dessert\":\"Strawberry Cheesecake\"},\"rules\":[{\"condition\":{\"dietaryRestrictions\":{\"$elemMatch\":{\"$eq\":\"gluten_free\"}}},\"force\":{\"meal_type\":\"gf\",\"dessert\":\"French Vanilla Ice Cream\"}}]}},\"dateUpdated\":\"2023-01-11T00:26:01.745Z\"}";
+        String attributes = "{}";
+        String url = "http://localhost:8080/url-feature-force?gb~meal_overrides_gluten_free=%7B%22gb~meal_type%22%3A%20%22gf%22%2C%20%22dessert%22%3A%20%22French%20Vanilla%20Ice%20Cream%22%7D&gb~dark_mode=on&donut_price=3.33&gb~banner_text=Hello%2C%20everyone!%20I%20hope%20you%20are%20all%20doing%20well!";
+
+        GBContext context = GBContext
+            .builder()
+            .featuresJson(featuresJson)
+            .attributesJson(attributes)
+            .url(url)
+            .build();
+        GrowthBook subject = new GrowthBook(context);
+
+        Boolean result = subject.getFeatureValue("dark_mode", false);
+
+        assertEquals(true, result);
+    }
+
+    @Test
+    void test_withUrl_getFeatureValue_forcesBooleanValue_1() {
+        String featuresJson = "{\"status\":200,\"features\":{\"banner_text\":{\"defaultValue\":\"Welcome to Acme Donuts!\",\"rules\":[{\"condition\":{\"country\":\"france\"},\"force\":\"Bienvenue au Beignets Acme !\"},{\"condition\":{\"country\":\"spain\"},\"force\":\"¡Bienvenidos y bienvenidas a Donas Acme!\"}]},\"dark_mode\":{\"defaultValue\":false,\"rules\":[{\"condition\":{\"loggedIn\":true},\"force\":true,\"coverage\":0.5,\"hashAttribute\":\"id\"}]},\"donut_price\":{\"defaultValue\":2.5,\"rules\":[{\"condition\":{\"employee\":true},\"force\":0}]},\"meal_overrides_gluten_free\":{\"defaultValue\":{\"meal_type\":\"standard\",\"dessert\":\"Strawberry Cheesecake\"},\"rules\":[{\"condition\":{\"dietaryRestrictions\":{\"$elemMatch\":{\"$eq\":\"gluten_free\"}}},\"force\":{\"meal_type\":\"gf\",\"dessert\":\"French Vanilla Ice Cream\"}}]}},\"dateUpdated\":\"2023-01-11T00:26:01.745Z\"}";
+        String attributes = "{}";
+        String url = "http://localhost:8080/url-feature-force?gb~meal_overrides_gluten_free=%7B%22gb~meal_type%22%3A%20%22gf%22%2C%20%22dessert%22%3A%20%22French%20Vanilla%20Ice%20Cream%22%7D&gb~dark_mode=1&donut_price=3.33&gb~banner_text=Hello%2C%20everyone!%20I%20hope%20you%20are%20all%20doing%20well!";
+
+        GBContext context = GBContext
+            .builder()
+            .featuresJson(featuresJson)
+            .attributesJson(attributes)
+            .url(url)
+            .build();
+        GrowthBook subject = new GrowthBook(context);
+
+        Boolean result = subject.getFeatureValue("dark_mode", false);
+
+        assertEquals(true, result);
+    }
+
+    @Test
+    void test_withUrl_getFeatureValue_forcesBooleanValue_false() {
+        String featuresJson = "{\"status\":200,\"features\":{\"banner_text\":{\"defaultValue\":\"Welcome to Acme Donuts!\",\"rules\":[{\"condition\":{\"country\":\"france\"},\"force\":\"Bienvenue au Beignets Acme !\"},{\"condition\":{\"country\":\"spain\"},\"force\":\"¡Bienvenidos y bienvenidas a Donas Acme!\"}]},\"dark_mode\":{\"defaultValue\":false,\"rules\":[{\"condition\":{\"loggedIn\":true},\"force\":true,\"coverage\":0.5,\"hashAttribute\":\"id\"}]},\"donut_price\":{\"defaultValue\":2.5,\"rules\":[{\"condition\":{\"employee\":true},\"force\":0}]},\"meal_overrides_gluten_free\":{\"defaultValue\":{\"meal_type\":\"standard\",\"dessert\":\"Strawberry Cheesecake\"},\"rules\":[{\"condition\":{\"dietaryRestrictions\":{\"$elemMatch\":{\"$eq\":\"gluten_free\"}}},\"force\":{\"meal_type\":\"gf\",\"dessert\":\"French Vanilla Ice Cream\"}}]}},\"dateUpdated\":\"2023-01-11T00:26:01.745Z\"}";
+        String attributes = "{}";
+        String url = "http://localhost:8080/url-feature-force?gb~meal_overrides_gluten_free=%7B%22gb~meal_type%22%3A%20%22gf%22%2C%20%22dessert%22%3A%20%22French%20Vanilla%20Ice%20Cream%22%7D&gb~dark_mode=false&donut_price=3.33&gb~banner_text=Hello%2C%20everyone!%20I%20hope%20you%20are%20all%20doing%20well!";
+
+        GBContext context = GBContext
+            .builder()
+            .featuresJson(featuresJson)
+            .attributesJson(attributes)
+            .url(url)
+            .build();
+        GrowthBook subject = new GrowthBook(context);
+
+        Boolean result = subject.getFeatureValue("dark_mode", true);
+
+        assertEquals(false, result);
+    }
+
+    @Test
+    void test_withUrl_getFeatureValue_forcesBooleanValue_off() {
+        String featuresJson = "{\"status\":200,\"features\":{\"banner_text\":{\"defaultValue\":\"Welcome to Acme Donuts!\",\"rules\":[{\"condition\":{\"country\":\"france\"},\"force\":\"Bienvenue au Beignets Acme !\"},{\"condition\":{\"country\":\"spain\"},\"force\":\"¡Bienvenidos y bienvenidas a Donas Acme!\"}]},\"dark_mode\":{\"defaultValue\":false,\"rules\":[{\"condition\":{\"loggedIn\":true},\"force\":true,\"coverage\":0.5,\"hashAttribute\":\"id\"}]},\"donut_price\":{\"defaultValue\":2.5,\"rules\":[{\"condition\":{\"employee\":true},\"force\":0}]},\"meal_overrides_gluten_free\":{\"defaultValue\":{\"meal_type\":\"standard\",\"dessert\":\"Strawberry Cheesecake\"},\"rules\":[{\"condition\":{\"dietaryRestrictions\":{\"$elemMatch\":{\"$eq\":\"gluten_free\"}}},\"force\":{\"meal_type\":\"gf\",\"dessert\":\"French Vanilla Ice Cream\"}}]}},\"dateUpdated\":\"2023-01-11T00:26:01.745Z\"}";
+        String attributes = "{}";
+        String url = "http://localhost:8080/url-feature-force?gb~meal_overrides_gluten_free=%7B%22gb~meal_type%22%3A%20%22gf%22%2C%20%22dessert%22%3A%20%22French%20Vanilla%20Ice%20Cream%22%7D&gb~dark_mode=off&donut_price=3.33&gb~banner_text=Hello%2C%20everyone!%20I%20hope%20you%20are%20all%20doing%20well!";
+
+        GBContext context = GBContext
+            .builder()
+            .featuresJson(featuresJson)
+            .attributesJson(attributes)
+            .url(url)
+            .build();
+        GrowthBook subject = new GrowthBook(context);
+
+        Boolean result = subject.getFeatureValue("dark_mode", true);
+
+        assertEquals(false, result);
+    }
+
+    @Test
+    void test_withUrl_getFeatureValue_forcesBooleanValue_0() {
+        String featuresJson = "{\"status\":200,\"features\":{\"banner_text\":{\"defaultValue\":\"Welcome to Acme Donuts!\",\"rules\":[{\"condition\":{\"country\":\"france\"},\"force\":\"Bienvenue au Beignets Acme !\"},{\"condition\":{\"country\":\"spain\"},\"force\":\"¡Bienvenidos y bienvenidas a Donas Acme!\"}]},\"dark_mode\":{\"defaultValue\":false,\"rules\":[{\"condition\":{\"loggedIn\":true},\"force\":true,\"coverage\":0.5,\"hashAttribute\":\"id\"}]},\"donut_price\":{\"defaultValue\":2.5,\"rules\":[{\"condition\":{\"employee\":true},\"force\":0}]},\"meal_overrides_gluten_free\":{\"defaultValue\":{\"meal_type\":\"standard\",\"dessert\":\"Strawberry Cheesecake\"},\"rules\":[{\"condition\":{\"dietaryRestrictions\":{\"$elemMatch\":{\"$eq\":\"gluten_free\"}}},\"force\":{\"meal_type\":\"gf\",\"dessert\":\"French Vanilla Ice Cream\"}}]}},\"dateUpdated\":\"2023-01-11T00:26:01.745Z\"}";
+        String attributes = "{}";
+        String url = "http://localhost:8080/url-feature-force?gb~meal_overrides_gluten_free=%7B%22gb~meal_type%22%3A%20%22gf%22%2C%20%22dessert%22%3A%20%22French%20Vanilla%20Ice%20Cream%22%7D&gb~dark_mode=0&donut_price=3.33&gb~banner_text=Hello%2C%20everyone!%20I%20hope%20you%20are%20all%20doing%20well!";
+
+        GBContext context = GBContext
+            .builder()
+            .featuresJson(featuresJson)
+            .attributesJson(attributes)
+            .url(url)
+            .build();
+        GrowthBook subject = new GrowthBook(context);
+
+        Boolean result = subject.getFeatureValue("dark_mode", true);
+
+        assertEquals(false, result);
+    }
+
+    @Test
+    void test_withUrl_getFeatureValue_forcesIntegerValue() {
+        String featuresJson = "{\"status\":200,\"features\":{\"banner_text\":{\"defaultValue\":\"Welcome to Acme Donuts!\",\"rules\":[{\"condition\":{\"country\":\"france\"},\"force\":\"Bienvenue au Beignets Acme !\"},{\"condition\":{\"country\":\"spain\"},\"force\":\"¡Bienvenidos y bienvenidas a Donas Acme!\"}]},\"dark_mode\":{\"defaultValue\":false,\"rules\":[{\"condition\":{\"loggedIn\":true},\"force\":true,\"coverage\":0.5,\"hashAttribute\":\"id\"}]},\"donut_price\":{\"defaultValue\":2.5,\"rules\":[{\"condition\":{\"employee\":true},\"force\":0}]},\"meal_overrides_gluten_free\":{\"defaultValue\":{\"meal_type\":\"standard\",\"dessert\":\"Strawberry Cheesecake\"},\"rules\":[{\"condition\":{\"dietaryRestrictions\":{\"$elemMatch\":{\"$eq\":\"gluten_free\"}}},\"force\":{\"meal_type\":\"gf\",\"dessert\":\"French Vanilla Ice Cream\"}}]}},\"dateUpdated\":\"2023-01-11T00:26:01.745Z\"}";
+        String attributes = "{}";
+        String url = "http://localhost:8080/url-feature-force?gb~meal_overrides_gluten_free=%7B%22gb~meal_type%22%3A%20%22gf%22%2C%20%22dessert%22%3A%20%22French%20Vanilla%20Ice%20Cream%22%7D&gb~dark_mode=true&donut_price=2&gb~banner_text=Hello%2C%20everyone!%20I%20hope%20you%20are%20all%20doing%20well!";
+
+        GBContext context = GBContext
+            .builder()
+            .featuresJson(featuresJson)
+            .attributesJson(attributes)
+            .url(url)
+            .build();
+        GrowthBook subject = new GrowthBook(context);
+
+        Integer result = subject.getFeatureValue("donut_price", 999);
+
+        assertEquals(2, result);
+    }
+
+    @Test
+    void test_withUrl_getFeatureValue_forcesFloatValue() {
+        String featuresJson = "{\"status\":200,\"features\":{\"banner_text\":{\"defaultValue\":\"Welcome to Acme Donuts!\",\"rules\":[{\"condition\":{\"country\":\"france\"},\"force\":\"Bienvenue au Beignets Acme !\"},{\"condition\":{\"country\":\"spain\"},\"force\":\"¡Bienvenidos y bienvenidas a Donas Acme!\"}]},\"dark_mode\":{\"defaultValue\":false,\"rules\":[{\"condition\":{\"loggedIn\":true},\"force\":true,\"coverage\":0.5,\"hashAttribute\":\"id\"}]},\"donut_price\":{\"defaultValue\":2.5,\"rules\":[{\"condition\":{\"employee\":true},\"force\":0}]},\"meal_overrides_gluten_free\":{\"defaultValue\":{\"meal_type\":\"standard\",\"dessert\":\"Strawberry Cheesecake\"},\"rules\":[{\"condition\":{\"dietaryRestrictions\":{\"$elemMatch\":{\"$eq\":\"gluten_free\"}}},\"force\":{\"meal_type\":\"gf\",\"dessert\":\"French Vanilla Ice Cream\"}}]}},\"dateUpdated\":\"2023-01-11T00:26:01.745Z\"}";
+        String attributes = "{}";
+        String url = "http://localhost:8080/url-feature-force?gb~meal_overrides_gluten_free=%7B%22gb~meal_type%22%3A%20%22gf%22%2C%20%22dessert%22%3A%20%22French%20Vanilla%20Ice%20Cream%22%7D&gb~dark_mode=true&donut_price=3.33&gb~banner_text=Hello%2C%20everyone!%20I%20hope%20you%20are%20all%20doing%20well!";
+        GBContext context = GBContext
+            .builder()
+            .featuresJson(featuresJson)
+            .attributesJson(attributes)
+            .url(url)
+            .build();
+        GrowthBook subject = new GrowthBook(context);
+
+        Float result = subject.getFeatureValue("donut_price", 9999f);
+
+        assertEquals(3.33f, result);
+    }
+
+    @Test
+    void test_withUrl_getFeatureValue_forcesStringValue() {
+        String featuresJson = "{\"status\":200,\"features\":{\"banner_text\":{\"defaultValue\":\"Welcome to Acme Donuts!\",\"rules\":[{\"condition\":{\"country\":\"france\"},\"force\":\"Bienvenue au Beignets Acme !\"},{\"condition\":{\"country\":\"spain\"},\"force\":\"¡Bienvenidos y bienvenidas a Donas Acme!\"}]},\"dark_mode\":{\"defaultValue\":false,\"rules\":[{\"condition\":{\"loggedIn\":true},\"force\":true,\"coverage\":0.5,\"hashAttribute\":\"id\"}]},\"donut_price\":{\"defaultValue\":2.5,\"rules\":[{\"condition\":{\"employee\":true},\"force\":0}]},\"meal_overrides_gluten_free\":{\"defaultValue\":{\"meal_type\":\"standard\",\"dessert\":\"Strawberry Cheesecake\"},\"rules\":[{\"condition\":{\"dietaryRestrictions\":{\"$elemMatch\":{\"$eq\":\"gluten_free\"}}},\"force\":{\"meal_type\":\"gf\",\"dessert\":\"French Vanilla Ice Cream\"}}]}},\"dateUpdated\":\"2023-01-11T00:26:01.745Z\"}";
+        String attributes = "{}";
+        String url = "http://localhost:8080/url-feature-force?gb~meal_overrides_gluten_free=%7B%22gb~meal_type%22%3A%20%22gf%22%2C%20%22dessert%22%3A%20%22French%20Vanilla%20Ice%20Cream%22%7D&gb~dark_mode=true&donut_price=3.33&gb~banner_text=Hello%2C%20everyone!%20I%20hope%20you%20are%20all%20doing%20well!";
+        GBContext context = GBContext
+            .builder()
+            .featuresJson(featuresJson)
+            .attributesJson(attributes)
+            .url(url)
+            .build();
+        GrowthBook subject = new GrowthBook(context);
+
+        String result = subject.getFeatureValue("banner_text", "???");
+        assertEquals("Hello, everyone! I hope you are all doing well!", result);
+    }
+
+//    @Test
+//    void test_withUrl_getFeatureValue_forcesJsonValue() {
+//        String featuresJson = "{\"status\":200,\"features\":{\"banner_text\":{\"defaultValue\":\"Welcome to Acme Donuts!\",\"rules\":[{\"condition\":{\"country\":\"france\"},\"force\":\"Bienvenue au Beignets Acme !\"},{\"condition\":{\"country\":\"spain\"},\"force\":\"¡Bienvenidos y bienvenidas a Donas Acme!\"}]},\"dark_mode\":{\"defaultValue\":false,\"rules\":[{\"condition\":{\"loggedIn\":true},\"force\":true,\"coverage\":0.5,\"hashAttribute\":\"id\"}]},\"donut_price\":{\"defaultValue\":2.5,\"rules\":[{\"condition\":{\"employee\":true},\"force\":0}]},\"meal_overrides_gluten_free\":{\"defaultValue\":{\"meal_type\":\"standard\",\"dessert\":\"Strawberry Cheesecake\"},\"rules\":[{\"condition\":{\"dietaryRestrictions\":{\"$elemMatch\":{\"$eq\":\"gluten_free\"}}},\"force\":{\"meal_type\":\"gf\",\"dessert\":\"French Vanilla Ice Cream\"}}]}},\"dateUpdated\":\"2023-01-11T00:26:01.745Z\"}";
+//        String attributes = "{}";
+//        String url = "http://localhost:8080/url-feature-force?gb~meal_overrides_gluten_free=%7B%22gb~meal_type%22%3A%20%22gf%22%2C%20%22dessert%22%3A%20%22French%20Vanilla%20Ice%20Cream%22%7D&gb~dark_mode=true&donut_price=3.33&gb~banner_text=Hello%2C%20everyone!%20I%20hope%20you%20are%20all%20doing%20well!";
+//
+//    }
+
+    // endregion URL -> force features
 }

--- a/lib/src/test/java/growthbook/sdk/java/GrowthBookTest.java
+++ b/lib/src/test/java/growthbook/sdk/java/GrowthBookTest.java
@@ -6,6 +6,7 @@ package growthbook.sdk.java;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import com.google.gson.annotations.SerializedName;
 import com.google.gson.reflect.TypeToken;
 import growthbook.sdk.java.testhelpers.PaperCupsConfig;
 import growthbook.sdk.java.testhelpers.TestCasesJsonHelper;
@@ -539,7 +540,7 @@ class GrowthBookTest {
     void test_withUrl_getFeatureValue_forcesBooleanValue_true() {
         String featuresJson = "{\"status\":200,\"features\":{\"banner_text\":{\"defaultValue\":\"Welcome to Acme Donuts!\",\"rules\":[{\"condition\":{\"country\":\"france\"},\"force\":\"Bienvenue au Beignets Acme !\"},{\"condition\":{\"country\":\"spain\"},\"force\":\"¡Bienvenidos y bienvenidas a Donas Acme!\"}]},\"dark_mode\":{\"defaultValue\":false,\"rules\":[{\"condition\":{\"loggedIn\":true},\"force\":true,\"coverage\":0.5,\"hashAttribute\":\"id\"}]},\"donut_price\":{\"defaultValue\":2.5,\"rules\":[{\"condition\":{\"employee\":true},\"force\":0}]},\"meal_overrides_gluten_free\":{\"defaultValue\":{\"meal_type\":\"standard\",\"dessert\":\"Strawberry Cheesecake\"},\"rules\":[{\"condition\":{\"dietaryRestrictions\":{\"$elemMatch\":{\"$eq\":\"gluten_free\"}}},\"force\":{\"meal_type\":\"gf\",\"dessert\":\"French Vanilla Ice Cream\"}}]}},\"dateUpdated\":\"2023-01-11T00:26:01.745Z\"}";
         String attributes = "{}";
-        String url = "http://localhost:8080/url-feature-force?gb~meal_overrides_gluten_free=%7B%22gb~meal_type%22%3A%20%22gf%22%2C%20%22dessert%22%3A%20%22French%20Vanilla%20Ice%20Cream%22%7D&gb~dark_mode=true&gb~donut_price=3.33&gb~banner_text=Hello%2C%20everyone!%20I%20hope%20you%20are%20all%20doing%20well!";
+        String url = "http://localhost:8080/url-feature-force?gb~meal_overrides_gluten_free=%7B%22meal_type%22%3A%20%22gf%22%2C%20%22dessert%22%3A%20%22French%20Vanilla%20Ice%20Cream%22%7D&gb~dark_mode=true&gb~donut_price=3.33&gb~banner_text=Hello%2C%20everyone!%20I%20hope%20you%20are%20all%20doing%20well!";
 
         GBContext context = GBContext
             .builder()
@@ -559,7 +560,7 @@ class GrowthBookTest {
     void test_withUrl_getFeatureValue_forcesBooleanValue_on() {
         String featuresJson = "{\"status\":200,\"features\":{\"banner_text\":{\"defaultValue\":\"Welcome to Acme Donuts!\",\"rules\":[{\"condition\":{\"country\":\"france\"},\"force\":\"Bienvenue au Beignets Acme !\"},{\"condition\":{\"country\":\"spain\"},\"force\":\"¡Bienvenidos y bienvenidas a Donas Acme!\"}]},\"dark_mode\":{\"defaultValue\":false,\"rules\":[{\"condition\":{\"loggedIn\":true},\"force\":true,\"coverage\":0.5,\"hashAttribute\":\"id\"}]},\"donut_price\":{\"defaultValue\":2.5,\"rules\":[{\"condition\":{\"employee\":true},\"force\":0}]},\"meal_overrides_gluten_free\":{\"defaultValue\":{\"meal_type\":\"standard\",\"dessert\":\"Strawberry Cheesecake\"},\"rules\":[{\"condition\":{\"dietaryRestrictions\":{\"$elemMatch\":{\"$eq\":\"gluten_free\"}}},\"force\":{\"meal_type\":\"gf\",\"dessert\":\"French Vanilla Ice Cream\"}}]}},\"dateUpdated\":\"2023-01-11T00:26:01.745Z\"}";
         String attributes = "{}";
-        String url = "http://localhost:8080/url-feature-force?gb~meal_overrides_gluten_free=%7B%22gb~meal_type%22%3A%20%22gf%22%2C%20%22dessert%22%3A%20%22French%20Vanilla%20Ice%20Cream%22%7D&gb~dark_mode=on&gb~donut_price=3.33&gb~banner_text=Hello%2C%20everyone!%20I%20hope%20you%20are%20all%20doing%20well!";
+        String url = "http://localhost:8080/url-feature-force?gb~meal_overrides_gluten_free=%7B%22meal_type%22%3A%20%22gf%22%2C%20%22dessert%22%3A%20%22French%20Vanilla%20Ice%20Cream%22%7D&gb~dark_mode=on&gb~donut_price=3.33&gb~banner_text=Hello%2C%20everyone!%20I%20hope%20you%20are%20all%20doing%20well!";
 
         GBContext context = GBContext
             .builder()
@@ -579,7 +580,7 @@ class GrowthBookTest {
     void test_withUrl_getFeatureValue_forcesBooleanValue_1() {
         String featuresJson = "{\"status\":200,\"features\":{\"banner_text\":{\"defaultValue\":\"Welcome to Acme Donuts!\",\"rules\":[{\"condition\":{\"country\":\"france\"},\"force\":\"Bienvenue au Beignets Acme !\"},{\"condition\":{\"country\":\"spain\"},\"force\":\"¡Bienvenidos y bienvenidas a Donas Acme!\"}]},\"dark_mode\":{\"defaultValue\":false,\"rules\":[{\"condition\":{\"loggedIn\":true},\"force\":true,\"coverage\":0.5,\"hashAttribute\":\"id\"}]},\"donut_price\":{\"defaultValue\":2.5,\"rules\":[{\"condition\":{\"employee\":true},\"force\":0}]},\"meal_overrides_gluten_free\":{\"defaultValue\":{\"meal_type\":\"standard\",\"dessert\":\"Strawberry Cheesecake\"},\"rules\":[{\"condition\":{\"dietaryRestrictions\":{\"$elemMatch\":{\"$eq\":\"gluten_free\"}}},\"force\":{\"meal_type\":\"gf\",\"dessert\":\"French Vanilla Ice Cream\"}}]}},\"dateUpdated\":\"2023-01-11T00:26:01.745Z\"}";
         String attributes = "{}";
-        String url = "http://localhost:8080/url-feature-force?gb~meal_overrides_gluten_free=%7B%22gb~meal_type%22%3A%20%22gf%22%2C%20%22dessert%22%3A%20%22French%20Vanilla%20Ice%20Cream%22%7D&gb~dark_mode=1&gb~donut_price=3.33&gb~banner_text=Hello%2C%20everyone!%20I%20hope%20you%20are%20all%20doing%20well!";
+        String url = "http://localhost:8080/url-feature-force?gb~meal_overrides_gluten_free=%7B%22meal_type%22%3A%20%22gf%22%2C%20%22dessert%22%3A%20%22French%20Vanilla%20Ice%20Cream%22%7D&gb~dark_mode=1&gb~donut_price=3.33&gb~banner_text=Hello%2C%20everyone!%20I%20hope%20you%20are%20all%20doing%20well!";
 
         GBContext context = GBContext
             .builder()
@@ -599,7 +600,7 @@ class GrowthBookTest {
     void test_withUrl_getFeatureValue_forcesBooleanValue_false() {
         String featuresJson = "{\"status\":200,\"features\":{\"banner_text\":{\"defaultValue\":\"Welcome to Acme Donuts!\",\"rules\":[{\"condition\":{\"country\":\"france\"},\"force\":\"Bienvenue au Beignets Acme !\"},{\"condition\":{\"country\":\"spain\"},\"force\":\"¡Bienvenidos y bienvenidas a Donas Acme!\"}]},\"dark_mode\":{\"defaultValue\":false,\"rules\":[{\"condition\":{\"loggedIn\":true},\"force\":true,\"coverage\":0.5,\"hashAttribute\":\"id\"}]},\"donut_price\":{\"defaultValue\":2.5,\"rules\":[{\"condition\":{\"employee\":true},\"force\":0}]},\"meal_overrides_gluten_free\":{\"defaultValue\":{\"meal_type\":\"standard\",\"dessert\":\"Strawberry Cheesecake\"},\"rules\":[{\"condition\":{\"dietaryRestrictions\":{\"$elemMatch\":{\"$eq\":\"gluten_free\"}}},\"force\":{\"meal_type\":\"gf\",\"dessert\":\"French Vanilla Ice Cream\"}}]}},\"dateUpdated\":\"2023-01-11T00:26:01.745Z\"}";
         String attributes = "{}";
-        String url = "http://localhost:8080/url-feature-force?gb~meal_overrides_gluten_free=%7B%22gb~meal_type%22%3A%20%22gf%22%2C%20%22dessert%22%3A%20%22French%20Vanilla%20Ice%20Cream%22%7D&gb~dark_mode=false&gb~donut_price=3.33&gb~banner_text=Hello%2C%20everyone!%20I%20hope%20you%20are%20all%20doing%20well!";
+        String url = "http://localhost:8080/url-feature-force?gb~meal_overrides_gluten_free=%7B%22meal_type%22%3A%20%22gf%22%2C%20%22dessert%22%3A%20%22French%20Vanilla%20Ice%20Cream%22%7D&gb~dark_mode=false&gb~donut_price=3.33&gb~banner_text=Hello%2C%20everyone!%20I%20hope%20you%20are%20all%20doing%20well!";
 
         GBContext context = GBContext
             .builder()
@@ -619,7 +620,7 @@ class GrowthBookTest {
     void test_withUrl_getFeatureValue_forcesBooleanValue_off() {
         String featuresJson = "{\"status\":200,\"features\":{\"banner_text\":{\"defaultValue\":\"Welcome to Acme Donuts!\",\"rules\":[{\"condition\":{\"country\":\"france\"},\"force\":\"Bienvenue au Beignets Acme !\"},{\"condition\":{\"country\":\"spain\"},\"force\":\"¡Bienvenidos y bienvenidas a Donas Acme!\"}]},\"dark_mode\":{\"defaultValue\":false,\"rules\":[{\"condition\":{\"loggedIn\":true},\"force\":true,\"coverage\":0.5,\"hashAttribute\":\"id\"}]},\"donut_price\":{\"defaultValue\":2.5,\"rules\":[{\"condition\":{\"employee\":true},\"force\":0}]},\"meal_overrides_gluten_free\":{\"defaultValue\":{\"meal_type\":\"standard\",\"dessert\":\"Strawberry Cheesecake\"},\"rules\":[{\"condition\":{\"dietaryRestrictions\":{\"$elemMatch\":{\"$eq\":\"gluten_free\"}}},\"force\":{\"meal_type\":\"gf\",\"dessert\":\"French Vanilla Ice Cream\"}}]}},\"dateUpdated\":\"2023-01-11T00:26:01.745Z\"}";
         String attributes = "{}";
-        String url = "http://localhost:8080/url-feature-force?gb~meal_overrides_gluten_free=%7B%22gb~meal_type%22%3A%20%22gf%22%2C%20%22dessert%22%3A%20%22French%20Vanilla%20Ice%20Cream%22%7D&gb~dark_mode=off&gb~donut_price=3.33&gb~banner_text=Hello%2C%20everyone!%20I%20hope%20you%20are%20all%20doing%20well!";
+        String url = "http://localhost:8080/url-feature-force?gb~meal_overrides_gluten_free=%7B%22meal_type%22%3A%20%22gf%22%2C%20%22dessert%22%3A%20%22French%20Vanilla%20Ice%20Cream%22%7D&gb~dark_mode=off&gb~donut_price=3.33&gb~banner_text=Hello%2C%20everyone!%20I%20hope%20you%20are%20all%20doing%20well!";
 
         GBContext context = GBContext
             .builder()
@@ -639,7 +640,7 @@ class GrowthBookTest {
     void test_withUrl_getFeatureValue_forcesBooleanValue_0() {
         String featuresJson = "{\"status\":200,\"features\":{\"banner_text\":{\"defaultValue\":\"Welcome to Acme Donuts!\",\"rules\":[{\"condition\":{\"country\":\"france\"},\"force\":\"Bienvenue au Beignets Acme !\"},{\"condition\":{\"country\":\"spain\"},\"force\":\"¡Bienvenidos y bienvenidas a Donas Acme!\"}]},\"dark_mode\":{\"defaultValue\":false,\"rules\":[{\"condition\":{\"loggedIn\":true},\"force\":true,\"coverage\":0.5,\"hashAttribute\":\"id\"}]},\"donut_price\":{\"defaultValue\":2.5,\"rules\":[{\"condition\":{\"employee\":true},\"force\":0}]},\"meal_overrides_gluten_free\":{\"defaultValue\":{\"meal_type\":\"standard\",\"dessert\":\"Strawberry Cheesecake\"},\"rules\":[{\"condition\":{\"dietaryRestrictions\":{\"$elemMatch\":{\"$eq\":\"gluten_free\"}}},\"force\":{\"meal_type\":\"gf\",\"dessert\":\"French Vanilla Ice Cream\"}}]}},\"dateUpdated\":\"2023-01-11T00:26:01.745Z\"}";
         String attributes = "{}";
-        String url = "http://localhost:8080/url-feature-force?gb~meal_overrides_gluten_free=%7B%22gb~meal_type%22%3A%20%22gf%22%2C%20%22dessert%22%3A%20%22French%20Vanilla%20Ice%20Cream%22%7D&gb~dark_mode=0&gb~donut_price=3.33&gb~banner_text=Hello%2C%20everyone!%20I%20hope%20you%20are%20all%20doing%20well!";
+        String url = "http://localhost:8080/url-feature-force?gb~meal_overrides_gluten_free=%7B%22meal_type%22%3A%20%22gf%22%2C%20%22dessert%22%3A%20%22French%20Vanilla%20Ice%20Cream%22%7D&gb~dark_mode=0&gb~donut_price=3.33&gb~banner_text=Hello%2C%20everyone!%20I%20hope%20you%20are%20all%20doing%20well!";
 
         GBContext context = GBContext
             .builder()
@@ -659,7 +660,7 @@ class GrowthBookTest {
     void test_withUrl_getFeatureValue_forcesIntegerValue() {
         String featuresJson = "{\"status\":200,\"features\":{\"banner_text\":{\"defaultValue\":\"Welcome to Acme Donuts!\",\"rules\":[{\"condition\":{\"country\":\"france\"},\"force\":\"Bienvenue au Beignets Acme !\"},{\"condition\":{\"country\":\"spain\"},\"force\":\"¡Bienvenidos y bienvenidas a Donas Acme!\"}]},\"dark_mode\":{\"defaultValue\":false,\"rules\":[{\"condition\":{\"loggedIn\":true},\"force\":true,\"coverage\":0.5,\"hashAttribute\":\"id\"}]},\"donut_price\":{\"defaultValue\":2.5,\"rules\":[{\"condition\":{\"employee\":true},\"force\":0}]},\"meal_overrides_gluten_free\":{\"defaultValue\":{\"meal_type\":\"standard\",\"dessert\":\"Strawberry Cheesecake\"},\"rules\":[{\"condition\":{\"dietaryRestrictions\":{\"$elemMatch\":{\"$eq\":\"gluten_free\"}}},\"force\":{\"meal_type\":\"gf\",\"dessert\":\"French Vanilla Ice Cream\"}}]}},\"dateUpdated\":\"2023-01-11T00:26:01.745Z\"}";
         String attributes = "{}";
-        String url = "http://localhost:8080/url-feature-force?gb~meal_overrides_gluten_free=%7B%22gb~meal_type%22%3A%20%22gf%22%2C%20%22dessert%22%3A%20%22French%20Vanilla%20Ice%20Cream%22%7D&gb~dark_mode=true&gb~donut_price=2&gb~banner_text=Hello%2C%20everyone!%20I%20hope%20you%20are%20all%20doing%20well!";
+        String url = "http://localhost:8080/url-feature-force?gb~meal_overrides_gluten_free=%7B%22meal_type%22%3A%20%22gf%22%2C%20%22dessert%22%3A%20%22French%20Vanilla%20Ice%20Cream%22%7D&gb~dark_mode=true&gb~donut_price=2&gb~banner_text=Hello%2C%20everyone!%20I%20hope%20you%20are%20all%20doing%20well!";
 
         GBContext context = GBContext
             .builder()
@@ -679,7 +680,7 @@ class GrowthBookTest {
     void test_withUrl_getFeatureValue_forcesFloatValue() {
         String featuresJson = "{\"status\":200,\"features\":{\"banner_text\":{\"defaultValue\":\"Welcome to Acme Donuts!\",\"rules\":[{\"condition\":{\"country\":\"france\"},\"force\":\"Bienvenue au Beignets Acme !\"},{\"condition\":{\"country\":\"spain\"},\"force\":\"¡Bienvenidos y bienvenidas a Donas Acme!\"}]},\"dark_mode\":{\"defaultValue\":false,\"rules\":[{\"condition\":{\"loggedIn\":true},\"force\":true,\"coverage\":0.5,\"hashAttribute\":\"id\"}]},\"donut_price\":{\"defaultValue\":2.5,\"rules\":[{\"condition\":{\"employee\":true},\"force\":0}]},\"meal_overrides_gluten_free\":{\"defaultValue\":{\"meal_type\":\"standard\",\"dessert\":\"Strawberry Cheesecake\"},\"rules\":[{\"condition\":{\"dietaryRestrictions\":{\"$elemMatch\":{\"$eq\":\"gluten_free\"}}},\"force\":{\"meal_type\":\"gf\",\"dessert\":\"French Vanilla Ice Cream\"}}]}},\"dateUpdated\":\"2023-01-11T00:26:01.745Z\"}";
         String attributes = "{}";
-        String url = "http://localhost:8080/url-feature-force?gb~meal_overrides_gluten_free=%7B%22gb~meal_type%22%3A%20%22gf%22%2C%20%22dessert%22%3A%20%22French%20Vanilla%20Ice%20Cream%22%7D&gb~dark_mode=true&gb~donut_price=3.33&gb~banner_text=Hello%2C%20everyone!%20I%20hope%20you%20are%20all%20doing%20well!";
+        String url = "http://localhost:8080/url-feature-force?gb~meal_overrides_gluten_free=%7B%22meal_type%22%3A%20%22gf%22%2C%20%22dessert%22%3A%20%22French%20Vanilla%20Ice%20Cream%22%7D&gb~dark_mode=true&gb~donut_price=3.33&gb~banner_text=Hello%2C%20everyone!%20I%20hope%20you%20are%20all%20doing%20well!";
         GBContext context = GBContext
             .builder()
             .featuresJson(featuresJson)
@@ -698,7 +699,7 @@ class GrowthBookTest {
     void test_withUrl_getFeatureValue_forcesStringValue() {
         String featuresJson = "{\"status\":200,\"features\":{\"banner_text\":{\"defaultValue\":\"Welcome to Acme Donuts!\",\"rules\":[{\"condition\":{\"country\":\"france\"},\"force\":\"Bienvenue au Beignets Acme !\"},{\"condition\":{\"country\":\"spain\"},\"force\":\"¡Bienvenidos y bienvenidas a Donas Acme!\"}]},\"dark_mode\":{\"defaultValue\":false,\"rules\":[{\"condition\":{\"loggedIn\":true},\"force\":true,\"coverage\":0.5,\"hashAttribute\":\"id\"}]},\"donut_price\":{\"defaultValue\":2.5,\"rules\":[{\"condition\":{\"employee\":true},\"force\":0}]},\"meal_overrides_gluten_free\":{\"defaultValue\":{\"meal_type\":\"standard\",\"dessert\":\"Strawberry Cheesecake\"},\"rules\":[{\"condition\":{\"dietaryRestrictions\":{\"$elemMatch\":{\"$eq\":\"gluten_free\"}}},\"force\":{\"meal_type\":\"gf\",\"dessert\":\"French Vanilla Ice Cream\"}}]}},\"dateUpdated\":\"2023-01-11T00:26:01.745Z\"}";
         String attributes = "{}";
-        String url = "http://localhost:8080/url-feature-force?gb~meal_overrides_gluten_free=%7B%22gb~meal_type%22%3A%20%22gf%22%2C%20%22dessert%22%3A%20%22French%20Vanilla%20Ice%20Cream%22%7D&gb~dark_mode=true&gb~donut_price=3.33&gb~banner_text=Hello%2C%20everyone!%20I%20hope%20you%20are%20all%20doing%20well!";
+        String url = "http://localhost:8080/url-feature-force?gb~meal_overrides_gluten_free=%7B%22meal_type%22%3A%20%22gf%22%2C%20%22dessert%22%3A%20%22French%20Vanilla%20Ice%20Cream%22%7D&gb~dark_mode=true&gb~donut_price=3.33&gb~banner_text=Hello%2C%20everyone!%20I%20hope%20you%20are%20all%20doing%20well!";
         GBContext context = GBContext
             .builder()
             .featuresJson(featuresJson)
@@ -712,14 +713,104 @@ class GrowthBookTest {
         assertEquals("Hello, everyone! I hope you are all doing well!", result);
     }
 
-    // TODO: Support JSON
-//    @Test
-//    void test_withUrl_getFeatureValue_forcesJsonValue() {
-//        String featuresJson = "{\"status\":200,\"features\":{\"banner_text\":{\"defaultValue\":\"Welcome to Acme Donuts!\",\"rules\":[{\"condition\":{\"country\":\"france\"},\"force\":\"Bienvenue au Beignets Acme !\"},{\"condition\":{\"country\":\"spain\"},\"force\":\"¡Bienvenidos y bienvenidas a Donas Acme!\"}]},\"dark_mode\":{\"defaultValue\":false,\"rules\":[{\"condition\":{\"loggedIn\":true},\"force\":true,\"coverage\":0.5,\"hashAttribute\":\"id\"}]},\"donut_price\":{\"defaultValue\":2.5,\"rules\":[{\"condition\":{\"employee\":true},\"force\":0}]},\"meal_overrides_gluten_free\":{\"defaultValue\":{\"meal_type\":\"standard\",\"dessert\":\"Strawberry Cheesecake\"},\"rules\":[{\"condition\":{\"dietaryRestrictions\":{\"$elemMatch\":{\"$eq\":\"gluten_free\"}}},\"force\":{\"meal_type\":\"gf\",\"dessert\":\"French Vanilla Ice Cream\"}}]}},\"dateUpdated\":\"2023-01-11T00:26:01.745Z\"}";
-//        String attributes = "{}";
-//        String url = "http://localhost:8080/url-feature-force?gb~meal_overrides_gluten_free=%7B%22gb~meal_type%22%3A%20%22gf%22%2C%20%22dessert%22%3A%20%22French%20Vanilla%20Ice%20Cream%22%7D&gb~dark_mode=true&gb~donut_price=3.33&gb~banner_text=Hello%2C%20everyone!%20I%20hope%20you%20are%20all%20doing%20well!";
-//
-//    }
+    @Test
+    void test_withUrl_getFeatureValue_forcesJsonValue() {
+        String featuresJson = "{\"status\":200,\"features\":{\"banner_text\":{\"defaultValue\":\"Welcome to Acme Donuts!\",\"rules\":[{\"condition\":{\"country\":\"france\"},\"force\":\"Bienvenue au Beignets Acme !\"},{\"condition\":{\"country\":\"spain\"},\"force\":\"¡Bienvenidos y bienvenidas a Donas Acme!\"}]},\"dark_mode\":{\"defaultValue\":false,\"rules\":[{\"condition\":{\"loggedIn\":true},\"force\":true,\"coverage\":0.5,\"hashAttribute\":\"id\"}]},\"donut_price\":{\"defaultValue\":2.5,\"rules\":[{\"condition\":{\"employee\":true},\"force\":0}]},\"meal_overrides_gluten_free\":{\"defaultValue\":{\"meal_type\":\"standard\",\"dessert\":\"Strawberry Cheesecake\"},\"rules\":[{\"condition\":{\"dietaryRestrictions\":{\"$elemMatch\":{\"$eq\":\"gluten_free\"}}},\"force\":{\"meal_type\":\"gf\",\"dessert\":\"French Vanilla Ice Cream\"}}]}},\"dateUpdated\":\"2023-01-11T00:26:01.745Z\"}";
+        String attributes = "{}";
+        String url = "http://localhost:8080/url-feature-force?gb~meal_overrides_gluten_free=%7B%22meal_type%22%3A%20%22gf%22%2C%20%22dessert%22%3A%20%22French%20Vanilla%20Ice%20Cream%22%7D&gb~dark_mode=true&gb~donut_price=3.33&gb~banner_text=Hello%2C%20everyone!%20I%20hope%20you%20are%20all%20doing%20well!";
+
+        GBContext context = GBContext
+            .builder()
+            .featuresJson(featuresJson)
+            .attributesJson(attributes)
+            .url(url)
+            .allowUrlOverrides(true)
+            .build();
+        GrowthBook subject = new GrowthBook(context);
+
+        MealOrder emptyMealOrder = new MealOrder(MealType.STANDARD, "Donut");
+
+        MealOrder result = (MealOrder) subject.getFeatureValue("meal_overrides_gluten_free", emptyMealOrder);
+
+        assertEquals(MealType.GLUTEN_FREE, result.getMealType());
+        assertEquals("French Vanilla Ice Cream", result.getDessert());
+    }
+
+    @Test
+    void test_withUrl_getFeatureValue_withForcedJsonValue_returnsDefaultValueWhenInvalid() {
+        String featuresJson = "{\"status\":200,\"features\":{\"banner_text\":{\"defaultValue\":\"Welcome to Acme Donuts!\",\"rules\":[{\"condition\":{\"country\":\"france\"},\"force\":\"Bienvenue au Beignets Acme !\"},{\"condition\":{\"country\":\"spain\"},\"force\":\"¡Bienvenidos y bienvenidas a Donas Acme!\"}]},\"dark_mode\":{\"defaultValue\":false,\"rules\":[{\"condition\":{\"loggedIn\":true},\"force\":true,\"coverage\":0.5,\"hashAttribute\":\"id\"}]},\"donut_price\":{\"defaultValue\":2.5,\"rules\":[{\"condition\":{\"employee\":true},\"force\":0}]},\"meal_overrides_gluten_free\":{\"defaultValue\":{\"meal_type\":\"standard\",\"dessert\":\"Strawberry Cheesecake\"},\"rules\":[{\"condition\":{\"dietaryRestrictions\":{\"$elemMatch\":{\"$eq\":\"gluten_free\"}}},\"force\":{\"meal_type\":\"gf\",\"dessert\":\"French Vanilla Ice Cream\"}}]}},\"dateUpdated\":\"2023-01-11T00:26:01.745Z\"}";
+        String attributes = "{}";
+        String url = "http://localhost:8080/url-feature-force?gb~meal_overrides_gluten_free=%7B%22meal_type%22%3A%20%22gf%22%2C%20%22dessert%22%3A%20%22French%20Vanilla%20Ice%20Cream%22%7D&gb~dark_mode=true&gb~donut_price=3.33&gb~banner_text=Hello%2C%20everyone!%20I%20hope%20you%20are%20all%20doing%20well!";
+
+        GBContext context = GBContext
+            .builder()
+            .featuresJson(featuresJson)
+            .attributesJson(attributes)
+            .url(url)
+            .allowUrlOverrides(true)
+            .build();
+        GrowthBook subject = new GrowthBook(context);
+
+        // We try to deserialize an unsupported class from the URL but it cannot deserialize properly, so we get the default value
+        GBTestingFoo defaultFoo = new GBTestingFoo();
+        GBTestingFoo result = (GBTestingFoo) subject.getFeatureValue("meal_overrides_gluten_free", defaultFoo);
+
+        assertEquals(defaultFoo, result);
+    }
+
+    enum MealType {
+        @SerializedName("standard")
+        STANDARD("Standard Meal"),
+
+        @SerializedName("gf")
+        GLUTEN_FREE("Gluten-Free Meal"),
+        ;
+
+        private final String rawValue;
+
+        MealType(String rawValue) {
+            this.rawValue = rawValue;
+        }
+
+        @Override
+        public String toString() {
+            return this.rawValue;
+        }
+    }
+
+    static class GBTestingFoo {
+        @SerializedName("foo") String foo = "FOO!";
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj instanceof GBTestingFoo) {
+                return Objects.equals(((GBTestingFoo) obj).foo, this.foo);
+            }
+
+            return false;
+        }
+    }
+
+    static class MealOrder {
+        @SerializedName("meal_type")
+        MealType mealType;
+
+        public MealType getMealType() {
+            return this.mealType;
+        }
+
+        @SerializedName("dessert")
+        String dessert;
+
+        public String getDessert() {
+            return this.dessert;
+        }
+
+        public MealOrder(MealType mealType, String dessert) {
+            this.mealType = mealType;
+            this.dessert = dessert;
+        }
+    }
 
 
     // region URL -> force features -> evaluateFeature
@@ -728,7 +819,7 @@ class GrowthBookTest {
     void test_withUrl_evaluateFeature_forcesBooleanValue() {
         String featuresJson = "{\"status\":200,\"features\":{\"banner_text\":{\"defaultValue\":\"Welcome to Acme Donuts!\",\"rules\":[{\"condition\":{\"country\":\"france\"},\"force\":\"Bienvenue au Beignets Acme !\"},{\"condition\":{\"country\":\"spain\"},\"force\":\"¡Bienvenidos y bienvenidas a Donas Acme!\"}]},\"dark_mode\":{\"defaultValue\":false,\"rules\":[{\"condition\":{\"loggedIn\":true},\"force\":true,\"coverage\":0.5,\"hashAttribute\":\"id\"}]},\"donut_price\":{\"defaultValue\":2.5,\"rules\":[{\"condition\":{\"employee\":true},\"force\":0}]},\"meal_overrides_gluten_free\":{\"defaultValue\":{\"meal_type\":\"standard\",\"dessert\":\"Strawberry Cheesecake\"},\"rules\":[{\"condition\":{\"dietaryRestrictions\":{\"$elemMatch\":{\"$eq\":\"gluten_free\"}}},\"force\":{\"meal_type\":\"gf\",\"dessert\":\"French Vanilla Ice Cream\"}}]}},\"dateUpdated\":\"2023-01-11T00:26:01.745Z\"}";
         String attributes = "{}";
-        String url = "http://localhost:8080/url-feature-force?gb~meal_overrides_gluten_free=%7B%22gb~meal_type%22%3A%20%22gf%22%2C%20%22dessert%22%3A%20%22French%20Vanilla%20Ice%20Cream%22%7D&gb~dark_mode=true&gb~donut_price=3.33&gb~banner_text=Hello%2C%20everyone!%20I%20hope%20you%20are%20all%20doing%20well!";
+        String url = "http://localhost:8080/url-feature-force?gb~meal_overrides_gluten_free=%7B%22meal_type%22%3A%20%22gf%22%2C%20%22dessert%22%3A%20%22French%20Vanilla%20Ice%20Cream%22%7D&gb~dark_mode=true&gb~donut_price=3.33&gb~banner_text=Hello%2C%20everyone!%20I%20hope%20you%20are%20all%20doing%20well!";
         GBContext context = GBContext
             .builder()
             .featuresJson(featuresJson)
@@ -748,7 +839,7 @@ class GrowthBookTest {
     void test_withUrl_evaluateFeature_forcesStringValue() {
         String featuresJson = "{\"status\":200,\"features\":{\"banner_text\":{\"defaultValue\":\"Welcome to Acme Donuts!\",\"rules\":[{\"condition\":{\"country\":\"france\"},\"force\":\"Bienvenue au Beignets Acme !\"},{\"condition\":{\"country\":\"spain\"},\"force\":\"¡Bienvenidos y bienvenidas a Donas Acme!\"}]},\"dark_mode\":{\"defaultValue\":false,\"rules\":[{\"condition\":{\"loggedIn\":true},\"force\":true,\"coverage\":0.5,\"hashAttribute\":\"id\"}]},\"donut_price\":{\"defaultValue\":2.5,\"rules\":[{\"condition\":{\"employee\":true},\"force\":0}]},\"meal_overrides_gluten_free\":{\"defaultValue\":{\"meal_type\":\"standard\",\"dessert\":\"Strawberry Cheesecake\"},\"rules\":[{\"condition\":{\"dietaryRestrictions\":{\"$elemMatch\":{\"$eq\":\"gluten_free\"}}},\"force\":{\"meal_type\":\"gf\",\"dessert\":\"French Vanilla Ice Cream\"}}]}},\"dateUpdated\":\"2023-01-11T00:26:01.745Z\"}";
         String attributes = "{}";
-        String url = "http://localhost:8080/url-feature-force?gb~meal_overrides_gluten_free=%7B%22gb~meal_type%22%3A%20%22gf%22%2C%20%22dessert%22%3A%20%22French%20Vanilla%20Ice%20Cream%22%7D&gb~dark_mode=true&gb~donut_price=3.33&gb~banner_text=Hello%2C%20everyone!%20I%20hope%20you%20are%20all%20doing%20well!";
+        String url = "http://localhost:8080/url-feature-force?gb~meal_overrides_gluten_free=%7B%22meal_type%22%3A%20%22gf%22%2C%20%22dessert%22%3A%20%22French%20Vanilla%20Ice%20Cream%22%7D&gb~dark_mode=true&gb~donut_price=3.33&gb~banner_text=Hello%2C%20everyone!%20I%20hope%20you%20are%20all%20doing%20well!";
         GBContext context = GBContext
             .builder()
             .featuresJson(featuresJson)
@@ -768,7 +859,7 @@ class GrowthBookTest {
     void test_withUrl_evaluateFeature_forcesFloatValue() {
         String featuresJson = "{\"status\":200,\"features\":{\"banner_text\":{\"defaultValue\":\"Welcome to Acme Donuts!\",\"rules\":[{\"condition\":{\"country\":\"france\"},\"force\":\"Bienvenue au Beignets Acme !\"},{\"condition\":{\"country\":\"spain\"},\"force\":\"¡Bienvenidos y bienvenidas a Donas Acme!\"}]},\"dark_mode\":{\"defaultValue\":false,\"rules\":[{\"condition\":{\"loggedIn\":true},\"force\":true,\"coverage\":0.5,\"hashAttribute\":\"id\"}]},\"donut_price\":{\"defaultValue\":2.5,\"rules\":[{\"condition\":{\"employee\":true},\"force\":0}]},\"meal_overrides_gluten_free\":{\"defaultValue\":{\"meal_type\":\"standard\",\"dessert\":\"Strawberry Cheesecake\"},\"rules\":[{\"condition\":{\"dietaryRestrictions\":{\"$elemMatch\":{\"$eq\":\"gluten_free\"}}},\"force\":{\"meal_type\":\"gf\",\"dessert\":\"French Vanilla Ice Cream\"}}]}},\"dateUpdated\":\"2023-01-11T00:26:01.745Z\"}";
         String attributes = "{}";
-        String url = "http://localhost:8080/url-feature-force?gb~meal_overrides_gluten_free=%7B%22gb~meal_type%22%3A%20%22gf%22%2C%20%22dessert%22%3A%20%22French%20Vanilla%20Ice%20Cream%22%7D&gb~dark_mode=true&gb~donut_price=3.33&gb~banner_text=Hello%2C%20everyone!%20I%20hope%20you%20are%20all%20doing%20well!";
+        String url = "http://localhost:8080/url-feature-force?gb~meal_overrides_gluten_free=%7B%22meal_type%22%3A%20%22gf%22%2C%20%22dessert%22%3A%20%22French%20Vanilla%20Ice%20Cream%22%7D&gb~dark_mode=true&gb~donut_price=3.33&gb~banner_text=Hello%2C%20everyone!%20I%20hope%20you%20are%20all%20doing%20well!";
         GBContext context = GBContext
             .builder()
             .featuresJson(featuresJson)
@@ -788,7 +879,7 @@ class GrowthBookTest {
     void test_withUrl_evaluateFeature_forcesIntegerValue() {
         String featuresJson = "{\"status\":200,\"features\":{\"banner_text\":{\"defaultValue\":\"Welcome to Acme Donuts!\",\"rules\":[{\"condition\":{\"country\":\"france\"},\"force\":\"Bienvenue au Beignets Acme !\"},{\"condition\":{\"country\":\"spain\"},\"force\":\"¡Bienvenidos y bienvenidas a Donas Acme!\"}]},\"dark_mode\":{\"defaultValue\":false,\"rules\":[{\"condition\":{\"loggedIn\":true},\"force\":true,\"coverage\":0.5,\"hashAttribute\":\"id\"}]},\"donut_price\":{\"defaultValue\":2.5,\"rules\":[{\"condition\":{\"employee\":true},\"force\":0}]},\"meal_overrides_gluten_free\":{\"defaultValue\":{\"meal_type\":\"standard\",\"dessert\":\"Strawberry Cheesecake\"},\"rules\":[{\"condition\":{\"dietaryRestrictions\":{\"$elemMatch\":{\"$eq\":\"gluten_free\"}}},\"force\":{\"meal_type\":\"gf\",\"dessert\":\"French Vanilla Ice Cream\"}}]}},\"dateUpdated\":\"2023-01-11T00:26:01.745Z\"}";
         String attributes = "{}";
-        String url = "http://localhost:8080/url-feature-force?gb~meal_overrides_gluten_free=%7B%22gb~meal_type%22%3A%20%22gf%22%2C%20%22dessert%22%3A%20%22French%20Vanilla%20Ice%20Cream%22%7D&gb~dark_mode=true&gb~donut_price=4&gb~banner_text=Hello%2C%20everyone!%20I%20hope%20you%20are%20all%20doing%20well!";
+        String url = "http://localhost:8080/url-feature-force?gb~meal_overrides_gluten_free=%7B%22meal_type%22%3A%20%22gf%22%2C%20%22dessert%22%3A%20%22French%20Vanilla%20Ice%20Cream%22%7D&gb~dark_mode=true&gb~donut_price=4&gb~banner_text=Hello%2C%20everyone!%20I%20hope%20you%20are%20all%20doing%20well!";
         GBContext context = GBContext
             .builder()
             .featuresJson(featuresJson)

--- a/lib/src/test/java/growthbook/sdk/java/GrowthBookTest.java
+++ b/lib/src/test/java/growthbook/sdk/java/GrowthBookTest.java
@@ -539,7 +539,7 @@ class GrowthBookTest {
     void test_withUrl_getFeatureValue_forcesBooleanValue_true() {
         String featuresJson = "{\"status\":200,\"features\":{\"banner_text\":{\"defaultValue\":\"Welcome to Acme Donuts!\",\"rules\":[{\"condition\":{\"country\":\"france\"},\"force\":\"Bienvenue au Beignets Acme !\"},{\"condition\":{\"country\":\"spain\"},\"force\":\"¡Bienvenidos y bienvenidas a Donas Acme!\"}]},\"dark_mode\":{\"defaultValue\":false,\"rules\":[{\"condition\":{\"loggedIn\":true},\"force\":true,\"coverage\":0.5,\"hashAttribute\":\"id\"}]},\"donut_price\":{\"defaultValue\":2.5,\"rules\":[{\"condition\":{\"employee\":true},\"force\":0}]},\"meal_overrides_gluten_free\":{\"defaultValue\":{\"meal_type\":\"standard\",\"dessert\":\"Strawberry Cheesecake\"},\"rules\":[{\"condition\":{\"dietaryRestrictions\":{\"$elemMatch\":{\"$eq\":\"gluten_free\"}}},\"force\":{\"meal_type\":\"gf\",\"dessert\":\"French Vanilla Ice Cream\"}}]}},\"dateUpdated\":\"2023-01-11T00:26:01.745Z\"}";
         String attributes = "{}";
-        String url = "http://localhost:8080/url-feature-force?gb~meal_overrides_gluten_free=%7B%22gb~meal_type%22%3A%20%22gf%22%2C%20%22dessert%22%3A%20%22French%20Vanilla%20Ice%20Cream%22%7D&gb~dark_mode=true&donut_price=3.33&gb~banner_text=Hello%2C%20everyone!%20I%20hope%20you%20are%20all%20doing%20well!";
+        String url = "http://localhost:8080/url-feature-force?gb~meal_overrides_gluten_free=%7B%22gb~meal_type%22%3A%20%22gf%22%2C%20%22dessert%22%3A%20%22French%20Vanilla%20Ice%20Cream%22%7D&gb~dark_mode=true&gb~donut_price=3.33&gb~banner_text=Hello%2C%20everyone!%20I%20hope%20you%20are%20all%20doing%20well!";
 
         GBContext context = GBContext
             .builder()
@@ -558,7 +558,7 @@ class GrowthBookTest {
     void test_withUrl_getFeatureValue_forcesBooleanValue_on() {
         String featuresJson = "{\"status\":200,\"features\":{\"banner_text\":{\"defaultValue\":\"Welcome to Acme Donuts!\",\"rules\":[{\"condition\":{\"country\":\"france\"},\"force\":\"Bienvenue au Beignets Acme !\"},{\"condition\":{\"country\":\"spain\"},\"force\":\"¡Bienvenidos y bienvenidas a Donas Acme!\"}]},\"dark_mode\":{\"defaultValue\":false,\"rules\":[{\"condition\":{\"loggedIn\":true},\"force\":true,\"coverage\":0.5,\"hashAttribute\":\"id\"}]},\"donut_price\":{\"defaultValue\":2.5,\"rules\":[{\"condition\":{\"employee\":true},\"force\":0}]},\"meal_overrides_gluten_free\":{\"defaultValue\":{\"meal_type\":\"standard\",\"dessert\":\"Strawberry Cheesecake\"},\"rules\":[{\"condition\":{\"dietaryRestrictions\":{\"$elemMatch\":{\"$eq\":\"gluten_free\"}}},\"force\":{\"meal_type\":\"gf\",\"dessert\":\"French Vanilla Ice Cream\"}}]}},\"dateUpdated\":\"2023-01-11T00:26:01.745Z\"}";
         String attributes = "{}";
-        String url = "http://localhost:8080/url-feature-force?gb~meal_overrides_gluten_free=%7B%22gb~meal_type%22%3A%20%22gf%22%2C%20%22dessert%22%3A%20%22French%20Vanilla%20Ice%20Cream%22%7D&gb~dark_mode=on&donut_price=3.33&gb~banner_text=Hello%2C%20everyone!%20I%20hope%20you%20are%20all%20doing%20well!";
+        String url = "http://localhost:8080/url-feature-force?gb~meal_overrides_gluten_free=%7B%22gb~meal_type%22%3A%20%22gf%22%2C%20%22dessert%22%3A%20%22French%20Vanilla%20Ice%20Cream%22%7D&gb~dark_mode=on&gb~donut_price=3.33&gb~banner_text=Hello%2C%20everyone!%20I%20hope%20you%20are%20all%20doing%20well!";
 
         GBContext context = GBContext
             .builder()
@@ -577,7 +577,7 @@ class GrowthBookTest {
     void test_withUrl_getFeatureValue_forcesBooleanValue_1() {
         String featuresJson = "{\"status\":200,\"features\":{\"banner_text\":{\"defaultValue\":\"Welcome to Acme Donuts!\",\"rules\":[{\"condition\":{\"country\":\"france\"},\"force\":\"Bienvenue au Beignets Acme !\"},{\"condition\":{\"country\":\"spain\"},\"force\":\"¡Bienvenidos y bienvenidas a Donas Acme!\"}]},\"dark_mode\":{\"defaultValue\":false,\"rules\":[{\"condition\":{\"loggedIn\":true},\"force\":true,\"coverage\":0.5,\"hashAttribute\":\"id\"}]},\"donut_price\":{\"defaultValue\":2.5,\"rules\":[{\"condition\":{\"employee\":true},\"force\":0}]},\"meal_overrides_gluten_free\":{\"defaultValue\":{\"meal_type\":\"standard\",\"dessert\":\"Strawberry Cheesecake\"},\"rules\":[{\"condition\":{\"dietaryRestrictions\":{\"$elemMatch\":{\"$eq\":\"gluten_free\"}}},\"force\":{\"meal_type\":\"gf\",\"dessert\":\"French Vanilla Ice Cream\"}}]}},\"dateUpdated\":\"2023-01-11T00:26:01.745Z\"}";
         String attributes = "{}";
-        String url = "http://localhost:8080/url-feature-force?gb~meal_overrides_gluten_free=%7B%22gb~meal_type%22%3A%20%22gf%22%2C%20%22dessert%22%3A%20%22French%20Vanilla%20Ice%20Cream%22%7D&gb~dark_mode=1&donut_price=3.33&gb~banner_text=Hello%2C%20everyone!%20I%20hope%20you%20are%20all%20doing%20well!";
+        String url = "http://localhost:8080/url-feature-force?gb~meal_overrides_gluten_free=%7B%22gb~meal_type%22%3A%20%22gf%22%2C%20%22dessert%22%3A%20%22French%20Vanilla%20Ice%20Cream%22%7D&gb~dark_mode=1&gb~donut_price=3.33&gb~banner_text=Hello%2C%20everyone!%20I%20hope%20you%20are%20all%20doing%20well!";
 
         GBContext context = GBContext
             .builder()
@@ -596,7 +596,7 @@ class GrowthBookTest {
     void test_withUrl_getFeatureValue_forcesBooleanValue_false() {
         String featuresJson = "{\"status\":200,\"features\":{\"banner_text\":{\"defaultValue\":\"Welcome to Acme Donuts!\",\"rules\":[{\"condition\":{\"country\":\"france\"},\"force\":\"Bienvenue au Beignets Acme !\"},{\"condition\":{\"country\":\"spain\"},\"force\":\"¡Bienvenidos y bienvenidas a Donas Acme!\"}]},\"dark_mode\":{\"defaultValue\":false,\"rules\":[{\"condition\":{\"loggedIn\":true},\"force\":true,\"coverage\":0.5,\"hashAttribute\":\"id\"}]},\"donut_price\":{\"defaultValue\":2.5,\"rules\":[{\"condition\":{\"employee\":true},\"force\":0}]},\"meal_overrides_gluten_free\":{\"defaultValue\":{\"meal_type\":\"standard\",\"dessert\":\"Strawberry Cheesecake\"},\"rules\":[{\"condition\":{\"dietaryRestrictions\":{\"$elemMatch\":{\"$eq\":\"gluten_free\"}}},\"force\":{\"meal_type\":\"gf\",\"dessert\":\"French Vanilla Ice Cream\"}}]}},\"dateUpdated\":\"2023-01-11T00:26:01.745Z\"}";
         String attributes = "{}";
-        String url = "http://localhost:8080/url-feature-force?gb~meal_overrides_gluten_free=%7B%22gb~meal_type%22%3A%20%22gf%22%2C%20%22dessert%22%3A%20%22French%20Vanilla%20Ice%20Cream%22%7D&gb~dark_mode=false&donut_price=3.33&gb~banner_text=Hello%2C%20everyone!%20I%20hope%20you%20are%20all%20doing%20well!";
+        String url = "http://localhost:8080/url-feature-force?gb~meal_overrides_gluten_free=%7B%22gb~meal_type%22%3A%20%22gf%22%2C%20%22dessert%22%3A%20%22French%20Vanilla%20Ice%20Cream%22%7D&gb~dark_mode=false&gb~donut_price=3.33&gb~banner_text=Hello%2C%20everyone!%20I%20hope%20you%20are%20all%20doing%20well!";
 
         GBContext context = GBContext
             .builder()
@@ -615,7 +615,7 @@ class GrowthBookTest {
     void test_withUrl_getFeatureValue_forcesBooleanValue_off() {
         String featuresJson = "{\"status\":200,\"features\":{\"banner_text\":{\"defaultValue\":\"Welcome to Acme Donuts!\",\"rules\":[{\"condition\":{\"country\":\"france\"},\"force\":\"Bienvenue au Beignets Acme !\"},{\"condition\":{\"country\":\"spain\"},\"force\":\"¡Bienvenidos y bienvenidas a Donas Acme!\"}]},\"dark_mode\":{\"defaultValue\":false,\"rules\":[{\"condition\":{\"loggedIn\":true},\"force\":true,\"coverage\":0.5,\"hashAttribute\":\"id\"}]},\"donut_price\":{\"defaultValue\":2.5,\"rules\":[{\"condition\":{\"employee\":true},\"force\":0}]},\"meal_overrides_gluten_free\":{\"defaultValue\":{\"meal_type\":\"standard\",\"dessert\":\"Strawberry Cheesecake\"},\"rules\":[{\"condition\":{\"dietaryRestrictions\":{\"$elemMatch\":{\"$eq\":\"gluten_free\"}}},\"force\":{\"meal_type\":\"gf\",\"dessert\":\"French Vanilla Ice Cream\"}}]}},\"dateUpdated\":\"2023-01-11T00:26:01.745Z\"}";
         String attributes = "{}";
-        String url = "http://localhost:8080/url-feature-force?gb~meal_overrides_gluten_free=%7B%22gb~meal_type%22%3A%20%22gf%22%2C%20%22dessert%22%3A%20%22French%20Vanilla%20Ice%20Cream%22%7D&gb~dark_mode=off&donut_price=3.33&gb~banner_text=Hello%2C%20everyone!%20I%20hope%20you%20are%20all%20doing%20well!";
+        String url = "http://localhost:8080/url-feature-force?gb~meal_overrides_gluten_free=%7B%22gb~meal_type%22%3A%20%22gf%22%2C%20%22dessert%22%3A%20%22French%20Vanilla%20Ice%20Cream%22%7D&gb~dark_mode=off&gb~donut_price=3.33&gb~banner_text=Hello%2C%20everyone!%20I%20hope%20you%20are%20all%20doing%20well!";
 
         GBContext context = GBContext
             .builder()
@@ -634,7 +634,7 @@ class GrowthBookTest {
     void test_withUrl_getFeatureValue_forcesBooleanValue_0() {
         String featuresJson = "{\"status\":200,\"features\":{\"banner_text\":{\"defaultValue\":\"Welcome to Acme Donuts!\",\"rules\":[{\"condition\":{\"country\":\"france\"},\"force\":\"Bienvenue au Beignets Acme !\"},{\"condition\":{\"country\":\"spain\"},\"force\":\"¡Bienvenidos y bienvenidas a Donas Acme!\"}]},\"dark_mode\":{\"defaultValue\":false,\"rules\":[{\"condition\":{\"loggedIn\":true},\"force\":true,\"coverage\":0.5,\"hashAttribute\":\"id\"}]},\"donut_price\":{\"defaultValue\":2.5,\"rules\":[{\"condition\":{\"employee\":true},\"force\":0}]},\"meal_overrides_gluten_free\":{\"defaultValue\":{\"meal_type\":\"standard\",\"dessert\":\"Strawberry Cheesecake\"},\"rules\":[{\"condition\":{\"dietaryRestrictions\":{\"$elemMatch\":{\"$eq\":\"gluten_free\"}}},\"force\":{\"meal_type\":\"gf\",\"dessert\":\"French Vanilla Ice Cream\"}}]}},\"dateUpdated\":\"2023-01-11T00:26:01.745Z\"}";
         String attributes = "{}";
-        String url = "http://localhost:8080/url-feature-force?gb~meal_overrides_gluten_free=%7B%22gb~meal_type%22%3A%20%22gf%22%2C%20%22dessert%22%3A%20%22French%20Vanilla%20Ice%20Cream%22%7D&gb~dark_mode=0&donut_price=3.33&gb~banner_text=Hello%2C%20everyone!%20I%20hope%20you%20are%20all%20doing%20well!";
+        String url = "http://localhost:8080/url-feature-force?gb~meal_overrides_gluten_free=%7B%22gb~meal_type%22%3A%20%22gf%22%2C%20%22dessert%22%3A%20%22French%20Vanilla%20Ice%20Cream%22%7D&gb~dark_mode=0&gb~donut_price=3.33&gb~banner_text=Hello%2C%20everyone!%20I%20hope%20you%20are%20all%20doing%20well!";
 
         GBContext context = GBContext
             .builder()
@@ -653,7 +653,7 @@ class GrowthBookTest {
     void test_withUrl_getFeatureValue_forcesIntegerValue() {
         String featuresJson = "{\"status\":200,\"features\":{\"banner_text\":{\"defaultValue\":\"Welcome to Acme Donuts!\",\"rules\":[{\"condition\":{\"country\":\"france\"},\"force\":\"Bienvenue au Beignets Acme !\"},{\"condition\":{\"country\":\"spain\"},\"force\":\"¡Bienvenidos y bienvenidas a Donas Acme!\"}]},\"dark_mode\":{\"defaultValue\":false,\"rules\":[{\"condition\":{\"loggedIn\":true},\"force\":true,\"coverage\":0.5,\"hashAttribute\":\"id\"}]},\"donut_price\":{\"defaultValue\":2.5,\"rules\":[{\"condition\":{\"employee\":true},\"force\":0}]},\"meal_overrides_gluten_free\":{\"defaultValue\":{\"meal_type\":\"standard\",\"dessert\":\"Strawberry Cheesecake\"},\"rules\":[{\"condition\":{\"dietaryRestrictions\":{\"$elemMatch\":{\"$eq\":\"gluten_free\"}}},\"force\":{\"meal_type\":\"gf\",\"dessert\":\"French Vanilla Ice Cream\"}}]}},\"dateUpdated\":\"2023-01-11T00:26:01.745Z\"}";
         String attributes = "{}";
-        String url = "http://localhost:8080/url-feature-force?gb~meal_overrides_gluten_free=%7B%22gb~meal_type%22%3A%20%22gf%22%2C%20%22dessert%22%3A%20%22French%20Vanilla%20Ice%20Cream%22%7D&gb~dark_mode=true&donut_price=2&gb~banner_text=Hello%2C%20everyone!%20I%20hope%20you%20are%20all%20doing%20well!";
+        String url = "http://localhost:8080/url-feature-force?gb~meal_overrides_gluten_free=%7B%22gb~meal_type%22%3A%20%22gf%22%2C%20%22dessert%22%3A%20%22French%20Vanilla%20Ice%20Cream%22%7D&gb~dark_mode=true&gb~donut_price=2&gb~banner_text=Hello%2C%20everyone!%20I%20hope%20you%20are%20all%20doing%20well!";
 
         GBContext context = GBContext
             .builder()
@@ -672,7 +672,7 @@ class GrowthBookTest {
     void test_withUrl_getFeatureValue_forcesFloatValue() {
         String featuresJson = "{\"status\":200,\"features\":{\"banner_text\":{\"defaultValue\":\"Welcome to Acme Donuts!\",\"rules\":[{\"condition\":{\"country\":\"france\"},\"force\":\"Bienvenue au Beignets Acme !\"},{\"condition\":{\"country\":\"spain\"},\"force\":\"¡Bienvenidos y bienvenidas a Donas Acme!\"}]},\"dark_mode\":{\"defaultValue\":false,\"rules\":[{\"condition\":{\"loggedIn\":true},\"force\":true,\"coverage\":0.5,\"hashAttribute\":\"id\"}]},\"donut_price\":{\"defaultValue\":2.5,\"rules\":[{\"condition\":{\"employee\":true},\"force\":0}]},\"meal_overrides_gluten_free\":{\"defaultValue\":{\"meal_type\":\"standard\",\"dessert\":\"Strawberry Cheesecake\"},\"rules\":[{\"condition\":{\"dietaryRestrictions\":{\"$elemMatch\":{\"$eq\":\"gluten_free\"}}},\"force\":{\"meal_type\":\"gf\",\"dessert\":\"French Vanilla Ice Cream\"}}]}},\"dateUpdated\":\"2023-01-11T00:26:01.745Z\"}";
         String attributes = "{}";
-        String url = "http://localhost:8080/url-feature-force?gb~meal_overrides_gluten_free=%7B%22gb~meal_type%22%3A%20%22gf%22%2C%20%22dessert%22%3A%20%22French%20Vanilla%20Ice%20Cream%22%7D&gb~dark_mode=true&donut_price=3.33&gb~banner_text=Hello%2C%20everyone!%20I%20hope%20you%20are%20all%20doing%20well!";
+        String url = "http://localhost:8080/url-feature-force?gb~meal_overrides_gluten_free=%7B%22gb~meal_type%22%3A%20%22gf%22%2C%20%22dessert%22%3A%20%22French%20Vanilla%20Ice%20Cream%22%7D&gb~dark_mode=true&gb~donut_price=3.33&gb~banner_text=Hello%2C%20everyone!%20I%20hope%20you%20are%20all%20doing%20well!";
         GBContext context = GBContext
             .builder()
             .featuresJson(featuresJson)
@@ -690,7 +690,7 @@ class GrowthBookTest {
     void test_withUrl_getFeatureValue_forcesStringValue() {
         String featuresJson = "{\"status\":200,\"features\":{\"banner_text\":{\"defaultValue\":\"Welcome to Acme Donuts!\",\"rules\":[{\"condition\":{\"country\":\"france\"},\"force\":\"Bienvenue au Beignets Acme !\"},{\"condition\":{\"country\":\"spain\"},\"force\":\"¡Bienvenidos y bienvenidas a Donas Acme!\"}]},\"dark_mode\":{\"defaultValue\":false,\"rules\":[{\"condition\":{\"loggedIn\":true},\"force\":true,\"coverage\":0.5,\"hashAttribute\":\"id\"}]},\"donut_price\":{\"defaultValue\":2.5,\"rules\":[{\"condition\":{\"employee\":true},\"force\":0}]},\"meal_overrides_gluten_free\":{\"defaultValue\":{\"meal_type\":\"standard\",\"dessert\":\"Strawberry Cheesecake\"},\"rules\":[{\"condition\":{\"dietaryRestrictions\":{\"$elemMatch\":{\"$eq\":\"gluten_free\"}}},\"force\":{\"meal_type\":\"gf\",\"dessert\":\"French Vanilla Ice Cream\"}}]}},\"dateUpdated\":\"2023-01-11T00:26:01.745Z\"}";
         String attributes = "{}";
-        String url = "http://localhost:8080/url-feature-force?gb~meal_overrides_gluten_free=%7B%22gb~meal_type%22%3A%20%22gf%22%2C%20%22dessert%22%3A%20%22French%20Vanilla%20Ice%20Cream%22%7D&gb~dark_mode=true&donut_price=3.33&gb~banner_text=Hello%2C%20everyone!%20I%20hope%20you%20are%20all%20doing%20well!";
+        String url = "http://localhost:8080/url-feature-force?gb~meal_overrides_gluten_free=%7B%22gb~meal_type%22%3A%20%22gf%22%2C%20%22dessert%22%3A%20%22French%20Vanilla%20Ice%20Cream%22%7D&gb~dark_mode=true&gb~donut_price=3.33&gb~banner_text=Hello%2C%20everyone!%20I%20hope%20you%20are%20all%20doing%20well!";
         GBContext context = GBContext
             .builder()
             .featuresJson(featuresJson)
@@ -707,7 +707,7 @@ class GrowthBookTest {
 //    void test_withUrl_getFeatureValue_forcesJsonValue() {
 //        String featuresJson = "{\"status\":200,\"features\":{\"banner_text\":{\"defaultValue\":\"Welcome to Acme Donuts!\",\"rules\":[{\"condition\":{\"country\":\"france\"},\"force\":\"Bienvenue au Beignets Acme !\"},{\"condition\":{\"country\":\"spain\"},\"force\":\"¡Bienvenidos y bienvenidas a Donas Acme!\"}]},\"dark_mode\":{\"defaultValue\":false,\"rules\":[{\"condition\":{\"loggedIn\":true},\"force\":true,\"coverage\":0.5,\"hashAttribute\":\"id\"}]},\"donut_price\":{\"defaultValue\":2.5,\"rules\":[{\"condition\":{\"employee\":true},\"force\":0}]},\"meal_overrides_gluten_free\":{\"defaultValue\":{\"meal_type\":\"standard\",\"dessert\":\"Strawberry Cheesecake\"},\"rules\":[{\"condition\":{\"dietaryRestrictions\":{\"$elemMatch\":{\"$eq\":\"gluten_free\"}}},\"force\":{\"meal_type\":\"gf\",\"dessert\":\"French Vanilla Ice Cream\"}}]}},\"dateUpdated\":\"2023-01-11T00:26:01.745Z\"}";
 //        String attributes = "{}";
-//        String url = "http://localhost:8080/url-feature-force?gb~meal_overrides_gluten_free=%7B%22gb~meal_type%22%3A%20%22gf%22%2C%20%22dessert%22%3A%20%22French%20Vanilla%20Ice%20Cream%22%7D&gb~dark_mode=true&donut_price=3.33&gb~banner_text=Hello%2C%20everyone!%20I%20hope%20you%20are%20all%20doing%20well!";
+//        String url = "http://localhost:8080/url-feature-force?gb~meal_overrides_gluten_free=%7B%22gb~meal_type%22%3A%20%22gf%22%2C%20%22dessert%22%3A%20%22French%20Vanilla%20Ice%20Cream%22%7D&gb~dark_mode=true&gb~donut_price=3.33&gb~banner_text=Hello%2C%20everyone!%20I%20hope%20you%20are%20all%20doing%20well!";
 //
 //    }
 

--- a/lib/src/test/java/growthbook/sdk/java/GrowthBookTest.java
+++ b/lib/src/test/java/growthbook/sdk/java/GrowthBookTest.java
@@ -64,7 +64,7 @@ class GrowthBookTest {
             String expectedString = testCase.get("result").getAsString();
             FeatureResult expectedResult = jsonUtils.gson.fromJson(expectedString, FeatureResult.class);
 
-            FeatureResult<Object> result = subject.evalFeature(featureKey);
+            FeatureResult<Object> result = subject.evalFeature(featureKey, Object.class);
 //            System.out.printf("\n\n Eval Feature result: %s - JSON: %s", result, result.toJson());
 
             boolean passes = expectedResult.equals(result);
@@ -710,6 +710,87 @@ class GrowthBookTest {
 //        String url = "http://localhost:8080/url-feature-force?gb~meal_overrides_gluten_free=%7B%22gb~meal_type%22%3A%20%22gf%22%2C%20%22dessert%22%3A%20%22French%20Vanilla%20Ice%20Cream%22%7D&gb~dark_mode=true&gb~donut_price=3.33&gb~banner_text=Hello%2C%20everyone!%20I%20hope%20you%20are%20all%20doing%20well!";
 //
 //    }
+
+
+    // region URL -> force features -> evaluateFeature
+
+    @Test
+    void test_withUrl_evaluateFeature_forcesBooleanValue() {
+        String featuresJson = "{\"status\":200,\"features\":{\"banner_text\":{\"defaultValue\":\"Welcome to Acme Donuts!\",\"rules\":[{\"condition\":{\"country\":\"france\"},\"force\":\"Bienvenue au Beignets Acme !\"},{\"condition\":{\"country\":\"spain\"},\"force\":\"¡Bienvenidos y bienvenidas a Donas Acme!\"}]},\"dark_mode\":{\"defaultValue\":false,\"rules\":[{\"condition\":{\"loggedIn\":true},\"force\":true,\"coverage\":0.5,\"hashAttribute\":\"id\"}]},\"donut_price\":{\"defaultValue\":2.5,\"rules\":[{\"condition\":{\"employee\":true},\"force\":0}]},\"meal_overrides_gluten_free\":{\"defaultValue\":{\"meal_type\":\"standard\",\"dessert\":\"Strawberry Cheesecake\"},\"rules\":[{\"condition\":{\"dietaryRestrictions\":{\"$elemMatch\":{\"$eq\":\"gluten_free\"}}},\"force\":{\"meal_type\":\"gf\",\"dessert\":\"French Vanilla Ice Cream\"}}]}},\"dateUpdated\":\"2023-01-11T00:26:01.745Z\"}";
+        String attributes = "{}";
+        String url = "http://localhost:8080/url-feature-force?gb~meal_overrides_gluten_free=%7B%22gb~meal_type%22%3A%20%22gf%22%2C%20%22dessert%22%3A%20%22French%20Vanilla%20Ice%20Cream%22%7D&gb~dark_mode=true&gb~donut_price=3.33&gb~banner_text=Hello%2C%20everyone!%20I%20hope%20you%20are%20all%20doing%20well!";
+        GBContext context = GBContext
+            .builder()
+            .featuresJson(featuresJson)
+            .attributesJson(attributes)
+            .url(url)
+            .build();
+        GrowthBook subject = new GrowthBook(context);
+
+        FeatureResult<Boolean> result = subject.evalFeature("dark_mode", Boolean.class);
+
+        assertEquals(true, result.getValue());
+        assertEquals(FeatureResultSource.URL_OVERRIDE, result.source);
+    }
+
+    @Test
+    void test_withUrl_evaluateFeature_forcesStringValue() {
+        String featuresJson = "{\"status\":200,\"features\":{\"banner_text\":{\"defaultValue\":\"Welcome to Acme Donuts!\",\"rules\":[{\"condition\":{\"country\":\"france\"},\"force\":\"Bienvenue au Beignets Acme !\"},{\"condition\":{\"country\":\"spain\"},\"force\":\"¡Bienvenidos y bienvenidas a Donas Acme!\"}]},\"dark_mode\":{\"defaultValue\":false,\"rules\":[{\"condition\":{\"loggedIn\":true},\"force\":true,\"coverage\":0.5,\"hashAttribute\":\"id\"}]},\"donut_price\":{\"defaultValue\":2.5,\"rules\":[{\"condition\":{\"employee\":true},\"force\":0}]},\"meal_overrides_gluten_free\":{\"defaultValue\":{\"meal_type\":\"standard\",\"dessert\":\"Strawberry Cheesecake\"},\"rules\":[{\"condition\":{\"dietaryRestrictions\":{\"$elemMatch\":{\"$eq\":\"gluten_free\"}}},\"force\":{\"meal_type\":\"gf\",\"dessert\":\"French Vanilla Ice Cream\"}}]}},\"dateUpdated\":\"2023-01-11T00:26:01.745Z\"}";
+        String attributes = "{}";
+        String url = "http://localhost:8080/url-feature-force?gb~meal_overrides_gluten_free=%7B%22gb~meal_type%22%3A%20%22gf%22%2C%20%22dessert%22%3A%20%22French%20Vanilla%20Ice%20Cream%22%7D&gb~dark_mode=true&gb~donut_price=3.33&gb~banner_text=Hello%2C%20everyone!%20I%20hope%20you%20are%20all%20doing%20well!";
+        GBContext context = GBContext
+            .builder()
+            .featuresJson(featuresJson)
+            .attributesJson(attributes)
+            .url(url)
+            .build();
+        GrowthBook subject = new GrowthBook(context);
+
+        FeatureResult<String> result = subject.evalFeature("banner_text", String.class);
+
+        assertEquals("Hello, everyone! I hope you are all doing well!", result.getValue());
+        assertEquals(FeatureResultSource.URL_OVERRIDE, result.source);
+    }
+
+    @Test
+    void test_withUrl_evaluateFeature_forcesFloatValue() {
+        String featuresJson = "{\"status\":200,\"features\":{\"banner_text\":{\"defaultValue\":\"Welcome to Acme Donuts!\",\"rules\":[{\"condition\":{\"country\":\"france\"},\"force\":\"Bienvenue au Beignets Acme !\"},{\"condition\":{\"country\":\"spain\"},\"force\":\"¡Bienvenidos y bienvenidas a Donas Acme!\"}]},\"dark_mode\":{\"defaultValue\":false,\"rules\":[{\"condition\":{\"loggedIn\":true},\"force\":true,\"coverage\":0.5,\"hashAttribute\":\"id\"}]},\"donut_price\":{\"defaultValue\":2.5,\"rules\":[{\"condition\":{\"employee\":true},\"force\":0}]},\"meal_overrides_gluten_free\":{\"defaultValue\":{\"meal_type\":\"standard\",\"dessert\":\"Strawberry Cheesecake\"},\"rules\":[{\"condition\":{\"dietaryRestrictions\":{\"$elemMatch\":{\"$eq\":\"gluten_free\"}}},\"force\":{\"meal_type\":\"gf\",\"dessert\":\"French Vanilla Ice Cream\"}}]}},\"dateUpdated\":\"2023-01-11T00:26:01.745Z\"}";
+        String attributes = "{}";
+        String url = "http://localhost:8080/url-feature-force?gb~meal_overrides_gluten_free=%7B%22gb~meal_type%22%3A%20%22gf%22%2C%20%22dessert%22%3A%20%22French%20Vanilla%20Ice%20Cream%22%7D&gb~dark_mode=true&gb~donut_price=3.33&gb~banner_text=Hello%2C%20everyone!%20I%20hope%20you%20are%20all%20doing%20well!";
+        GBContext context = GBContext
+            .builder()
+            .featuresJson(featuresJson)
+            .attributesJson(attributes)
+            .url(url)
+            .build();
+        GrowthBook subject = new GrowthBook(context);
+
+        FeatureResult<Float> result = subject.evalFeature("donut_price", Float.class);
+
+        assertEquals(3.33f, result.getValue());
+        assertEquals(FeatureResultSource.URL_OVERRIDE, result.source);
+    }
+
+    @Test
+    void test_withUrl_evaluateFeature_forcesIntegerValue() {
+        String featuresJson = "{\"status\":200,\"features\":{\"banner_text\":{\"defaultValue\":\"Welcome to Acme Donuts!\",\"rules\":[{\"condition\":{\"country\":\"france\"},\"force\":\"Bienvenue au Beignets Acme !\"},{\"condition\":{\"country\":\"spain\"},\"force\":\"¡Bienvenidos y bienvenidas a Donas Acme!\"}]},\"dark_mode\":{\"defaultValue\":false,\"rules\":[{\"condition\":{\"loggedIn\":true},\"force\":true,\"coverage\":0.5,\"hashAttribute\":\"id\"}]},\"donut_price\":{\"defaultValue\":2.5,\"rules\":[{\"condition\":{\"employee\":true},\"force\":0}]},\"meal_overrides_gluten_free\":{\"defaultValue\":{\"meal_type\":\"standard\",\"dessert\":\"Strawberry Cheesecake\"},\"rules\":[{\"condition\":{\"dietaryRestrictions\":{\"$elemMatch\":{\"$eq\":\"gluten_free\"}}},\"force\":{\"meal_type\":\"gf\",\"dessert\":\"French Vanilla Ice Cream\"}}]}},\"dateUpdated\":\"2023-01-11T00:26:01.745Z\"}";
+        String attributes = "{}";
+        String url = "http://localhost:8080/url-feature-force?gb~meal_overrides_gluten_free=%7B%22gb~meal_type%22%3A%20%22gf%22%2C%20%22dessert%22%3A%20%22French%20Vanilla%20Ice%20Cream%22%7D&gb~dark_mode=true&gb~donut_price=4&gb~banner_text=Hello%2C%20everyone!%20I%20hope%20you%20are%20all%20doing%20well!";
+        GBContext context = GBContext
+            .builder()
+            .featuresJson(featuresJson)
+            .attributesJson(attributes)
+            .url(url)
+            .build();
+        GrowthBook subject = new GrowthBook(context);
+
+        FeatureResult<Integer> result = subject.evalFeature("donut_price", Integer.class);
+
+        assertEquals(4, result.getValue());
+        assertEquals(FeatureResultSource.URL_OVERRIDE, result.source);
+    }
+
+    // endregion URL -> force features -> evaluateFeature
 
     // endregion URL -> force features
 }

--- a/lib/src/test/java/growthbook/sdk/java/UrlUtilsTest.java
+++ b/lib/src/test/java/growthbook/sdk/java/UrlUtilsTest.java
@@ -14,7 +14,7 @@ class UrlUtilsTest {
 
     @Test
     void test_parseQueryString() throws MalformedURLException {
-        String urlString = "http://localhost:8080/url-feature-force?gb~meal_overrides_gluten_free=%7B%22gb~meal_type%22%3A%20%22gf%22%2C%20%22dessert%22%3A%20%22French%20Vanilla%20Ice%20Cream%22%7D&gb~dark_mode=on&gb~donut_price=3.33&gb~banner_text=Hello%2C%20everyone!%20I%20hope%20you%20are%20all%20doing%20well!";
+        String urlString = "http://localhost:8080/url-feature-force?gb~meal_overrides_gluten_free=%7B%22meal_type%22%3A%20%22gf%22%2C%20%22dessert%22%3A%20%22French%20Vanilla%20Ice%20Cream%22%7D&gb~dark_mode=on&gb~donut_price=3.33&gb~banner_text=Hello%2C%20everyone!%20I%20hope%20you%20are%20all%20doing%20well!";
         URL url = new URL(urlString);
         String query = url.getQuery();
 
@@ -23,6 +23,6 @@ class UrlUtilsTest {
         assertEquals("Hello, everyone! I hope you are all doing well!", result.get("gb~banner_text"));
         assertEquals("3.33", result.get("gb~donut_price"));
         assertEquals("on", result.get("gb~dark_mode"));
-        assertEquals("{\"gb~meal_type\": \"gf\", \"dessert\": \"French Vanilla Ice Cream\"}", result.get("gb~meal_overrides_gluten_free"));
+        assertEquals("{\"meal_type\": \"gf\", \"dessert\": \"French Vanilla Ice Cream\"}", result.get("gb~meal_overrides_gluten_free"));
     }
 }

--- a/lib/src/test/java/growthbook/sdk/java/UrlUtilsTest.java
+++ b/lib/src/test/java/growthbook/sdk/java/UrlUtilsTest.java
@@ -1,0 +1,28 @@
+package growthbook.sdk.java;
+
+import org.junit.jupiter.api.Test;
+
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class UrlUtilsTest {
+
+    @Test
+    void test_parseQueryString() throws MalformedURLException {
+        String urlString = "http://localhost:8080/url-feature-force?gb~meal_overrides_gluten_free=%7B%22gb~meal_type%22%3A%20%22gf%22%2C%20%22dessert%22%3A%20%22French%20Vanilla%20Ice%20Cream%22%7D&gb~dark_mode=on&gb~donut_price=3.33&gb~banner_text=Hello%2C%20everyone!%20I%20hope%20you%20are%20all%20doing%20well!";
+        URL url = new URL(urlString);
+        String query = url.getQuery();
+
+        Map<String, String> result = UrlUtils.parseQueryString(query);
+
+        assertEquals("Hello, everyone! I hope you are all doing well!", result.get("gb~banner_text"));
+        assertEquals("3.33", result.get("gb~donut_price"));
+        assertEquals("on", result.get("gb~dark_mode"));
+        assertEquals("{\"gb~meal_type\": \"gf\", \"dessert\": \"French Vanilla Ice Cream\"}", result.get("gb~meal_overrides_gluten_free"));
+    }
+}


### PR DESCRIPTION
Adds support for parsing feature default values from the URL for the following data types:

- boolean (as 0/1, true/false, on/off)
- integer
- float
- string
- json
    - Gson deserializable that doesn't require a custom type attribute
    - from string, allowing a custom deserialization implementation (see JSON region in tests)

Closes https://github.com/growthbook/growthbook-sdk-java/issues/17