### PR TITLE
chore: remove v from version

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,6 +3,7 @@
         ".": {
             "release-type": "java-yoshi",
             "package-name": "com.github.growthbook.growthbook-sdk-java",
+            "include-v-in-tag": false,
             "include-component-in-tag": false,
             "bump-minor-pre-major": true,
             "bump-patch-for-minor-pre-major": true,


### PR DESCRIPTION
disable the default "v" in tagging and stick to strict SemVer