### PR TITLE
Gracefully handle error response codes on features repository initialization

### DIFF
--- a/lib/src/main/java/growthbook/sdk/java/GBFeaturesRepository.java
+++ b/lib/src/main/java/growthbook/sdk/java/GBFeaturesRepository.java
@@ -382,7 +382,13 @@ public class GBFeaturesRepository implements IGBFeaturesRepository {
             ResponseBody responseBody = response.body();
             if (responseBody == null) {
                 throw new FeatureFetchException(
-                    FeatureFetchException.FeatureFetchErrorCode.NO_RESPONSE_ERROR
+                        FeatureFetchException.FeatureFetchErrorCode.NO_RESPONSE_ERROR
+                );
+            }
+            if (response.code() != 200) {
+                throw new FeatureFetchException(
+                        FeatureFetchException.FeatureFetchErrorCode.UNKNOWN,
+                        "Unexpected HTTP response code: " + response.code() + ", body: " + responseBody.string()
                 );
             }
 


### PR DESCRIPTION
At the moment, HTTP status codes different than 200 are completely ignored. This leads to confusing error messages that don't help clients debug the issue quickly. Adding a check for the return status code helps ensure a more meaningful error message can be returned.

Ideally, the body of the response should be logged rather than provided in the exception message. In the absence of a logging framework in the library however, I think emitting the body in the message can help debugging.

Happy to adapt as needed if you have any feedback.