### PR TITLE
GH-26 The SDK should use a logging library

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 ## Requirements
 
 - Java version 1.8 or later
+- The library uses Slf4j for logging. You will need to add an appropriate slf4j binding for the logging framework that your project uses.
 
 
 ## Documentation

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -34,6 +34,10 @@ dependencies {
     implementation 'org.apache.commons:commons-math3:3.6.1'
     implementation 'com.google.guava:guava:31.0.1-jre'
 
+    // https://mvnrepository.com/artifact/org.slf4j/slf4j-api
+    implementation 'org.slf4j:slf4j-api:2.0.7'
+    testImplementation 'org.slf4j:slf4j-simple:2.0.7'
+
     // https://mvnrepository.com/artifact/com.google.code.gson/gson
     implementation 'com.google.code.gson:gson:2.9.1'
 

--- a/lib/src/main/java/growthbook/sdk/java/ConditionEvaluator.java
+++ b/lib/src/main/java/growthbook/sdk/java/ConditionEvaluator.java
@@ -5,6 +5,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
 import com.google.gson.reflect.TypeToken;
+import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.Nullable;
 import java.lang.reflect.Type;
@@ -15,6 +16,7 @@ import java.util.regex.Pattern;
 /**
  * <b>INTERNAL</b>: Implementation of condition evaluation
  */
+@Slf4j
 class ConditionEvaluator implements IConditionEvaluator {
 
     private final GrowthBookJsonUtils jsonUtils = GrowthBookJsonUtils.getInstance();
@@ -66,7 +68,7 @@ class ConditionEvaluator implements IConditionEvaluator {
 
             return true;
         } catch (RuntimeException e) {
-            e.printStackTrace();
+            log.error("Error evaluating condition [{}] with attributes [{}]", conditionJsonString, conditionJsonString, e);
             return false;
         }
     }
@@ -371,7 +373,7 @@ class ConditionEvaluator implements IConditionEvaluator {
                 //
         }
 
-        System.out.printf("\nUnsupported data type %s", dataType);
+        log.info("Unsupported data type [{}]", dataType);
 
         return false;
     }

--- a/lib/src/main/java/growthbook/sdk/java/DecryptionUtils.java
+++ b/lib/src/main/java/growthbook/sdk/java/DecryptionUtils.java
@@ -1,5 +1,7 @@
 package growthbook.sdk.java;
 
+import lombok.extern.slf4j.Slf4j;
+
 import javax.crypto.BadPaddingException;
 import javax.crypto.Cipher;
 import javax.crypto.IllegalBlockSizeException;
@@ -18,6 +20,7 @@ import java.util.Base64;
 /**
  * INTERNAL: This class is used internally to decrypt an encrypted features response
  */
+@Slf4j
 class DecryptionUtils {
 
     public static class DecryptionException extends Exception {
@@ -65,7 +68,7 @@ class DecryptionUtils {
             | IllegalArgumentException
             | BadPaddingException e
         ) {
-            e.printStackTrace();
+            log.error("Unable to decrypt payload", e);
             throw new DecryptionException(e.getMessage());
         }
     }

--- a/lib/src/main/java/growthbook/sdk/java/FeatureEvaluator.java
+++ b/lib/src/main/java/growthbook/sdk/java/FeatureEvaluator.java
@@ -3,6 +3,7 @@ package growthbook.sdk.java;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
+import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.Nullable;
 import java.net.MalformedURLException;
@@ -12,6 +13,7 @@ import java.util.List;
 /**
  * <b>INTERNAL</b>: Implementation of feature evaluation
  */
+@Slf4j
 class FeatureEvaluator implements IFeatureEvaluator {
 
     private final GrowthBookJsonUtils jsonUtils = GrowthBookJsonUtils.getInstance();
@@ -54,7 +56,7 @@ class FeatureEvaluator implements IFeatureEvaluator {
                     .build();
 
             if (featureJson == null) {
-                System.out.println("featureJson is null");
+                log.debug("featureJson is null for [{}]", key);
                 // When key exists but there is no value, should be default value with null value
                 return defaultValueFeature;
             }
@@ -191,7 +193,7 @@ class FeatureEvaluator implements IFeatureEvaluator {
                     .value(value)
                     .build();
         } catch (Exception e) {
-            e.printStackTrace();
+            log.error("Error evaluating feature [{}]", key, e);
             return emptyFeature;
         }
     }
@@ -224,7 +226,7 @@ class FeatureEvaluator implements IFeatureEvaluator {
 
             return GrowthBookUtils.getForcedSerializableValueFromUrl(key, url, valueTypeClass, jsonUtils.gson);
         } catch (MalformedURLException | ClassCastException e) {
-            e.printStackTrace();
+            log.error("Error evaluating forced feature [{}] from URL [{}]", key, urlString, e);
             return null;
         }
     }

--- a/lib/src/main/java/growthbook/sdk/java/GBContext.java
+++ b/lib/src/main/java/growthbook/sdk/java/GBContext.java
@@ -6,6 +6,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Data;
 import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.Nullable;
 import java.util.HashMap;
@@ -16,6 +17,7 @@ import java.util.Map;
  * The {@link GBContext#builder()} is recommended for constructing a Context.
  * Alternatively, you can use the class's constructor.
  */
+@Slf4j
 @Data
 public class GBContext {
 
@@ -56,7 +58,7 @@ public class GBContext {
                 String decrypted = DecryptionUtils.decrypt(featuresJson, encryptionKey);
                 this.featuresJson = decrypted.trim();
             } catch (DecryptionUtils.DecryptionException e) {
-                e.printStackTrace();
+                log.error("Unable to decrypt feature json", e);
             }
         } else if (featuresJson != null) {
             // Use features
@@ -170,7 +172,7 @@ public class GBContext {
         try {
             return GrowthBookJsonUtils.getInstance().gson.fromJson(featuresJsonString, JsonObject.class);
         } catch (Exception e) {
-            e.printStackTrace();
+            log.error("Error transforming features [{}]", featuresJsonString, e);
             return null;
         }
     }
@@ -188,7 +190,7 @@ public class GBContext {
 
             return GrowthBookJsonUtils.getInstance().gson.fromJson(attributesJsonString, JsonObject.class);
         } catch (Exception e) {
-            e.printStackTrace();
+            log.error("Error transforming attributes [{}]", attributesJsonString, e);
             return new JsonObject();
         }
     }

--- a/lib/src/main/java/growthbook/sdk/java/GBFeaturesRepository.java
+++ b/lib/src/main/java/growthbook/sdk/java/GBFeaturesRepository.java
@@ -4,6 +4,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
 import okhttp3.*;
 import org.jetbrains.annotations.NotNull;
 
@@ -20,6 +21,7 @@ import java.util.List;
  * Get the features JSON with {@link GBFeaturesRepository#getFeaturesJson()}.
  * You would provide the features JSON when creating the {@link GBContext}
  */
+@Slf4j
 public class GBFeaturesRepository implements IGBFeaturesRepository {
 
     @Getter
@@ -131,7 +133,7 @@ public class GBFeaturesRepository implements IGBFeaturesRepository {
                 try {
                     self.onSuccess(response);
                 } catch (FeatureFetchException e) {
-                    e.printStackTrace();
+                    log.error("Error refreshing features", e);
                 }
             }
         });
@@ -178,7 +180,7 @@ public class GBFeaturesRepository implements IGBFeaturesRepository {
         try (Response response = this.okHttpClient.newCall(request).execute()) {
             this.onSuccess(response);
         } catch (IOException e) {
-            e.printStackTrace();
+            log.error("Error fetching features", e);
 
             throw new FeatureFetchException(
                 FeatureFetchException.FeatureFetchErrorCode.UNKNOWN,
@@ -237,7 +239,7 @@ public class GBFeaturesRepository implements IGBFeaturesRepository {
                 featureRefreshCallback.onRefresh(this.featuresJson);
             });
         } catch (IOException | DecryptionUtils.DecryptionException e) {
-            e.printStackTrace();
+            log.error("Error fetching features", e);
 
             throw new FeatureFetchException(
                 FeatureFetchException.FeatureFetchErrorCode.UNKNOWN,

--- a/lib/src/main/java/growthbook/sdk/java/GrowthBook.java
+++ b/lib/src/main/java/growthbook/sdk/java/GrowthBook.java
@@ -1,5 +1,7 @@
 package growthbook.sdk.java;
 
+import lombok.extern.slf4j.Slf4j;
+
 import javax.annotation.Nullable;
 import java.util.ArrayList;
 
@@ -8,6 +10,7 @@ import java.util.ArrayList;
  * Build a context with {@link GBContext#builder()} or the {@link GBContext} constructor
  * and pass it as an argument to the class constructor.
  */
+@Slf4j
 public class GrowthBook implements IGrowthBook {
 
     private final GBContext context;
@@ -104,7 +107,7 @@ public class GrowthBook implements IGrowthBook {
             Boolean maybeValue = (Boolean) this.featureEvaluator.evaluateFeature(featureKey, context, Boolean.class).getValue();
             return maybeValue == null ? defaultValue : maybeValue;
         } catch (Exception e) {
-            e.printStackTrace();
+            log.error("Error evaluating feature [{}]", featureKey, e);
             return defaultValue;
         }
     }
@@ -115,7 +118,7 @@ public class GrowthBook implements IGrowthBook {
             String maybeValue = (String) this.featureEvaluator.evaluateFeature(featureKey, context, String.class).getValue();
             return maybeValue == null ? defaultValue : maybeValue;
         } catch (Exception e) {
-            e.printStackTrace();
+            log.error("Error evaluating feature [{}]", featureKey, e);
             return defaultValue;
         }
     }
@@ -136,7 +139,7 @@ public class GrowthBook implements IGrowthBook {
                 return defaultValue;
             }
         } catch (Exception e) {
-            e.printStackTrace();
+            log.error("Error evaluating feature [{}]", featureKey, e);
             return defaultValue;
         }
     }
@@ -157,7 +160,7 @@ public class GrowthBook implements IGrowthBook {
                 return defaultValue;
             }
         } catch (Exception e) {
-            e.printStackTrace();
+            log.error("Error evaluating feature [{}]", featureKey, e);
             return defaultValue;
         }
     }
@@ -168,7 +171,7 @@ public class GrowthBook implements IGrowthBook {
             Object maybeValue = this.featureEvaluator.evaluateFeature(featureKey, context, defaultValue.getClass()).getValue();
             return maybeValue == null ? defaultValue : maybeValue;
         } catch (Exception e) {
-            e.printStackTrace();
+            log.error("Error evaluating feature [{}]", featureKey, e);
             return defaultValue;
         }
     }
@@ -185,7 +188,7 @@ public class GrowthBook implements IGrowthBook {
 
             return jsonUtils.gson.fromJson(stringValue, gsonDeserializableClass);
         } catch (Exception e) {
-            e.printStackTrace();
+            log.error("Error evaluating feature [{}]", featureKey, e);
             return defaultValue;
         }
     }
@@ -201,7 +204,7 @@ public class GrowthBook implements IGrowthBook {
             Double maybeValue = (Double) this.featureEvaluator.evaluateFeature(featureKey, context, Double.class).getValue();
             return maybeValue == null ? defaultValue : maybeValue;
         } catch (Exception e) {
-            e.printStackTrace();
+            log.error("Error evaluating feature [{}]", featureKey, e);
             return defaultValue;
         }
     }

--- a/lib/src/main/java/growthbook/sdk/java/GrowthBookJsonUtils.java
+++ b/lib/src/main/java/growthbook/sdk/java/GrowthBookJsonUtils.java
@@ -4,6 +4,7 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonPrimitive;
+import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.Nullable;
 import java.math.BigDecimal;
@@ -14,6 +15,7 @@ import java.math.BigInteger;
  * Some types in the JSON source are tuples. This helps with transforming to and from POJOs.
  * The provided methods use a custom Gson instance that has all required type adapters registered.
  */
+@Slf4j
 class GrowthBookJsonUtils {
     /**
      * The Gson instance is exposed for convenience.
@@ -145,7 +147,7 @@ class GrowthBookJsonUtils {
 
             return DataType.UNKNOWN;
         } catch (RuntimeException e) {
-            e.printStackTrace();
+            log.error("Error getting element type [{}]", element, e);
             return DataType.UNKNOWN;
         }
     }
@@ -172,7 +174,7 @@ class GrowthBookJsonUtils {
 
             return GrowthBookJsonUtils.getInstance().gson.toJsonTree(object);
         } catch (Exception e) {
-            e.printStackTrace();
+            log.error("Error getting json element for object [{}]", object, e);
             return null;
         }
     }

--- a/lib/src/main/java/growthbook/sdk/java/GrowthBookUtils.java
+++ b/lib/src/main/java/growthbook/sdk/java/GrowthBookUtils.java
@@ -4,6 +4,7 @@ import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
+import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nullable;
@@ -18,6 +19,7 @@ import java.util.Map;
 /**
  * <b>INTERNAL</b>: Implementation of for internal utility methods to support {@link growthbook.sdk.java.GrowthBook}
  */
+@Slf4j
 class GrowthBookUtils {
     /**
      * Hashes a string to a float between 0 and 1, or null if the hash version is unsupported.
@@ -183,7 +185,7 @@ class GrowthBookUtils {
 
             return variationValue;
         } catch (NumberFormatException exception) {
-            exception.printStackTrace();
+            log.error("Error querying override for [{}] from [{}]", id, url, exception);
             return null;
         }
     }
@@ -337,7 +339,7 @@ class GrowthBookUtils {
         try {
             return gson.fromJson(value, valueTypeClass);
         } catch (Exception e) {
-            e.printStackTrace();
+            log.error("Error forced value for feature [{}] from url [{}]", featureKey, url, e);
             return null;
         }
     }

--- a/lib/src/main/java/growthbook/sdk/java/UrlUtils.java
+++ b/lib/src/main/java/growthbook/sdk/java/UrlUtils.java
@@ -1,11 +1,14 @@
 package growthbook.sdk.java;
 
+import lombok.extern.slf4j.Slf4j;
+
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
+@Slf4j
 class UrlUtils {
     /**
      * Parse a query string into a map of key/value pairs.
@@ -30,7 +33,7 @@ class UrlUtils {
 
                 map.put(name, value);
             } catch (UnsupportedEncodingException e) {
-                e.printStackTrace();
+                log.error("Unable to parse query string [{}]", queryString, e);
             }
         }
         return map;


### PR DESCRIPTION
As per [GH-26](https://github.com/growthbook/growthbook-sdk-java/issues/23), I have migrated all the System.out and .printStackTrace to logging calls.

I noticed there are a bunch of commented out println statements in the code; We may want to un-comment them and log them at .debug or .trace levels, depending on how you use them.
