### PR TITLE
Fix GrowthBookClient not refreshing cache

### DIFF
--- a/lib/src/main/java/growthbook/sdk/java/multiusermode/GrowthBookClient.java
+++ b/lib/src/main/java/growthbook/sdk/java/multiusermode/GrowthBookClient.java
@@ -71,6 +71,9 @@ public class GrowthBookClient {
                 // Add featureRefreshCallback
                 repository.onFeaturesRefresh(this.options.getFeatureRefreshCallback());
 
+                // Add a callback to refresh the global context
+                repository.onFeaturesRefresh(this.refreshGlobalContext());
+
                 try {
                     repository.initialize();
                 } catch (FeatureFetchException e) {

--- a/lib/src/main/java/growthbook/sdk/java/multiusermode/GrowthBookClient.java
+++ b/lib/src/main/java/growthbook/sdk/java/multiusermode/GrowthBookClient.java
@@ -71,9 +71,6 @@ public class GrowthBookClient {
                 // Add featureRefreshCallback
                 repository.onFeaturesRefresh(this.options.getFeatureRefreshCallback());
 
-                // Add a callback to refresh the global context
-                repository.onFeaturesRefresh(this.refreshGlobalContext());
-
                 try {
                     repository.initialize();
                 } catch (FeatureFetchException e) {
@@ -227,6 +224,9 @@ public class GrowthBookClient {
     }
 
     private EvaluationContext getEvalContext(UserContext userContext) {
+        // Refresh features on each evaluation to ensure cache refresh is triggered
+        this.globalContext.setFeatures(repository.getParsedFeatures());
+        
         HashMap<String, JsonElement> globalAttributes = null;
         if (this.options.getGlobalAttributes() != null) {
             globalAttributes = GrowthBookJsonUtils.getInstance().gson.fromJson(this.options.getGlobalAttributes(), HashMap.class);


### PR DESCRIPTION
This is related to #151. I tested that cache refresh still broken in `0.10.1` (which includes https://github.com/growthbook/growthbook-sdk-java/pull/148). I decided to figure out why, and found out that the reason the cache is not being refreshed is because the cache is only refreshed when features is fetched: https://github.com/growthbook/growthbook-sdk-java/blob/9cfd963875b82bc18067f4856884f2eddc7d1c5a/lib/src/main/java/growthbook/sdk/java/repository/GBFeaturesRepository.java#L327-L351

But in `GrowthBookClient`, `getParsedFeatures` is only called once on init:
https://github.com/growthbook/growthbook-sdk-java/blob/9cfd963875b82bc18067f4856884f2eddc7d1c5a/lib/src/main/java/growthbook/sdk/java/multiusermode/GrowthBookClient.java#L86

The fix is to call this on each feature evaluation.