### PR TITLE
Throw exception on HTTP errors

### DIFF
--- a/lib/src/main/java/growthbook/sdk/java/FeatureFetchException.java
+++ b/lib/src/main/java/growthbook/sdk/java/FeatureFetchException.java
@@ -34,6 +34,11 @@ public class FeatureFetchException extends Exception {
         CONFIGURATION_ERROR,
 
         /**
+         * - the server responded with an HTTP error
+         */
+        HTTP_RESPONSE_ERROR,
+
+        /**
          * - there was no response body
          */
         NO_RESPONSE_ERROR,

--- a/lib/src/main/java/growthbook/sdk/java/GBFeaturesRepository.java
+++ b/lib/src/main/java/growthbook/sdk/java/GBFeaturesRepository.java
@@ -450,10 +450,20 @@ public class GBFeaturesRepository implements IGBFeaturesRepository {
     private void onSuccess(Response response) throws FeatureFetchException {
         try {
             ResponseBody responseBody = response.body();
+
             if (responseBody == null) {
-                log.error("FeatureFetchException: FeatureFetchErrorCode.NO_RESPONSE_ERROR");
+                log.error("FeatureFetchException: FeatureFetchErrorCode.NO_RESPONSE_ERROR (HTTP status {})", response.code());
                 throw new FeatureFetchException(
                         FeatureFetchException.FeatureFetchErrorCode.NO_RESPONSE_ERROR
+                );
+            }
+
+            if (response.code() != 200) {
+                log.error("FeatureFetchException: HTTP_RESPONSE_ERROR with status {}, response: {}", response.code(), responseBody.string());
+
+                throw new FeatureFetchException(
+                        FeatureFetchException.FeatureFetchErrorCode.HTTP_RESPONSE_ERROR,
+                        "responded with status " + response.code()
                 );
             }
 

--- a/lib/src/test/java/growthbook/sdk/java/FeatureFetchExceptionTest.java
+++ b/lib/src/test/java/growthbook/sdk/java/FeatureFetchExceptionTest.java
@@ -50,6 +50,27 @@ class FeatureFetchExceptionTest {
                 noResponseExcWithMessage.getMessage()
         );
 
+        // HTTP_RESPONSE_ERROR
+        FeatureFetchException httpResponseExc = new FeatureFetchException(
+                FeatureFetchException.FeatureFetchErrorCode.HTTP_RESPONSE_ERROR
+        );
+        assertEquals(
+                FeatureFetchException.FeatureFetchErrorCode.HTTP_RESPONSE_ERROR,
+                httpResponseExc.getErrorCode()
+        );
+        FeatureFetchException httpResponseExcWithMessage = new FeatureFetchException(
+                FeatureFetchException.FeatureFetchErrorCode.HTTP_RESPONSE_ERROR,
+                "responded with status 400"
+        );
+        assertEquals(
+                FeatureFetchException.FeatureFetchErrorCode.HTTP_RESPONSE_ERROR,
+                httpResponseExcWithMessage.getErrorCode()
+        );
+        assertEquals(
+                "HTTP_RESPONSE_ERROR : responded with status 400",
+                httpResponseExcWithMessage.getMessage()
+        );
+
         // UNKNOWN
         FeatureFetchException unknownExc = new FeatureFetchException(
                 FeatureFetchException.FeatureFetchErrorCode.UNKNOWN


### PR DESCRIPTION
Adds a new FeatureFetchErrorCode called HTTP_RESPONSE_ERROR that is used on non-200 HTTP status codes and also logs the server response. One of the common instances this happens is when you use a wrong SDK key (which I managed to do by copy and pasting to few characters 😬).

They were previously mangled into FeatureFetchErrorCode.CONFIGURATION_ERROR with a very non-descriptive message of "No features found". And since you couldn't see the API response anywhere you were essentially blind on the "why" unless you were able to place a breakpoint into the `onResponseJson`.

Logging the response might be something to argue about but I think it will really help with finding the root cause.

---

This is my first contribution here so let me know if you want anything changed. We can also take this PR as a chance to discuss if this even a good idea.