### PR TITLE
Optimize Json Conversion in ConditionEvaluator and Update GBContext to Accept JsonObject for attributes

### DIFF
--- a/lib/src/main/java/growthbook/sdk/java/ConditionEvaluator.java
+++ b/lib/src/main/java/growthbook/sdk/java/ConditionEvaluator.java
@@ -36,12 +36,6 @@ class ConditionEvaluator implements IConditionEvaluator {
     @Override
     public Boolean evaluateCondition(JsonObject attributesJson, JsonObject conditionJson) {
         try {
-            //System.out.println("AttributesJsonString = " + attributesJsonString);
-            //System.out.println("ConditionJsonString = " + conditionJsonString);
-            //JsonElement attributesJson = jsonUtils.gson.fromJson(attributesJsonString, JsonElement.class);
-            //System.out.println(attributesJson.getClass());
-//            JsonObject conditionJson = jsonUtils.gson.fromJson(conditionElement, JsonObject.class);
-
             // Loop through the conditionObj key/value pairs
             for (Map.Entry<String, JsonElement> entry : conditionJson.entrySet()) {
                 String key = entry.getKey();

--- a/lib/src/main/java/growthbook/sdk/java/ConditionEvaluator.java
+++ b/lib/src/main/java/growthbook/sdk/java/ConditionEvaluator.java
@@ -30,7 +30,7 @@ class ConditionEvaluator implements IConditionEvaluator {
      * This is defined in the Feature's targeting conditions' Advanced settings.
      *
      * @param attributesJson A JsonObject of the user attributes to evaluate
-     * @param conditionJson  A JsonObject string of the condition
+     * @param conditionJson  A JsonObject of the condition
      * @return Whether the condition should be true for the user
      */
     @Override

--- a/lib/src/main/java/growthbook/sdk/java/ConditionEvaluator.java
+++ b/lib/src/main/java/growthbook/sdk/java/ConditionEvaluator.java
@@ -29,15 +29,18 @@ class ConditionEvaluator implements IConditionEvaluator {
      * The condition syntax closely resembles MongoDB's syntax.
      * This is defined in the Feature's targeting conditions' Advanced settings.
      *
-     * @param attributesJsonString A JSON string of the user attributes to evaluate
-     * @param conditionJsonString  A JSON string of the condition
+     * @param attributesJson A JsonObject of the user attributes to evaluate
+     * @param conditionJson  A JsonObject string of the condition
      * @return Whether the condition should be true for the user
      */
     @Override
-    public Boolean evaluateCondition(String attributesJsonString, String conditionJsonString) {
+    public Boolean evaluateCondition(JsonObject attributesJson, JsonObject conditionJson) {
         try {
-            JsonElement attributesJson = jsonUtils.gson.fromJson(attributesJsonString, JsonElement.class);
-            JsonObject conditionJson = jsonUtils.gson.fromJson(conditionJsonString, JsonObject.class);
+            //System.out.println("AttributesJsonString = " + attributesJsonString);
+            //System.out.println("ConditionJsonString = " + conditionJsonString);
+            //JsonElement attributesJson = jsonUtils.gson.fromJson(attributesJsonString, JsonElement.class);
+            //System.out.println(attributesJson.getClass());
+//            JsonObject conditionJson = jsonUtils.gson.fromJson(conditionElement, JsonObject.class);
 
             // Loop through the conditionObj key/value pairs
             for (Map.Entry<String, JsonElement> entry : conditionJson.entrySet()) {
@@ -75,7 +78,7 @@ class ConditionEvaluator implements IConditionEvaluator {
                     case "$not":
                         // If conditionObj has a key $not, return !evalCondition(attributes, condition["$not"])
                         if (value != null) {
-                            if (evaluateCondition(attributesJsonString, value.toString())) {
+                            if (evaluateCondition(attributesJson, value.getAsJsonObject())) {
                                 return false;
                             }
                         }
@@ -559,7 +562,7 @@ class ConditionEvaluator implements IConditionEvaluator {
                     return true;
                 }
             }
-            else if (evaluateCondition(actualElement.toString(), expected.toString())) {
+            else if (evaluateCondition(actualElement.getAsJsonObject(), expected.getAsJsonObject())) {
                 return true;
             }
         }
@@ -579,8 +582,8 @@ class ConditionEvaluator implements IConditionEvaluator {
         }
 
         for (JsonElement condition : conditions) {
-            String attributesString = attributes == null ? "{}" : attributes.toString();
-            Boolean matches = evaluateCondition(attributesString, condition.toString());
+            JsonObject attributesObj = (null == attributes) ? new JsonObject() : attributes.getAsJsonObject();
+            Boolean matches = evaluateCondition(attributesObj, condition.getAsJsonObject());
 
             if (matches) {
                 return true;
@@ -597,8 +600,8 @@ class ConditionEvaluator implements IConditionEvaluator {
      */
     Boolean evalAnd(JsonElement attributes, JsonArray conditions) {
         for (JsonElement condition : conditions) {
-            String attributesString = attributes == null ? "{}" : attributes.toString();
-            Boolean matches = evaluateCondition(attributesString, condition.toString());
+            JsonObject attributesObj = (null == attributes) ? new JsonObject() : attributes.getAsJsonObject();
+            Boolean matches = evaluateCondition(attributesObj, condition.getAsJsonObject());
 
             if (!matches) {
                 return false;

--- a/lib/src/main/java/growthbook/sdk/java/Experiment.java
+++ b/lib/src/main/java/growthbook/sdk/java/Experiment.java
@@ -1,6 +1,7 @@
 package growthbook.sdk.java;
 
 import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 import com.google.gson.annotations.SerializedName;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -48,7 +49,7 @@ public class Experiment<ValueType> {
     /**
      * Optional targeting condition
      */
-    JsonElement conditionJson;
+    JsonObject conditionJson;
 
     /**
      * Each item defines a prerequisite where a `condition` must evaluate against

--- a/lib/src/main/java/growthbook/sdk/java/ExperimentEvaluator.java
+++ b/lib/src/main/java/growthbook/sdk/java/ExperimentEvaluator.java
@@ -142,10 +142,11 @@ class ExperimentEvaluator implements IExperimentEvaluator {
             }
 
             // Evaluate the condition JSON
-            JsonElement jsonStringCondition = experiment.getConditionJson();
-            if (jsonStringCondition != null) {
+            // can it be instead JsonObject
+            JsonObject conditionJson = experiment.getConditionJson();
+            if (conditionJson != null) {
                 String attributesJson = jsonUtils.gson.toJson(attributes);
-                Boolean shouldEvaluate = conditionEvaluator.evaluateCondition(attributesJson, jsonStringCondition.toString());
+                Boolean shouldEvaluate = conditionEvaluator.evaluateCondition(attributes, conditionJson);
 
                 // If experiment.condition is set and the condition evaluates to false,
                 // return immediately (not in experiment, variationId 0)
@@ -178,11 +179,11 @@ class ExperimentEvaluator implements IExperimentEvaluator {
                     if (parentResult.getValue() != null) {
                         evalObj.put("value", parentResult.getValue());
                     }
-                    String attributesJson = GrowthBookJsonUtils.getInstance().gson.toJson(evalObj);
+                    JsonObject attributesJson = GrowthBookJsonUtils.getInstance().gson.toJsonTree(evalObj).getAsJsonObject();
 
                     boolean evalCondition = conditionEvaluator.evaluateCondition(
                             attributesJson,
-                            parentCondition.getCondition().toString()
+                            parentCondition.getCondition()
                     );
 
                     // blocking prerequisite eval failed: feature evaluation fails

--- a/lib/src/main/java/growthbook/sdk/java/ExperimentEvaluator.java
+++ b/lib/src/main/java/growthbook/sdk/java/ExperimentEvaluator.java
@@ -145,7 +145,6 @@ class ExperimentEvaluator implements IExperimentEvaluator {
             // can it be instead JsonObject
             JsonObject conditionJson = experiment.getConditionJson();
             if (conditionJson != null) {
-                String attributesJson = jsonUtils.gson.toJson(attributes);
                 Boolean shouldEvaluate = conditionEvaluator.evaluateCondition(attributes, conditionJson);
 
                 // If experiment.condition is set and the condition evaluates to false,

--- a/lib/src/main/java/growthbook/sdk/java/FeatureEvaluator.java
+++ b/lib/src/main/java/growthbook/sdk/java/FeatureEvaluator.java
@@ -180,11 +180,11 @@ class FeatureEvaluator implements IFeatureEvaluator {
                         if (parentResult.getValue() != null) {
                             evalObj.put("value", parentResult.getValue());
                         }
-                        String attributesJsonString = GrowthBookJsonUtils.getInstance().gson.toJson(evalObj);
+                        JsonObject parentAttributesJson = GrowthBookJsonUtils.getInstance().gson.toJsonTree(evalObj).getAsJsonObject();
 
                         boolean evalCondition = conditionEvaluator.evaluateCondition(
-                                attributesJsonString,
-                                String.valueOf(parentCondition.getCondition())
+                                parentAttributesJson,
+                                parentCondition.getCondition()
                         );
 
                         // blocking prerequisite eval failed: feature evaluation fails
@@ -224,7 +224,7 @@ class FeatureEvaluator implements IFeatureEvaluator {
 
                     // If the rule has a condition, and it evaluates to false, skip this rule and continue to the next one
                     if (rule.getCondition() != null) {
-                        if (!conditionEvaluator.evaluateCondition(attributesJson, rule.getCondition().toString())) {
+                        if (!conditionEvaluator.evaluateCondition(attributes, rule.getCondition())) {
 
                             // Skip rule because of condition
                             continue;

--- a/lib/src/main/java/growthbook/sdk/java/FeatureRule.java
+++ b/lib/src/main/java/growthbook/sdk/java/FeatureRule.java
@@ -1,6 +1,7 @@
 package growthbook.sdk.java;
 
 import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 import com.google.gson.annotations.SerializedName;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -82,7 +83,7 @@ public class FeatureRule<ValueType> {
      * Optional targeting condition
      */
     @Nullable
-    JsonElement condition;
+    JsonObject condition;
 
     /**
      * Each item defines a prerequisite where a `condition` must evaluate against

--- a/lib/src/main/java/growthbook/sdk/java/GBContext.java
+++ b/lib/src/main/java/growthbook/sdk/java/GBContext.java
@@ -28,6 +28,7 @@ public class GBContext {
      * Alternatively, you can use this static method instead of the builder.
      *
      * @param attributesJson                   User attributes as JSON string
+     * @param attributes                       User attributes as JSON Object, either set this or `attributesJson`
      * @param featuresJson                     Features response as JSON string, or the encrypted payload. Encrypted payload requires `encryptionKey`
      * @param features                         Features response as JSON Object, either set this or `featuresJson`
      * @param encryptionKey                    Optional encryption key. If this is not null, featuresJson should be an encrypted payload.
@@ -46,6 +47,7 @@ public class GBContext {
     @Builder
     public GBContext(
             @Nullable String attributesJson,
+            @Nullable JsonObject attributes,
             @Nullable String featuresJson,
             @Nullable JsonObject features,
             @Nullable String encryptionKey,
@@ -62,6 +64,7 @@ public class GBContext {
     ) {
         this.encryptionKey = encryptionKey;
         this.attributesJson = attributesJson == null ? "{}" : attributesJson;
+        this.attributes = attributes == null ? new JsonObject() : attributes;
 
         if (featuresJson != null) {
             this.features = transformEncryptedFeatures(featuresJson, encryptionKey);
@@ -148,11 +151,15 @@ public class GBContext {
      * Map of user attributes that are used to assign variations
      */
     @Nullable
-    @Getter(AccessLevel.PACKAGE)
     private JsonObject attributes;
 
-    private void setAttributes(@Nullable JsonObject attributes) {
-        this.attributes = attributes;
+    /**
+     * You can update the attributes with new user attributes to evaluate against.
+     *
+     * @param attributes updated user attributes
+     */
+    public void setAttributes(@Nullable JsonObject attributes) {
+        this.attributes = (attributes == null) ? new JsonObject() : attributes;
     }
 
     /**

--- a/lib/src/main/java/growthbook/sdk/java/GrowthBook.java
+++ b/lib/src/main/java/growthbook/sdk/java/GrowthBook.java
@@ -213,9 +213,14 @@ public class GrowthBook implements IGrowthBook {
 
     @Override
     public Boolean evaluateCondition(String attributesJsonString, String conditionJsonString) {
-        JsonObject attributesJson = jsonUtils.gson.fromJson(attributesJsonString, JsonObject.class);
-        JsonObject conditionJson = jsonUtils.gson.fromJson(conditionJsonString, JsonObject.class);
-        return conditionEvaluator.evaluateCondition(attributesJson, conditionJson);
+        try {
+            JsonObject attributesJson = jsonUtils.gson.fromJson(attributesJsonString, JsonObject.class);
+            JsonObject conditionJson = jsonUtils.gson.fromJson(conditionJsonString, JsonObject.class);
+            return conditionEvaluator.evaluateCondition(attributesJson, conditionJson);
+        } catch (Exception e) {
+            log.error(e.getMessage(), e);
+            return false;
+        }
     }
 
     @Override

--- a/lib/src/main/java/growthbook/sdk/java/GrowthBook.java
+++ b/lib/src/main/java/growthbook/sdk/java/GrowthBook.java
@@ -213,7 +213,9 @@ public class GrowthBook implements IGrowthBook {
 
     @Override
     public Boolean evaluateCondition(String attributesJsonString, String conditionJsonString) {
-        return conditionEvaluator.evaluateCondition(attributesJsonString, conditionJsonString);
+        JsonObject attributesJson = jsonUtils.gson.fromJson(attributesJsonString, JsonObject.class);
+        JsonObject conditionJson = jsonUtils.gson.fromJson(conditionJsonString, JsonObject.class);
+        return conditionEvaluator.evaluateCondition(attributesJson, conditionJson);
     }
 
     @Override

--- a/lib/src/main/java/growthbook/sdk/java/IConditionEvaluator.java
+++ b/lib/src/main/java/growthbook/sdk/java/IConditionEvaluator.java
@@ -1,5 +1,7 @@
 package growthbook.sdk.java;
 
+import com.google.gson.JsonObject;
+
 interface IConditionEvaluator {
-    Boolean evaluateCondition(String attributesJsonString, String conditionJsonString);
+    Boolean evaluateCondition(JsonObject attributesJson, JsonObject conditionJson);
 }

--- a/lib/src/test/java/growthbook/sdk/java/ConditionEvaluatorTest.java
+++ b/lib/src/test/java/growthbook/sdk/java/ConditionEvaluatorTest.java
@@ -45,7 +45,9 @@ class ConditionEvaluatorTest {
         String attributes = "{\"name\": \"world\"}";
         String condition = "[\"$not\": { \"name\": \"hello\" }]";
 
-        assertFalse(evaluator.evaluateCondition(attributes, condition));
+        JsonObject attributesJson = GrowthBookJsonUtils.getInstance().gson.fromJson(attributes, JsonObject.class);
+        JsonObject conditionJson = GrowthBookJsonUtils.getInstance().gson.fromJson(condition, JsonObject.class);
+        assertFalse(evaluator.evaluateCondition(attributesJson, conditionJson));
     }
 
     @Test
@@ -71,7 +73,10 @@ class ConditionEvaluatorTest {
             String attributes = testCase.get(2).getAsJsonObject().toString();
             boolean expected = testCase.get(3).getAsBoolean();
 
-            boolean evaluationResult = evaluator.evaluateCondition(attributes, condition);
+            JsonObject attributesJson = GrowthBookJsonUtils.getInstance().gson.fromJson(attributes, JsonObject.class);
+            JsonObject conditionJson = GrowthBookJsonUtils.getInstance().gson.fromJson(condition, JsonObject.class);
+
+            boolean evaluationResult = evaluator.evaluateCondition(attributesJson, conditionJson);
 
             if (unexpectedExceptionOccurred(errContent.toString())) {
                 failingIndexes.add(i);

--- a/lib/src/test/java/growthbook/sdk/java/ConditionEvaluatorTest.java
+++ b/lib/src/test/java/growthbook/sdk/java/ConditionEvaluatorTest.java
@@ -40,14 +40,14 @@ class ConditionEvaluatorTest {
 
     @Test
     void test_evaluateCondition_returnsFalseIfWrongShape() {
-        ConditionEvaluator evaluator = new ConditionEvaluator();
-
-        String attributes = "{\"name\": \"world\"}";
-        String condition = "[\"$not\": { \"name\": \"hello\" }]";
-
-        JsonObject attributesJson = GrowthBookJsonUtils.getInstance().gson.fromJson(attributes, JsonObject.class);
-        JsonObject conditionJson = GrowthBookJsonUtils.getInstance().gson.fromJson(condition, JsonObject.class);
-        assertFalse(evaluator.evaluateCondition(attributesJson, conditionJson));
+//        ConditionEvaluator evaluator = new ConditionEvaluator();
+//
+//        String attributes = "{\"name\": \"world\"}";
+//        String condition = "[\"$not\": { \"name\": \"hello\" }]";
+//
+//        JsonObject attributesJson = GrowthBookJsonUtils.getInstance().gson.fromJson(attributes, JsonObject.class);
+//        JsonObject conditionJson = GrowthBookJsonUtils.getInstance().gson.fromJson(condition, JsonObject.class);
+//        assertFalse(evaluator.evaluateCondition(attributesJson, conditionJson));
     }
 
     @Test

--- a/lib/src/test/java/growthbook/sdk/java/ConditionEvaluatorTest.java
+++ b/lib/src/test/java/growthbook/sdk/java/ConditionEvaluatorTest.java
@@ -37,19 +37,6 @@ class ConditionEvaluatorTest {
         System.setErr(originalErrorOutputStream);
     }
 
-
-    @Test
-    void test_evaluateCondition_returnsFalseIfWrongShape() {
-//        ConditionEvaluator evaluator = new ConditionEvaluator();
-//
-//        String attributes = "{\"name\": \"world\"}";
-//        String condition = "[\"$not\": { \"name\": \"hello\" }]";
-//
-//        JsonObject attributesJson = GrowthBookJsonUtils.getInstance().gson.fromJson(attributes, JsonObject.class);
-//        JsonObject conditionJson = GrowthBookJsonUtils.getInstance().gson.fromJson(condition, JsonObject.class);
-//        assertFalse(evaluator.evaluateCondition(attributesJson, conditionJson));
-    }
-
     @Test
     void test_evaluateCondition_testCases() {
         ArrayList<String> passedTests = new ArrayList<>();

--- a/lib/src/test/java/growthbook/sdk/java/GBContextTest.java
+++ b/lib/src/test/java/growthbook/sdk/java/GBContextTest.java
@@ -44,6 +44,7 @@ class GBContextTest {
 
         GBContext subject = new GBContext(
                 sampleUserAttributes,
+                null,
                 featuresJson,
                 null,
                 null,
@@ -125,6 +126,7 @@ class GBContextTest {
 
         GBContext subject = new GBContext(
                 sampleUserAttributes,
+                null,
                 encryptedFeaturesJson,
                 null,
                 encryptionKey,

--- a/lib/src/test/java/growthbook/sdk/java/GrowthBookTest.java
+++ b/lib/src/test/java/growthbook/sdk/java/GrowthBookTest.java
@@ -519,6 +519,15 @@ class GrowthBookTest {
     }
 
     @Test
+    void test_evaluateCondition_returnsFalseIfWrongShape() {
+        String attributes = "{\"name\": \"world\"}";
+        String condition = "[\"$not\": { \"name\": \"hello\" }]";
+
+        GrowthBook growthBook = new GrowthBook();
+        assertFalse(growthBook.evaluateCondition(attributes, condition));
+    }
+
+    @Test
     void test_destroyClearsCallbacks() {
         GrowthBook subject = new GrowthBook();
         ExperimentRunCallback mockCallback1 = mock(ExperimentRunCallback.class);

--- a/lib/src/test/java/growthbook/sdk/java/GrowthBookTest.java
+++ b/lib/src/test/java/growthbook/sdk/java/GrowthBookTest.java
@@ -246,7 +246,7 @@ class GrowthBookTest {
                 if (experimentElement != null) {
 //                System.out.printf("\n\n HERE: Experiment %s (index = %s)", experiment, i);
                     JsonObject experimentObject = jsonUtils.gson.fromJson(experimentElement.getAsJsonObject(), JsonObject.class);
-                    JsonElement conditionElement = experimentObject.get("condition");
+                    JsonObject conditionElement = experimentObject.getAsJsonObject("condition");
                     if (conditionElement != null) {
                         experiment.setConditionJson(conditionElement);
                     }
@@ -504,14 +504,18 @@ class GrowthBookTest {
         FeatureEvaluator mockFeatureEvaluator = mock(FeatureEvaluator.class);
         GBContext context = GBContext.builder().build();
 
-        String attrJson = "{ id: 1 }";
-        String conditionJson = "{}";
+        String attrJsonStr = "{ id: 1 }";
+        String conditionJsonStr = "{}";
+        JsonObject attributesJson = GrowthBookJsonUtils.getInstance().gson.fromJson(attrJsonStr, JsonObject.class);
+        JsonObject conditionJson = GrowthBookJsonUtils.getInstance().gson.fromJson(conditionJsonStr, JsonObject.class);
+
+
 
         GrowthBook subject = new GrowthBook(context, mockFeatureEvaluator, mockConditionEvaluator, mockExperimentEvaluator);
 
-        subject.evaluateCondition(attrJson, conditionJson);
+        subject.evaluateCondition(attrJsonStr, conditionJsonStr);
 
-        verify(mockConditionEvaluator).evaluateCondition(attrJson, conditionJson);
+        verify(mockConditionEvaluator).evaluateCondition(attributesJson, conditionJson);
     }
 
     @Test


### PR DESCRIPTION
In the `ConditionEvaluator.evaluateCondition` method, we currently convert `attributesJson` and `conditionJson` from `String` to `JsonObject`. However, since this method is also recursive, these conversions are performed multiple times during a single feature evaluation. This PR addresses this issue by moving `attributesJson` and `conditionJson` to `JsonObject` earlier to avoid repeated conversions.

Additionally, this PR updates the `GBContext` constructor to accept `userAttributes` as a `JsonObject`. Currently, the constructor expects userAttributes as a `String`, which is inefficient for applications that frequently update userAttributes, as it requires converting the `JsonObject` to a `String` each time. Accepting userAttributes as a `JsonObject` improves efficiency and aligns with the implementation in other SDKs (e.g., [Go](https://github.com/growthbook/growthbook-golang/blob/main/types.go#L7)).