### PR TITLE
Add support for setting JSON Feature Object in GBContext builder

### DIFF
--- a/lib/src/main/java/growthbook/sdk/java/GBContext.java
+++ b/lib/src/main/java/growthbook/sdk/java/GBContext.java
@@ -94,7 +94,6 @@ public class GBContext {
      * Feature definitions - To be pulled from API / Cache
      */
     @Nullable
-    @Getter(AccessLevel.PACKAGE)
     private JsonObject features;
 
     private void setFeatures(@Nullable JsonObject features) {

--- a/lib/src/main/java/growthbook/sdk/java/GBContext.java
+++ b/lib/src/main/java/growthbook/sdk/java/GBContext.java
@@ -28,6 +28,7 @@ public class GBContext {
      * Alternatively, you can use this static method instead of the builder.
      *
      * @param attributesJson                   User attributes as JSON string
+     * @param featuresJson                     Features response as JSON string, or the encrypted payload. Encrypted payload requires `encryptionKey`
      * @param features                         Features response as JSON Object, either set this or `featuresJson`
      * @param encryptionKey                    Optional encryption key. If this is not null, featuresJson should be an encrypted payload.
      * @param enabled                          Whether globally all experiments are enabled (default: true)

--- a/lib/src/main/java/growthbook/sdk/java/GBContext.java
+++ b/lib/src/main/java/growthbook/sdk/java/GBContext.java
@@ -63,7 +63,7 @@ public class GBContext {
         this.attributesJson = attributesJson == null ? "{}" : attributesJson;
 
         if (featuresJson != null) {
-            this.features = convertStringToJsonObject(featuresJson, encryptionKey);
+            this.features = transformEncryptedFeatures(featuresJson, encryptionKey);
         }
         if (features != null) {
             this.features = features;
@@ -221,7 +221,17 @@ public class GBContext {
         }
     }
 
-    public static JsonObject convertStringToJsonObject(
+    @Nullable
+    public static JsonObject transformFeatures(String featuresJsonString) {
+        try {
+            return GrowthBookJsonUtils.getInstance().gson.fromJson(featuresJsonString, JsonObject.class);
+        } catch (Exception e) {
+            log.error(e.getMessage(), e);
+            return null;
+        }
+    }
+
+    public static JsonObject transformEncryptedFeatures(
             @Nullable String featuresJson,
             @Nullable String encryptionKey
     ) {
@@ -244,16 +254,6 @@ public class GBContext {
         }
 
         return jsonObject;
-    }
-
-    @Nullable
-    public static JsonObject transformFeatures(String featuresJsonString) {
-        try {
-            return GrowthBookJsonUtils.getInstance().gson.fromJson(featuresJsonString, JsonObject.class);
-        } catch (Exception e) {
-            log.error(e.getMessage(), e);
-            return null;
-        }
     }
 
     private static JsonObject transformAttributes(@Nullable String attributesJsonString) {

--- a/lib/src/main/java/growthbook/sdk/java/GBContext.java
+++ b/lib/src/main/java/growthbook/sdk/java/GBContext.java
@@ -263,7 +263,7 @@ public class GBContext {
         }
     }
 
-    private static JsonObject convertStringToJsonObject(
+    public static JsonObject convertStringToJsonObject(
             @Nullable String featuresJson,
             @Nullable String encryptionKey
     ) {

--- a/lib/src/main/java/growthbook/sdk/java/GBContext.java
+++ b/lib/src/main/java/growthbook/sdk/java/GBContext.java
@@ -29,6 +29,7 @@ public class GBContext {
      *
      * @param attributesJson                   User attributes as JSON string
      * @param featuresJson                     Features response as JSON string, or the encrypted payload. Encrypted payload requires `encryptionKey`
+     * @param features                         Features response as JSON Object, either set this or `featuresJson`
      * @param encryptionKey                    Optional encryption key. If this is not null, featuresJson should be an encrypted payload.
      * @param enabled                          Whether globally all experiments are enabled (default: true)
      * @param isQaMode                         If true, random assignment is disabled and only explicitly forced variations are used.
@@ -46,6 +47,7 @@ public class GBContext {
     public GBContext(
             @Nullable String attributesJson,
             @Nullable String featuresJson,
+            @Nullable JsonObject features,
             @Nullable String encryptionKey,
             @Nullable Boolean enabled,
             Boolean isQaMode,
@@ -64,7 +66,9 @@ public class GBContext {
 
         // Features start as empty JSON
         this.featuresJson = "{}";
-        if (encryptionKey != null && featuresJson != null) {
+        if (features != null) {
+            this.features = features;
+        } else if (encryptionKey != null && featuresJson != null) {
             // Attempt to decrypt payload
             try {
                 String decrypted = DecryptionUtils.decrypt(featuresJson, encryptionKey);

--- a/lib/src/main/java/growthbook/sdk/java/GBContext.java
+++ b/lib/src/main/java/growthbook/sdk/java/GBContext.java
@@ -289,7 +289,7 @@ public class GBContext {
     }
 
     @Nullable
-    private static JsonObject transformFeatures(String featuresJsonString) {
+    public static JsonObject transformFeatures(String featuresJsonString) {
         try {
             return GrowthBookJsonUtils.getInstance().gson.fromJson(featuresJsonString, JsonObject.class);
         } catch (Exception e) {

--- a/lib/src/main/java/growthbook/sdk/java/GBContext.java
+++ b/lib/src/main/java/growthbook/sdk/java/GBContext.java
@@ -96,10 +96,6 @@ public class GBContext {
     @Nullable
     private JsonObject features;
 
-    private void setFeatures(@Nullable JsonObject features) {
-        this.features = features;
-    }
-
     /**
      * Switch to globally disable all experiments. Default true.
      */

--- a/lib/src/main/java/growthbook/sdk/java/GBContext.java
+++ b/lib/src/main/java/growthbook/sdk/java/GBContext.java
@@ -235,8 +235,9 @@ public class GBContext {
         @Override
         public GBContext build() {
             GBContext context = super.build();
-
-            if (context.featuresJson != null) {
+            if (context.features != null) {
+                context.setFeatures(context.features);
+            } else if (context.featuresJson != null) {
                 context.setFeatures(GBContext.transformFeatures(context.featuresJson));
             }
 

--- a/lib/src/main/java/growthbook/sdk/java/GBContext.java
+++ b/lib/src/main/java/growthbook/sdk/java/GBContext.java
@@ -28,49 +28,6 @@ public class GBContext {
      * Alternatively, you can use this static method instead of the builder.
      *
      * @param attributesJson                   User attributes as JSON string
-     * @param featuresJson                     Features response as JSON string, or the encrypted payload. Encrypted payload requires `encryptionKey`
-     * @param encryptionKey                    Optional encryption key. If this is not null, featuresJson should be an encrypted payload.
-     * @param enabled                          Whether globally all experiments are enabled (default: true)
-     * @param isQaMode                         If true, random assignment is disabled and only explicitly forced variations are used.
-     * @param url                              A URL string that is used for experiment evaluation, as well as forcing feature values.
-     * @param allowUrlOverrides                Boolean flag to allow URL overrides (default: false)
-     * @param forcedVariationsMap              Force specific experiments to always assign a specific variation (used for QA)
-     * @param trackingCallback                 A function that takes {@link Experiment} and {@link ExperimentResult} as arguments.
-     * @param featureUsageCallback             A function that takes {@link String} and {@link FeatureResult} as arguments.
-     *                                         A callback that will be invoked every time a feature is viewed. Listen for feature usage events
-     * @param stickyBucketService              Service that provide functionality of Sticky Bucketing.
-     * @param stickyBucketAssignmentDocs       Map of Sticky Bucket documents.
-     * @param stickyBucketIdentifierAttributes List of user's attributes keys.
-     */
-    @Builder
-    public GBContext(
-            @Nullable String attributesJson,
-            @Nullable String featuresJson,
-            @Nullable String encryptionKey,
-            @Nullable Boolean enabled,
-            Boolean isQaMode,
-            @Nullable String url,
-            Boolean allowUrlOverrides,
-            @Nullable Map<String, Integer> forcedVariationsMap,
-            @Nullable TrackingCallback trackingCallback,
-            @Nullable FeatureUsageCallback featureUsageCallback,
-            @Nullable StickyBucketService stickyBucketService,
-            @Nullable Map<String, StickyAssignmentsDocument> stickyBucketAssignmentDocs,
-            @Nullable List<String> stickyBucketIdentifierAttributes
-    ) {
-        this(
-                attributesJson, convertStringToJsonObject(featuresJson, encryptionKey),
-                encryptionKey, enabled, isQaMode, url, allowUrlOverrides, forcedVariationsMap,
-                trackingCallback, featureUsageCallback, stickyBucketService,
-                stickyBucketAssignmentDocs,stickyBucketIdentifierAttributes
-        );
-    }
-
-    /**
-     * The {@link GBContextBuilder} is recommended for constructing a Context.
-     * Alternatively, you can use this static method instead of the builder.
-     *
-     * @param attributesJson                   User attributes as JSON string
      * @param features                         Features response as JSON Object, either set this or `featuresJson`
      * @param encryptionKey                    Optional encryption key. If this is not null, featuresJson should be an encrypted payload.
      * @param enabled                          Whether globally all experiments are enabled (default: true)
@@ -88,6 +45,7 @@ public class GBContext {
     @Builder
     public GBContext(
             @Nullable String attributesJson,
+            @Nullable String featuresJson,
             @Nullable JsonObject features,
             @Nullable String encryptionKey,
             @Nullable Boolean enabled,
@@ -102,13 +60,13 @@ public class GBContext {
             @Nullable List<String> stickyBucketIdentifierAttributes
     ) {
         this.encryptionKey = encryptionKey;
-
         this.attributesJson = attributesJson == null ? "{}" : attributesJson;
 
+        if (featuresJson != null) {
+            this.features = convertStringToJsonObject(featuresJson, encryptionKey);
+        }
         if (features != null) {
             this.features = features;
-        } else {
-            this.features = new JsonObject();
         }
 
         this.enabled = enabled == null ? true : enabled;

--- a/lib/src/test/java/growthbook/sdk/java/GBContextTest.java
+++ b/lib/src/test/java/growthbook/sdk/java/GBContextTest.java
@@ -46,6 +46,7 @@ class GBContextTest {
                 sampleUserAttributes,
                 featuresJson,
                 null,
+                null,
                 isEnabled,
                 isQaMode,
                 url,
@@ -125,6 +126,7 @@ class GBContextTest {
         GBContext subject = new GBContext(
                 sampleUserAttributes,
                 encryptedFeaturesJson,
+                null,
                 encryptionKey,
                 isEnabled,
                 isQaMode,

--- a/lib/src/test/java/growthbook/sdk/java/GBContextTest.java
+++ b/lib/src/test/java/growthbook/sdk/java/GBContextTest.java
@@ -46,7 +46,6 @@ class GBContextTest {
                 sampleUserAttributes,
                 featuresJson,
                 null,
-                null,
                 isEnabled,
                 isQaMode,
                 url,
@@ -126,7 +125,6 @@ class GBContextTest {
         GBContext subject = new GBContext(
                 sampleUserAttributes,
                 encryptedFeaturesJson,
-                null,
                 encryptionKey,
                 isEnabled,
                 isQaMode,
@@ -142,7 +140,7 @@ class GBContextTest {
         String expectedFeaturesJson = "{\"greeting\":{\"defaultValue\":\"hello\",\"rules\":[{\"condition\":{\"country\":\"france\"},\"force\":\"bonjour\"},{\"condition\":{\"country\":\"mexico\"},\"force\":\"hola\"}]}}";
 
         assertNotNull(subject);
-        assertEquals(expectedFeaturesJson.trim(), subject.getFeaturesJson().trim());
+        assertEquals(expectedFeaturesJson.trim(), subject.getFeatures().toString().trim());
     }
 
     @Test
@@ -173,8 +171,8 @@ class GBContextTest {
         String expectedFeaturesJson = "{\"greeting\":{\"defaultValue\":\"hello\",\"rules\":[{\"condition\":{\"country\":\"france\"},\"force\":\"bonjour\"},{\"condition\":{\"country\":\"mexico\"},\"force\":\"hola\"}]}}";
 
         assertNotNull(subject);
-        assert subject.getFeaturesJson() != null;
-        assertEquals(expectedFeaturesJson.trim(), subject.getFeaturesJson().trim());
+        assert subject.getFeatures() != null;
+        assertEquals(expectedFeaturesJson.trim(), subject.getFeatures().toString().trim());
     }
 
     @Test
@@ -189,7 +187,7 @@ class GBContextTest {
                 .encryptionKey(encryptionKey)
                 .build();
 
-        assertEquals("{}", subject.getFeaturesJson());
+        assertEquals("{}", subject.getFeatures().toString());
     }
 
     @Test
@@ -204,6 +202,6 @@ class GBContextTest {
                 .encryptionKey(encryptionKey)
                 .build();
 
-        assertEquals("{}", subject.getFeaturesJson());
+        assertEquals("{}", subject.getFeatures().toString());
     }
 }


### PR DESCRIPTION
The current GBContext implementation is suboptimal for java backend integrations.
We have to create a new GBContext for each request, and because the CustomGbContextBuilder only supports StringType featureJson, we have to pass featureJson as string and it parses the JSON (converting from String to JSONType) for each and every request.
This can be avoided by letting the application maintain JSON and set JSON directly.

Flame graph with the current GBContext:

![Screenshot 2024-06-25 at 1 53 59 PM](https://github.com/growthbook/growthbook-sdk-java/assets/11795117/0deb347d-fa1b-450d-9ab1-6d81f4bdae6e)




As we can see, around 42% of total CPU is spent inside parsing this JSON for each and every request, this overhead can be clearly avoided by letting the client set the JSON directly instead of string.

After the fix:
![Screenshot 2024-06-25 at 8 41 37 PM](https://github.com/growthbook/growthbook-sdk-java/assets/11795117/1a3460d2-39f0-46a4-ac7c-d73cb75885f9)

The stack frames for transformFeatures went away. 
