### PR TITLE
Reduce Exceptions in the ConditionEvaluator

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 For now we are manually managing the version number.
 
 When making a new release, ensure the file `growthbook/sdk/java/Version.java` has the version matching the tag and release. For example, if you are releasing version `0.3.0`, the following criteria should be met:
- 
+
 - the tag should be `0.3.0`
 - the release should be `0.3.0` 
 - the contents of the `Version.java` file should include the version as `static final String SDK_VERSION = "0.3.0";`

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 For now we are manually managing the version number.
 
 When making a new release, ensure the file `growthbook/sdk/java/Version.java` has the version matching the tag and release. For example, if you are releasing version `0.3.0`, the following criteria should be met:
-
+ 
 - the tag should be `0.3.0`
 - the release should be `0.3.0` 
 - the contents of the `Version.java` file should include the version as `static final String SDK_VERSION = "0.3.0";`

--- a/lib/src/main/java/growthbook/sdk/java/ConditionEvaluator.java
+++ b/lib/src/main/java/growthbook/sdk/java/ConditionEvaluator.java
@@ -265,7 +265,8 @@ class ConditionEvaluator implements IConditionEvaluator {
 
             case GT:
                 if (actual == null || DataType.NULL.equals(attributeDataType)) {
-                    return 0.0 > expected.getAsDouble();
+                    return (!expected.isJsonPrimitive() || expected.getAsJsonPrimitive().isNumber())
+                        && 0.0 > expected.getAsDouble();
                 }
                 if (actual.getAsJsonPrimitive().isNumber()) {
                     return actual.getAsNumber().floatValue() > expected.getAsNumber().floatValue();
@@ -277,7 +278,8 @@ class ConditionEvaluator implements IConditionEvaluator {
 
             case GTE:
                 if (actual == null || DataType.NULL.equals(attributeDataType)) {
-                    return 0.0 >= expected.getAsDouble();
+                    return (!expected.isJsonPrimitive() || expected.getAsJsonPrimitive().isNumber())
+                        && 0.0 >= expected.getAsDouble();
                 }
                 if (actual.getAsJsonPrimitive().isNumber()) {
                     return actual.getAsNumber().floatValue() >= expected.getAsNumber().floatValue();
@@ -289,7 +291,8 @@ class ConditionEvaluator implements IConditionEvaluator {
 
             case LT:
                 if (actual == null || DataType.NULL.equals(attributeDataType)) {
-                    return 0.0 < expected.getAsDouble();
+                    return (!expected.isJsonPrimitive() || expected.getAsJsonPrimitive().isNumber())
+                        && 0.0 < expected.getAsDouble();
                 }
                 if (actual.getAsString().toLowerCase().matches("\\d+")) {
                     return Double.parseDouble(actual.getAsString()) < expected.getAsDouble();
@@ -304,7 +307,8 @@ class ConditionEvaluator implements IConditionEvaluator {
 
             case LTE:
                 if (actual == null || DataType.NULL.equals(attributeDataType)) {
-                    return 0.0 <= expected.getAsDouble();
+                    return (!expected.isJsonPrimitive() || expected.getAsJsonPrimitive().isNumber())
+                        && 0.0 <= expected.getAsDouble();
                 }
                 if (actual.getAsJsonPrimitive().isNumber()) {
                     return actual.getAsNumber().floatValue() <= expected.getAsNumber().floatValue();

--- a/lib/src/main/java/growthbook/sdk/java/ConditionEvaluator.java
+++ b/lib/src/main/java/growthbook/sdk/java/ConditionEvaluator.java
@@ -225,6 +225,8 @@ class ConditionEvaluator implements IConditionEvaluator {
                     ArrayList<Boolean> conditionsList = jsonUtils.gson.fromJson(expected, listType);
                     return conditionsList.contains(value);
                 }
+                break;
+
 
             case NIN:
                 if (actual == null) return false;
@@ -258,45 +260,51 @@ class ConditionEvaluator implements IConditionEvaluator {
                     ArrayList<Boolean> conditionsList = jsonUtils.gson.fromJson(expected, listType);
                     return !conditionsList.contains(value);
                 }
+                break;
+
 
             case GT:
-                if (actual == null) return false;
+                if (actual == null || DataType.NULL.equals(attributeDataType)) return false;
                 if (actual.getAsJsonPrimitive().isNumber()) {
                     return actual.getAsNumber().floatValue() > expected.getAsNumber().floatValue();
                 }
                 if (actual.getAsJsonPrimitive().isString()) {
                     return actual.getAsString().compareTo(expected.getAsString()) > 0;
                 }
+                break;
 
             case GTE:
-                if (actual == null) return false;
+                if (actual == null || DataType.NULL.equals(attributeDataType)) return false;
                 if (actual.getAsJsonPrimitive().isNumber()) {
                     return actual.getAsNumber().floatValue() >= expected.getAsNumber().floatValue();
                 }
                 if (actual.getAsJsonPrimitive().isString()) {
                     return actual.getAsString().compareTo(expected.getAsString()) >= 0;
                 }
+                break;
 
             case LT:
-                if (actual == null) return false;
+                if (actual == null || DataType.NULL.equals(attributeDataType)) return false;
                 if (actual.getAsJsonPrimitive().isNumber()) {
                     return actual.getAsNumber().floatValue() < expected.getAsNumber().floatValue();
                 }
                 if (actual.getAsJsonPrimitive().isString()) {
                     return actual.getAsString().compareTo(expected.getAsString()) < 0;
                 }
+                break;
 
             case LTE:
-                if (actual == null) return false;
+                if (actual == null || DataType.NULL.equals(attributeDataType)) return false;
                 if (actual.getAsJsonPrimitive().isNumber()) {
                     return actual.getAsNumber().floatValue() <= expected.getAsNumber().floatValue();
                 }
                 if (actual.getAsJsonPrimitive().isString()) {
                     return actual.getAsString().compareTo(expected.getAsString()) <= 0;
                 }
+                break;
 
             case REGEX:
-                if (actual == null) return false;
+                if (actual == null || DataType.NULL.equals(attributeDataType)) return false;
                 Pattern pattern = Pattern.compile(expected.getAsString());
                 Matcher matcher = pattern.matcher(actual.getAsString());
 
@@ -309,11 +317,11 @@ class ConditionEvaluator implements IConditionEvaluator {
                 return matches;
 
             case NE:
-                if (actual == null) return false;
+                if (actual == null || DataType.NULL.equals(attributeDataType)) return false;
                 return !arePrimitivesEqual(actual.getAsJsonPrimitive(), expected.getAsJsonPrimitive(), attributeDataType);
 
             case EQ:
-                if (actual == null) return false;
+                if (actual == null || DataType.NULL.equals(attributeDataType)) return false;
                 return arePrimitivesEqual(actual.getAsJsonPrimitive(), expected.getAsJsonPrimitive(), attributeDataType);
 
             case SIZE:
@@ -341,6 +349,7 @@ class ConditionEvaluator implements IConditionEvaluator {
                     }
                     if (!passed) return false;
                 }
+                return true;
 
             case NOT:
                 return !evalConditionValue(expected, actual);
@@ -360,37 +369,37 @@ class ConditionEvaluator implements IConditionEvaluator {
                 }
 
             case VERSION_GT:
-                if (actual == null || expected == null) return false;
+                if (actual == null || expected == null || DataType.NULL.equals(attributeDataType)) return false;
 
                 return StringUtils.paddedVersionString(actual.getAsString())
                     .compareTo(StringUtils.paddedVersionString(expected.getAsString())) > 0;
 
             case VERSION_GTE:
-                if (actual == null || expected == null) return false;
+                if (actual == null || expected == null || DataType.NULL.equals(attributeDataType)) return false;
 
                 return StringUtils.paddedVersionString(actual.getAsString())
                     .compareTo(StringUtils.paddedVersionString(expected.getAsString())) >= 0;
 
             case VERSION_LT:
-                if (actual == null || expected == null) return false;
+                if (actual == null || expected == null || DataType.NULL.equals(attributeDataType)) return false;
 
                 return StringUtils.paddedVersionString(actual.getAsString())
                     .compareTo(StringUtils.paddedVersionString(expected.getAsString())) < 0;
 
             case VERSION_LTE:
-                if (actual == null || expected == null) return false;
+                if (actual == null || expected == null || DataType.NULL.equals(attributeDataType)) return false;
 
                 return StringUtils.paddedVersionString(actual.getAsString())
                     .compareTo(StringUtils.paddedVersionString(expected.getAsString())) <= 0;
 
             case VERSION_NE:
-                if (actual == null || expected == null) return false;
+                if (actual == null || expected == null || DataType.NULL.equals(attributeDataType)) return false;
 
                 return StringUtils.paddedVersionString(actual.getAsString())
                     .compareTo(StringUtils.paddedVersionString(expected.getAsString())) != 0;
 
             case VERSION_EQ:
-                if (actual == null || expected == null) return false;
+                if (actual == null || expected == null || DataType.NULL.equals(attributeDataType)) return false;
 
                 return StringUtils.paddedVersionString(actual.getAsString())
                     .compareTo(StringUtils.paddedVersionString(expected.getAsString())) == 0;
@@ -398,6 +407,7 @@ class ConditionEvaluator implements IConditionEvaluator {
             default:
                 return false;
         }
+        return false;
     }
 
     /**

--- a/lib/src/main/java/growthbook/sdk/java/ConditionEvaluator.java
+++ b/lib/src/main/java/growthbook/sdk/java/ConditionEvaluator.java
@@ -328,6 +328,7 @@ class ConditionEvaluator implements IConditionEvaluator {
                 return matches;
 
             case NE:
+                if (DataType.NULL.equals(attributeDataType)) return false;
                 return !Objects.equals(actual, expected);
 
             case EQ:

--- a/lib/src/test/java/growthbook/sdk/java/ConditionEvaluatorTest.java
+++ b/lib/src/test/java/growthbook/sdk/java/ConditionEvaluatorTest.java
@@ -4,6 +4,10 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import growthbook.sdk.java.testhelpers.TestCasesJsonHelper;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -13,6 +17,24 @@ import static org.junit.jupiter.api.Assertions.*;
 class ConditionEvaluatorTest {
 
     final TestCasesJsonHelper helper = TestCasesJsonHelper.getInstance();
+    final PrintStream originalErrorOutputStream = System.err;
+    final ByteArrayOutputStream errContent = new ByteArrayOutputStream();
+
+    static final String[] expectedExceptionStrings = {
+        "Expected BEGIN_ARRAY but was NUMBER at path $",
+        "java.util.regex.PatternSyntaxException: Dangling meta character '?' near index 3"
+    };
+
+    @BeforeEach
+    public void setUpErrorStream() {
+        System.setErr(new PrintStream(errContent));
+    }
+
+    @AfterEach
+    public void restoreErrorStreams() {
+        System.setErr(originalErrorOutputStream);
+    }
+
 
     @Test
     void test_evaluateCondition_returnsFalseIfWrongShape() {
@@ -36,31 +58,32 @@ class ConditionEvaluatorTest {
         JsonArray testCases = helper.evalConditionTestCases();
 
         for (int i = 0; i < testCases.size(); i++) {
+            resetErrorOutputStream();
             // Run only test at index i
-//            if (i == 71) {
-                JsonElement jsonElement = testCases.get(i);
-                JsonArray testCase = (JsonArray) jsonElement;
+            JsonElement jsonElement = testCases.get(i);
+            JsonArray testCase = (JsonArray) jsonElement;
+            String testDescription = testCase.get(0).getAsString();
 
-                String testDescription = testCase.get(0).getAsString();
+            // Get attributes and conditions as JSON objects then convert them to a JSON string
+            String condition = testCase.get(1).getAsJsonObject().toString();
+            String attributes = testCase.get(2).getAsJsonObject().toString();
+            boolean expected = testCase.get(3).getAsBoolean();
 
-                // Get attributes and conditions as JSON objects then convert them to a JSON string
-                String condition = testCase.get(1).getAsJsonObject().toString();
-                String attributes = testCase.get(2).getAsJsonObject().toString();
+            boolean evaluationResult = evaluator.evaluateCondition(attributes, condition);
 
-                boolean expected = testCase.get(3).getAsBoolean();
+            if (unexpectedExceptionOccurred(errContent.toString())) {
+                failingIndexes.add(i);
+                failedTests.add(String.format("Unexpected Exception: %s", testDescription));
+                continue;
+            }
 
-                if (expected == evaluator.evaluateCondition(attributes, condition)) {
-                    passedTests.add(testDescription);
-                } else {
-                    failingIndexes.add(i);
-                    failedTests.add(testDescription);
-                }
-
-//            }
-
+            if (expected == evaluationResult) {
+                passedTests.add(testDescription);
+            } else {
+                failingIndexes.add(i);
+                failedTests.add(testDescription);
+            }
         }
-
-//        System.out.printf("\n\nPassed tests: %s", passedTests);
         System.out.printf("\n\n\nFailed tests = %s / %s . Failing = %s", failedTests.size(), testCases.size(), failedTests);
         System.out.printf("\n\n\nFailing indexes = %s", failingIndexes);
 
@@ -145,5 +168,22 @@ class ConditionEvaluatorTest {
 
             assertEquals(paddedVersion.compareTo(paddedOther) > 0, equals);
         }
+    }
+
+    private boolean unexpectedExceptionOccurred(String stacktrace) {
+        if (stacktrace.isEmpty()) {
+            return false;
+        }
+        for (String expectedExceptionSubString : expectedExceptionStrings) {
+            if (stacktrace.contains(expectedExceptionSubString)) {
+                return false;
+            }
+        }
+        System.out.println(stacktrace.toString());
+        return true;
+    }
+
+    private void resetErrorOutputStream() {
+        errContent.reset();
     }
 }

--- a/lib/src/test/resources/test-cases.json
+++ b/lib/src/test/resources/test-cases.json
@@ -1953,7 +1953,7 @@
       "$nor - pass with null value for age",
       {"$nor": [{"name": "john"}, {"age": {"$lt": 30}}]},
       {"name": "jim", "age": null},
-      true
+      false
     ],
     [
       "$nor - fail both",

--- a/lib/src/test/resources/test-cases.json
+++ b/lib/src/test/resources/test-cases.json
@@ -1372,6 +1372,7 @@
     ["$in - pass", {"num": {"$in": [1, 2, 3]}}, {"num": 2}, true],
     ["$in - fail", {"num": {"$in": [1, 2, 3]}}, {"num": 4}, false],
     ["$in - not array", {"num": {"$in": 1}}, {"num": 1}, false],
+    ["$in - fail with null value", {"num": {"$in": [1, 2, 3]}}, {"num": null}, false],
     [
       "$in - array pass 1",
       {"tags": {"$in": ["a", "b"]}},
@@ -1400,6 +1401,7 @@
     ["$nin - pass", {"num": {"$nin": [1, 2, 3]}}, {"num": 4}, true],
     ["$nin - fail", {"num": {"$nin": [1, 2, 3]}}, {"num": 2}, false],
     ["$nin - not array", {"num": {"$nin": 1}}, {"num": 1}, false],
+    ["$nin - fail with null value", {"num": {"$in": [1, 2, 3]}}, {"num": null}, false],
     [
       "$nin - array fail 1",
       {"tags": {"$nin": ["a", "b"]}},
@@ -1432,9 +1434,21 @@
       true
     ],
     [
+      "$elemMatch - pass - flat arrays with null value",
+      {"nums": {"$elemMatch": {"$gt": 10}}},
+      {"nums": [0, null, -20, 15]},
+      true
+    ],
+    [
       "$elemMatch - fail - flat arrays",
       {"nums": {"$elemMatch": {"$gt": 10}}},
       {"nums": [0, 5, -20, 8]},
+      false
+    ],
+    [
+      "$elemMatch - fail - flat arrays with null value",
+      {"nums": {"$elemMatch": {"$gt": 10}}},
+      {"nums": [0, 5, -20, null]},
       false
     ],
     [
@@ -1444,8 +1458,11 @@
       false
     ],
     ["empty $or - pass", {"$or": []}, {"hello": "world"}, true],
+    ["empty $or - pass with null value", {"$or": []}, {"hello": null}, true],
     ["empty $and - pass", {"$and": []}, {"hello": "world"}, true],
+    ["empty $and - pass with null value", {"$and": []}, {"hello": null}, true],
     ["empty - pass", {}, {"hello": "world"}, true],
+    ["empty - pass with null value", {}, {"hello": null}, true],
     [
       "$eq - pass",
       {"occupation": {"$eq": "engineer"}},
@@ -1458,8 +1475,15 @@
       {"occupation": "civil engineer"},
       false
     ],
+    [
+      "$eq - fail with null value",
+      {"occupation": {"$eq": "engineer"}},
+      {"occupation": null},
+      false
+    ],
     ["$ne - pass", {"level": {"$ne": "senior"}}, {"level": "junior"}, true],
     ["$ne - fail", {"level": {"$ne": "senior"}}, {"level": "senior"}, false],
+    ["$ne - fail with null value", {"level": {"$ne": "senior"}}, {"level": null}, false],
     [
       "$regex - pass",
       {"userAgent": {"$regex": "(Mobile|Tablet)"}},
@@ -1473,6 +1497,12 @@
       false
     ],
     [
+      "$regex - fail with null value",
+      {"userAgent": {"$regex": "(Mobile|Tablet)"}},
+      {"userAgent": null},
+      false
+    ],
+    [
       "$gt/$lt numbers - pass",
       {"age": {"$gt": 30, "$lt": 60}},
       {"age": 50},
@@ -1482,6 +1512,12 @@
       "$gt/$lt numbers - fail $lt",
       {"age": {"$gt": 30, "$lt": 60}},
       {"age": 60},
+      false
+    ],
+    [
+      "$gt/$lt numbers - fail with null value",
+      {"age": {"$gt": 30, "$lt": 60}},
+      {"age": null},
       false
     ],
     [
@@ -1515,6 +1551,12 @@
       false
     ],
     [
+      "$gte/$lte numbers - fail with null value ",
+      {"age": {"$gte": 30, "$lte": 60}},
+      {"age": null},
+      false
+    ],
+    [
       "$gte/$lte numbers - fail $gte",
       {"age": {"$gt": 30, "$lt": 60}},
       {"age": 29},
@@ -1524,6 +1566,12 @@
       "$gt/$lt strings - fail $gt",
       {"word": {"$gt": "alphabet", "$lt": "zebra"}},
       {"word": "alphabet"},
+      false
+    ],
+    [
+      "$gt/$lt string - fail with null value",
+      {"word": {"$gt": "alphabet", "$lt": "zebra"}},
+      {"word": null},
       false
     ],
     [
@@ -1553,12 +1601,15 @@
     ],
     ["$type string - pass", {"a": {"$type": "string"}}, {"a": "a"}, true],
     ["$type string - fail", {"a": {"$type": "string"}}, {"a": 1}, false],
+    ["$type string - fail with null value", {"a": {"$type": "string"}}, {"a": null}, false],
     ["$type null - pass", {"a": {"$type": "null"}}, {"a": null}, true],
     ["$type null - fail", {"a": {"$type": "null"}}, {"a": 1}, false],
     ["$type boolean - pass", {"a": {"$type": "boolean"}}, {"a": false}, true],
     ["$type boolean - fail", {"a": {"$type": "boolean"}}, {"a": 1}, false],
+    ["$type boolean - fail with null value", {"a": {"$type": "boolean"}}, {"a": null}, false],
     ["$type number - pass", {"a": {"$type": "number"}}, {"a": 1}, true],
     ["$type number - fail", {"a": {"$type": "number"}}, {"a": "a"}, false],
+    ["$type number - fail with null value", {"a": {"$type": "number"}}, {"a": null}, false],
     [
       "$type object - pass",
       {"a": {"$type": "object"}},
@@ -1566,8 +1617,10 @@
       true
     ],
     ["$type object - fail", {"a": {"$type": "object"}}, {"a": 1}, false],
+    ["$type object - fail with null value", {"a": {"$type": "object"}}, {"a": null}, false],
     ["$type array - pass", {"a": {"$type": "array"}}, {"a": [1, 2]}, true],
     ["$type array - fail", {"a": {"$type": "array"}}, {"a": 1}, false],
+    ["$type array - fail with null value", {"a": {"$type": "array"}}, {"a": null}, false],
     [
       "unknown operator - pass",
       {"name": {"$regx": "hello"}},
@@ -1613,6 +1666,12 @@
       false
     ],
     [
+      "$size number - fail with null value",
+      {"tags": {"$size": 3}},
+      {"tags": null},
+      false
+    ],
+    [
       "$size nested - pass",
       {"tags": {"$size": {"$gt": 2}}},
       {"tags": [0, 1, 2]},
@@ -1622,6 +1681,12 @@
       "$size nested - fail equal",
       {"tags": {"$size": {"$gt": 2}}},
       {"tags": [0, 1]},
+      false
+    ],
+    [
+      "$size nested - fail with null value",
+      {"tags": {"$size": {"$gt": 2}}},
+      {"tags": null},
       false
     ],
     [
@@ -1642,6 +1707,13 @@
       {"tags": ["foo", "baz"]},
       false
     ],
+    [
+      "$elemMatch contains - false with null value",
+      {"tags": {"$elemMatch": {"$eq": "bar"}}},
+      {"tags": null},
+      false
+    ],
+
     [
       "$elemMatch intersection - pass",
       {"tags": {"$elemMatch": {"$in": ["a", "b"]}}},
@@ -1685,6 +1757,12 @@
       false
     ],
     [
+      "$elemMatch nested - fail with null value",
+      {"hobbies": {"$elemMatch": {"name": {"$regex": "^ping"}}}},
+      {"hobbies": [{"name": null}, {"name": null}]},
+      false
+    ],
+    [
       "$elemMatch nested - fail not array",
       {"hobbies": {"$elemMatch": {"name": {"$regex": "^ping"}}}},
       {"hobbies": "all"},
@@ -1694,6 +1772,12 @@
       "$not - pass",
       {"name": {"$not": {"$regex": "^hello"}}},
       {"name": "world"},
+      true
+    ],
+    [
+      "$not - pass with null value",
+      {"name": {"$not": {"$regex": "^hello"}}},
+      {"name": null},
       true
     ],
     [
@@ -1721,9 +1805,27 @@
       false
     ],
     [
+      "$all - fail null value",
+      {"tags": {"$all": ["one", "three"]}},
+      {"tags": null},
+      false
+    ],
+    [
       "$nor - pass",
       {"$nor": [{"name": "john"}, {"age": {"$lt": 30}}]},
       {"name": "jim", "age": 40},
+      true
+    ],
+    [
+      "$nor - pass with null value for name",
+      {"$nor": [{"name": "john"}, {"age": {"$lt": 30}}]},
+      {"name": null, "age": 40},
+      true
+    ],
+    [
+      "$nor - pass with null value for age",
+      {"$nor": [{"name": "john"}, {"age": {"$lt": 30}}]},
+      {"name": "jim", "age": null},
       true
     ],
     [
@@ -1763,6 +1865,12 @@
       false
     ],
     [
+      "equals array - fail with null value",
+      {"tags": ["hello", "world"]},
+      {"tags": null},
+      false
+    ],
+    [
       "equals array - fail extra item",
       {"tags": ["hello", "world"]},
       {"tags": ["hello", "world", "foo"]},
@@ -1784,6 +1892,12 @@
       "equals object - fail extra property",
       {"tags": {"hello": "world"}},
       {"tags": {"hello": "world", "yes": "please"}},
+      false
+    ],
+    [
+      "equals object - fail with extra property null",
+      {"tags": {"hello": "world"}},
+      {"tags": {"hello": "world", "yes": null}},
       false
     ],
     [
@@ -1823,6 +1937,12 @@
       {"version": {"$vgt": "9.99.8", "$vlt": "11.0.1"}},
       {"version": "10.12.13"},
       true
+    ],
+    [
+      "$vgt/$vlt - fail with null value",
+      {"version": {"$vgt": "9.99.8", "$vlt": "11.0.1"}},
+      {"version": null},
+      false
     ],
     [
       "$vgt/$vlt - pass - minor",
@@ -1957,6 +2077,7 @@
       false
     ],
     ["$veq - pass", {"v": {"$veq": "1.2.3"}}, {"v": "1.2.3"}, true],
+    ["$veq - fail with null value", {"v": {"$veq": "1.2.3"}}, {"v": null}, false],
     [
       "$veq - pass (with build)",
       {"v": {"$veq": "1.2.3"}},
@@ -1964,6 +2085,7 @@
       true
     ],
     ["$vne - pass", {"v": {"$vne": "1.2.3"}}, {"v": "2.2.3"}, true],
+    ["$vne - fail with null value", {"v": {"$vne": "1.2.3"}}, {"v": null}, false],
     [
       "$vne - pass (prerelease)",
       {"v": {"$vne": "1.2.3"}},


### PR DESCRIPTION
Hello,

this PR should reduce the amount of exceptions that the `ConditionEvaluator` would throw, if it receives incoming null values for the evaluation. 
There are some sections in the code that are not able to handle that properly. I received already the following exceptions (in the form of stack traces on the stderr) in one of my applications:

- **java.lang.IllegalStateException: Not a JSON Primitive: null**
- **java.lang.UnsupportedOperationException: JsonNull**

The SDK is catching all exceptions and additionally prints the stacktrace to the standard error output channel. Unfortunately this can also harm consumers of this library, because some applications might require a specific format of messages that get printed to the error or normal output channels. From my point of view i think it is really worth it to work on the issue (#23), but i think as well, that it is always good to handle errors properly.

I also adjusted the test to let them fail, if exceptions will occur that are not expected to appear under a specific test condition. I'm not really happy with the changes that i had to introduce in the tests, but i couldn't come up with a better solution, unfortunately the SDK is catching every error which makes it hard to check if a specific error occurred. 

I hope that you see value in this PR. 

All the best,
Norman