### PR TITLE
Feature/add error handler for callback

### DIFF
--- a/lib/src/main/java/growthbook/sdk/java/FeatureRefreshCallback.java
+++ b/lib/src/main/java/growthbook/sdk/java/FeatureRefreshCallback.java
@@ -10,4 +10,10 @@ public interface FeatureRefreshCallback {
      * @param featuresJson  Features as JSON string
      */
     void onRefresh(String featuresJson);
+
+    /**
+     * See {@link GBFeaturesRepository#onFeaturesRefresh(FeatureRefreshCallback)}
+     * @param throwable Exception on refreshCallback
+     */
+    void onError(Throwable throwable);
 }

--- a/lib/src/main/java/growthbook/sdk/java/GBFeaturesRepository.java
+++ b/lib/src/main/java/growthbook/sdk/java/GBFeaturesRepository.java
@@ -123,7 +123,7 @@ public class GBFeaturesRepository implements IGBFeaturesRepository {
             @Override
             public void onFailure(@NotNull Call call, @NotNull IOException e) {
                 // OkHttp will auto-retry on failure
-                self.refreshFailedCallbacks(e);
+                self.onRefreshFailed(e);
             }
 
             @Override
@@ -233,8 +233,7 @@ public class GBFeaturesRepository implements IGBFeaturesRepository {
 
             this.featuresJson = refreshedFeatures;
 
-            this.refreshSuccessfullyCallbacks(this.featuresJson);
-
+            this.onRefreshSuccess(this.featuresJson);
         } catch (IOException | DecryptionUtils.DecryptionException e) {
             e.printStackTrace();
 
@@ -245,14 +244,16 @@ public class GBFeaturesRepository implements IGBFeaturesRepository {
         }
     }
 
-    private void refreshSuccessfullyCallbacks(String featuresJson) {
-        this.refreshCallbacks
-                .forEach(featureRefreshCallback -> featureRefreshCallback.onRefresh(featuresJson));
+    private void onRefreshSuccess(String featuresJson) {
+        this.refreshCallbacks.forEach(featureRefreshCallback -> {
+            featureRefreshCallback.onRefresh(featuresJson);
+        });
     }
 
-    private void refreshFailedCallbacks(Throwable throwable) {
-        this.refreshCallbacks
-                .forEach(featureRefreshCallback -> featureRefreshCallback.onError(throwable));
+    private void onRefreshFailed(Throwable throwable) {
+        this.refreshCallbacks.forEach(featureRefreshCallback -> {
+            featureRefreshCallback.onError(throwable);
+        });
     }
 
     /**

--- a/lib/src/main/java/growthbook/sdk/java/GBFeaturesRepository.java
+++ b/lib/src/main/java/growthbook/sdk/java/GBFeaturesRepository.java
@@ -98,7 +98,7 @@ public class GBFeaturesRepository implements IGBFeaturesRepository {
 
     /**
      * Subscribe to feature refresh events
-     * This callback is called when the features are successfully or error refreshed.
+     * This callback is called when the features are successfully refreshed or there is an error when refreshing.
      * This is called even if the features have not changed.
      * @param callback  This callback will be called when features are refreshed
      */

--- a/lib/src/test/java/growthbook/sdk/java/GBFeaturesRepositoryTest.java
+++ b/lib/src/test/java/growthbook/sdk/java/GBFeaturesRepositoryTest.java
@@ -181,10 +181,12 @@ class GBFeaturesRepositoryTest {
         FeatureRefreshCallback featureRefreshCallback = mock(FeatureRefreshCallback.class);
 
         GBFeaturesRepository subject = new GBFeaturesRepository(
-                mockOkHttpClient,
                 "http://localhost:80",
+                "sdk-abc123",
                 null,
-                0
+                null,
+                0,
+                mockOkHttpClient
         );
 
         subject.onFeaturesRefresh(featureRefreshCallback);
@@ -212,11 +214,14 @@ class GBFeaturesRepositoryTest {
         FeatureRefreshCallback featureRefreshCallback = mock(FeatureRefreshCallback.class);
 
         GBFeaturesRepository subject = new GBFeaturesRepository(
-                mockOkHttpClient,
                 "http://localhost:80",
+                "sdk-abc123",
                 null,
-                0
+                null,
+                0,
+                mockOkHttpClient
         );
+
         subject.onFeaturesRefresh(featureRefreshCallback);
 
         subject.getFeaturesJson();

--- a/lib/src/test/java/growthbook/sdk/java/GBFeaturesRepositoryTest.java
+++ b/lib/src/test/java/growthbook/sdk/java/GBFeaturesRepositoryTest.java
@@ -237,10 +237,10 @@ class GBFeaturesRepositoryTest {
             .request(new Request.Builder().url("http://url.com").build())
             .protocol(Protocol.HTTP_1_1)
             .code(200).message("").body(
-                    ResponseBody.create(
-                            serializedBody,
-                            MediaType.parse("application/json")
-                    ))
+                ResponseBody.create(
+                        serializedBody,
+                        MediaType.parse("application/json")
+                ))
             .build();
 
         when(remoteCall.execute()).thenReturn(response);

--- a/lib/src/test/java/growthbook/sdk/java/GBFeaturesRepositoryTest.java
+++ b/lib/src/test/java/growthbook/sdk/java/GBFeaturesRepositoryTest.java
@@ -7,10 +7,12 @@ import java.io.IOException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class GBFeaturesRepositoryTest {
@@ -140,64 +142,51 @@ class GBFeaturesRepositoryTest {
     }
 
     @Test
-    void refreshCallbackWhenCacheRefreshSuccess() throws IOException, FeatureFetchException, InterruptedException {
+    void testOnFeaturesRefresh_Success() throws IOException, FeatureFetchException {
         String fakeResponseJson = "{\"status\":200,\"features\":{\"banner_text\":{\"defaultValue\":\"Welcome to Acme Donuts!\",\"rules\":[{\"condition\":{\"country\":\"france\"},\"force\":\"Bienvenue au Beignets Acme !\"},{\"condition\":{\"country\":\"spain\"},\"force\":\"¡Bienvenidos y bienvenidas a Donas Acme!\"}]},\"dark_mode\":{\"defaultValue\":false,\"rules\":[{\"condition\":{\"loggedIn\":true},\"force\":true,\"coverage\":0.5,\"hashAttribute\":\"id\"}]},\"donut_price\":{\"defaultValue\":2.5,\"rules\":[{\"condition\":{\"employee\":true},\"force\":0}]},\"meal_overrides_gluten_free\":{\"defaultValue\":{\"meal_type\":\"standard\",\"dessert\":\"Strawberry Cheesecake\"},\"rules\":[{\"condition\":{\"dietaryRestrictions\":{\"$elemMatch\":{\"$eq\":\"gluten_free\"}}},\"force\":{\"meal_type\":\"gf\",\"dessert\":\"French Vanilla Ice Cream\"}}]}},\"dateUpdated\":\"2023-01-11T00:26:01.745Z\"}";
         OkHttpClient mockOkHttpClient = mockHttpClient(fakeResponseJson);
-        int ttlSeconds = 0;
+        FeatureRefreshCallback featureRefreshCallback = mock(FeatureRefreshCallback.class);
 
         GBFeaturesRepository subject = new GBFeaturesRepository(
                 mockOkHttpClient,
                 "http://localhost:80",
                 null,
-                ttlSeconds
+                0
         );
         subject.initialize();
 
-        String expected = "{\"banner_text\":{\"defaultValue\":\"Welcome to Acme Donuts!\",\"rules\":[{\"condition\":{\"country\":\"france\"},\"force\":\"Bienvenue au Beignets Acme !\"},{\"condition\":{\"country\":\"spain\"},\"force\":\"¡Bienvenidos y bienvenidas a Donas Acme!\"}]},\"dark_mode\":{\"defaultValue\":false,\"rules\":[{\"condition\":{\"loggedIn\":true},\"force\":true,\"coverage\":0.5,\"hashAttribute\":\"id\"}]},\"donut_price\":{\"defaultValue\":2.5,\"rules\":[{\"condition\":{\"employee\":true},\"force\":0}]},\"meal_overrides_gluten_free\":{\"defaultValue\":{\"meal_type\":\"standard\",\"dessert\":\"Strawberry Cheesecake\"},\"rules\":[{\"condition\":{\"dietaryRestrictions\":{\"$elemMatch\":{\"$eq\":\"gluten_free\"}}},\"force\":{\"meal_type\":\"gf\",\"dessert\":\"French Vanilla Ice Cream\"}}]}}";
-
-        subject.onFeaturesRefresh(new FeatureRefreshCallback() {
-            @Override
-            public void onRefresh(String featuresJson) {
-                assertEquals(expected, featuresJson);
-            }
-
-            @Override
-            public void onError(Throwable throwable) {
-            }
-        });
+        subject.onFeaturesRefresh(featureRefreshCallback);
 
         subject.getFeaturesJson();
+
+        String expected = "{\"banner_text\":{\"defaultValue\":\"Welcome to Acme Donuts!\",\"rules\":[{\"condition\":{\"country\":\"france\"},\"force\":\"Bienvenue au Beignets Acme !\"},{\"condition\":{\"country\":\"spain\"},\"force\":\"¡Bienvenidos y bienvenidas a Donas Acme!\"}]},\"dark_mode\":{\"defaultValue\":false,\"rules\":[{\"condition\":{\"loggedIn\":true},\"force\":true,\"coverage\":0.5,\"hashAttribute\":\"id\"}]},\"donut_price\":{\"defaultValue\":2.5,\"rules\":[{\"condition\":{\"employee\":true},\"force\":0}]},\"meal_overrides_gluten_free\":{\"defaultValue\":{\"meal_type\":\"standard\",\"dessert\":\"Strawberry Cheesecake\"},\"rules\":[{\"condition\":{\"dietaryRestrictions\":{\"$elemMatch\":{\"$eq\":\"gluten_free\"}}},\"force\":{\"meal_type\":\"gf\",\"dessert\":\"French Vanilla Ice Cream\"}}]}}";
+        verify(featureRefreshCallback).onRefresh(expected);
+        verify(featureRefreshCallback, never()).onError(any(Throwable.class));
     }
 
     @Test
-    void refreshCallbackWhenCacheRefreshFailed() throws IOException, FeatureFetchException, InterruptedException {
+    void testOnFeaturesRefresh_Error() throws IOException, FeatureFetchException {
         String fakeResponseJson = "{\"status\":200,\"features\":{\"banner_text\":{\"defaultValue\":\"Welcome to Acme Donuts!\",\"rules\":[{\"condition\":{\"country\":\"france\"},\"force\":\"Bienvenue au Beignets Acme !\"},{\"condition\":{\"country\":\"spain\"},\"force\":\"¡Bienvenidos y bienvenidas a Donas Acme!\"}]},\"dark_mode\":{\"defaultValue\":false,\"rules\":[{\"condition\":{\"loggedIn\":true},\"force\":true,\"coverage\":0.5,\"hashAttribute\":\"id\"}]},\"donut_price\":{\"defaultValue\":2.5,\"rules\":[{\"condition\":{\"employee\":true},\"force\":0}]},\"meal_overrides_gluten_free\":{\"defaultValue\":{\"meal_type\":\"standard\",\"dessert\":\"Strawberry Cheesecake\"},\"rules\":[{\"condition\":{\"dietaryRestrictions\":{\"$elemMatch\":{\"$eq\":\"gluten_free\"}}},\"force\":{\"meal_type\":\"gf\",\"dessert\":\"French Vanilla Ice Cream\"}}]}},\"dateUpdated\":\"2023-01-11T00:26:01.745Z\"}";
-        OkHttpClient okHttpClient = mockHttpClientFailedCallback(fakeResponseJson, new IOException("Request failed"));
-        int ttlSeconds = 0;
+        IOException error = new IOException("Request failed");
+        OkHttpClient mockOkHttpClient = mockHttpClientFailedCallback(fakeResponseJson, error);
+        FeatureRefreshCallback featureRefreshCallback = mock(FeatureRefreshCallback.class);
 
         GBFeaturesRepository subject = new GBFeaturesRepository(
-                okHttpClient,
+                mockOkHttpClient,
                 "http://localhost:80",
                 null,
-                ttlSeconds
+                0
         );
         subject.initialize();
 
-        subject.onFeaturesRefresh(new FeatureRefreshCallback() {
-            @Override
-            public void onRefresh(String featuresJson) {
-            }
-
-            @Override
-            public void onError(Throwable throwable) {
-                assertThrows(IOException.class, () -> {
-                    throw throwable;
-                });
-            }
-        });
+        subject.onFeaturesRefresh(featureRefreshCallback);
 
         subject.getFeaturesJson();
+
+        verify(featureRefreshCallback).onError(error);
+        verify(featureRefreshCallback, never()).onRefresh(anyString());
     }
+
     /*
     @Test
     void testUserAgentHeaders() throws FeatureFetchException {

--- a/lib/src/test/java/growthbook/sdk/java/GBFeaturesRepositoryTest.java
+++ b/lib/src/test/java/growthbook/sdk/java/GBFeaturesRepositoryTest.java
@@ -238,8 +238,8 @@ class GBFeaturesRepositoryTest {
             .protocol(Protocol.HTTP_1_1)
             .code(200).message("").body(
                 ResponseBody.create(
-                        serializedBody,
-                        MediaType.parse("application/json")
+                    serializedBody,
+                    MediaType.parse("application/json")
                 ))
             .build();
 

--- a/lib/src/test/java/growthbook/sdk/java/GBFeaturesRepositoryTest.java
+++ b/lib/src/test/java/growthbook/sdk/java/GBFeaturesRepositoryTest.java
@@ -234,14 +234,14 @@ class GBFeaturesRepositoryTest {
         Call remoteCall = mock(Call.class);
 
         Response response = new Response.Builder()
-                .request(new Request.Builder().url("http://url.com").build())
-                .protocol(Protocol.HTTP_1_1)
-                .code(200).message("").body(
-                        ResponseBody.create(
-                                serializedBody,
-                                MediaType.parse("application/json")
-                        ))
-                .build();
+            .request(new Request.Builder().url("http://url.com").build())
+            .protocol(Protocol.HTTP_1_1)
+            .code(200).message("").body(
+                    ResponseBody.create(
+                            serializedBody,
+                            MediaType.parse("application/json")
+                    ))
+            .build();
 
         when(remoteCall.execute()).thenReturn(response);
         when(okHttpClient.newCall(any())).thenReturn(remoteCall);


### PR DESCRIPTION
Hello. We want to use client-side Growthbook service call metrics. But a handler made for succesfully calls only would like to add an error handler as well. Here's the pull request, it's not claims to be the best solution. Thank you)

Closes #32 