### PR TITLE
Add caching logic to Growthbook repositories

### DIFF
--- a/lib/src/main/java/growthbook/sdk/java/CachingManager.java
+++ b/lib/src/main/java/growthbook/sdk/java/CachingManager.java
@@ -1,0 +1,75 @@
+package growthbook.sdk.java;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.BufferedReader;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.FileNotFoundException;
+
+/**
+ * Class responsible for caching data to a file
+ */
+@Slf4j
+public class CachingManager {
+    private final File cacheDir;
+
+    public CachingManager(String filePath) {
+        this.cacheDir = new File(filePath);
+        if (!cacheDir.exists()) {
+            boolean created = cacheDir.mkdirs();
+            if (!created) {
+                throw new RuntimeException("Failed to create cache directory at " + filePath);
+            }
+        }
+    }
+
+    /**
+     * Method that saves feature JSON as String to a cache file
+     * @param fileName The name of file in the cache directory
+     * @param content Feature JSON as String type
+     */
+    public void saveContent(String fileName, String content) {
+        File file = new File(cacheDir, fileName);
+        try (BufferedWriter writer = new BufferedWriter(new FileWriter(file))) {
+           writer.write(content);
+       } catch (IOException e) {
+           log.error("Error occur while writing data to file with name: {} error message was {}", fileName, e.getMessage());
+           throw new RuntimeException(e);
+       }
+    }
+
+    /**
+     * Method that fetches data from cache by file name
+     * @param fileName The name of the file in the cache directory.
+     * @return The cached data as a String.
+     */
+    public String loadCache(String fileName) {
+        File file = new File(cacheDir, fileName);
+
+        if (!file.exists()) {
+            return null;
+        }
+
+        try (BufferedReader reader = new BufferedReader(new FileReader(file))) {
+            StringBuilder builder = new StringBuilder();
+            String line;
+
+            while ((line = reader.readLine()) != null) {
+                builder.append(line).append(System.lineSeparator());
+            }
+
+            return builder.toString().trim();
+        } catch (FileNotFoundException e) {
+            log.error("Error was occur because of file isn't exist, error message was - {}", e.getMessage());
+            throw new RuntimeException(e);
+        } catch (IOException e) {
+            log.error("Error was occur during reading data from file, error message was - {}", e.getMessage());
+
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/lib/src/main/java/growthbook/sdk/java/multiusermode/GrowthBookClient.java
+++ b/lib/src/main/java/growthbook/sdk/java/multiusermode/GrowthBookClient.java
@@ -41,10 +41,6 @@ public class GrowthBookClient {
     public boolean initialize() {
         boolean isReady = false;
         try {
-            // load features, experiments, sticky bucket thing whatever!
-            if (!this.options.getIsCacheDisabled()) {
-                // enable cache? is there anything we could do here!
-            }
 
             if (repository == null) {
                 repository = GBFeaturesRepository.builder()
@@ -52,6 +48,7 @@ public class GrowthBookClient {
                         .clientKey(this.options.getClientKey())
                         .decryptionKey(this.options.getDecryptionKey())
                         .refreshStrategy(this.options.getRefreshStrategy())
+                        .isCacheDisabled(this.options.getIsCacheDisabled())
                         .build();
 
                 // Add featureRefreshCallback

--- a/lib/src/test/java/growthbook/sdk/java/GBFeaturesRepositoryRefreshingTest.java
+++ b/lib/src/test/java/growthbook/sdk/java/GBFeaturesRepositoryRefreshingTest.java
@@ -45,7 +45,8 @@ public class GBFeaturesRepositoryRefreshingTest {
                 encryptionKey,
                 FeatureRefreshStrategy.STALE_WHILE_REVALIDATE,
                 ttlSeconds,
-                mockOkHttpClient
+                mockOkHttpClient,
+                null
         );
         subject.initialize();
 
@@ -81,7 +82,8 @@ public class GBFeaturesRepositoryRefreshingTest {
                 encryptionKey,
                 FeatureRefreshStrategy.STALE_WHILE_REVALIDATE,
                 ttlSeconds,
-                mockOkHttpClient
+                mockOkHttpClient,
+                null
         );
         subject.initialize();
 
@@ -115,7 +117,8 @@ public class GBFeaturesRepositoryRefreshingTest {
                 encryptionKey,
                 FeatureRefreshStrategy.STALE_WHILE_REVALIDATE,
                 ttlSeconds,
-                mockOkHttpClient
+                mockOkHttpClient,
+                null
         );
         subject.initialize();
 

--- a/lib/src/test/java/growthbook/sdk/java/GBFeaturesRepositoryTest.java
+++ b/lib/src/test/java/growthbook/sdk/java/GBFeaturesRepositoryTest.java
@@ -32,7 +32,8 @@ class GBFeaturesRepositoryTest {
                 null,
                 null,
                 null,
-                null
+                null,
+                true
         );
 
         assertNotNull(subject);
@@ -48,7 +49,8 @@ class GBFeaturesRepositoryTest {
                 "BhB1wORFmZLTDjbvstvS8w==",
                 null,
                 null,
-                null
+                null,
+                true
         );
 
         assertNotNull(subject);
@@ -107,7 +109,8 @@ class GBFeaturesRepositoryTest {
                 null,
                 null,
                 null,
-                mockOkHttpClient
+                mockOkHttpClient,
+                true
         );
         subject.initialize();
 
@@ -152,7 +155,8 @@ class GBFeaturesRepositoryTest {
                 encryptionKey,
                 null,
                 null,
-                mockOkHttpClient
+                mockOkHttpClient,
+                true
         );
         subject.initialize();
 
@@ -193,7 +197,8 @@ class GBFeaturesRepositoryTest {
                 null,
                 null,
                 0,
-                mockOkHttpClient
+                mockOkHttpClient,
+                true
         );
 
         subject.onFeaturesRefresh(featureRefreshCallback);
@@ -226,7 +231,8 @@ class GBFeaturesRepositoryTest {
                 null,
                 null,
                 0,
-                mockOkHttpClient
+                mockOkHttpClient,
+                true
         );
 
         subject.onFeaturesRefresh(featureRefreshCallback);

--- a/lib/src/test/java/growthbook/sdk/java/multiusermode/GrowthBookClientTest.java
+++ b/lib/src/test/java/growthbook/sdk/java/multiusermode/GrowthBookClientTest.java
@@ -145,6 +145,7 @@ class GrowthBookClientTest {
         when(builder.clientKey(anyString())).thenReturn(builder);
         when(builder.decryptionKey(anyString())).thenReturn(builder);
         when(builder.refreshStrategy(any())).thenReturn(builder);
+        when(builder.isCacheDisabled(anyBoolean())).thenReturn(builder);
         when(builder.build()).thenReturn(repository);
 
         return builder;


### PR DESCRIPTION
Add caching logic to Growthbook repositories to improve performance and enable the ability to retrieve feature JSON data from the cache.