### PR TITLE
Updating features fix

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/lib/src/main/java/growthbook/sdk/java/multiusermode/configurations/EvaluationContext.java
+++ b/lib/src/main/java/growthbook/sdk/java/multiusermode/configurations/EvaluationContext.java
@@ -1,11 +1,13 @@
 package growthbook.sdk.java.multiusermode.configurations;
 
+import growthbook.sdk.java.model.Feature;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.Nullable;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
 @Data
@@ -29,4 +31,13 @@ public class EvaluationContext {
             this.evaluatedFeatures = new HashSet<>();
         }
     }
+
+    public void setFeatures(Map<String, Feature<?>> features) {
+        if (this.global != null) {
+            this.global.setFeatures(features);
+        } else {
+            log.warn("GlobalContext is null. Cannot set features.");
+        }
+    }
+
 }

--- a/lib/src/main/java/growthbook/sdk/java/multiusermode/configurations/GlobalContext.java
+++ b/lib/src/main/java/growthbook/sdk/java/multiusermode/configurations/GlobalContext.java
@@ -6,6 +6,7 @@ import growthbook.sdk.java.model.Feature;
 import lombok.Builder;
 import lombok.Data;
 import lombok.Getter;
+import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.Nullable;
@@ -23,6 +24,7 @@ public class GlobalContext {
      * Feature definitions - To be pulled from API / Cache
      */
     @Getter
+    @Setter
     @Nullable
     private Map<String, Feature<?>> features;
 

--- a/lib/src/test/java/growthbook/sdk/java/EvaluateFeatureWithStickyBucketingFeatureTest.java
+++ b/lib/src/test/java/growthbook/sdk/java/EvaluateFeatureWithStickyBucketingFeatureTest.java
@@ -9,6 +9,7 @@ import com.google.gson.JsonNull;
 import growthbook.sdk.java.model.ExperimentResult;
 import growthbook.sdk.java.model.FeatureResult;
 import growthbook.sdk.java.model.GBContext;
+import growthbook.sdk.java.repository.GBFeaturesRepository;
 import growthbook.sdk.java.stickyBucketing.InMemoryStickyBucketServiceImpl;
 import growthbook.sdk.java.model.StickyAssignmentsDocument;
 import growthbook.sdk.java.stickyBucketing.StickyBucketService;
@@ -86,7 +87,19 @@ public class EvaluateFeatureWithStickyBucketingFeatureTest {
                     .stickyBucketAssignmentDocs(initialStickyBucketAssignmentDocs)
                     .build();
 
-            GrowthBook subject = new GrowthBook(context);
+            GBFeaturesRepository repository = new GBFeaturesRepository(
+                    "https://cdn.growthbook.io",
+                    "java_NsrWldWd5bxQJZftGsWKl7R2yD2LtAK8C8EUYh9L8",
+                    null,
+                    null,
+                    null,
+                    null,
+                    true,
+                    null,
+                    null
+            );
+
+            GrowthBook subject = new GrowthBook(context, repository);
             FeatureResult<Object> actualFeatureResult = subject.evalFeature(
                     testCase.get(3).getAsJsonPrimitive().getAsString(),
                     Object.class

--- a/lib/src/test/java/growthbook/sdk/java/FeatureResultTest.java
+++ b/lib/src/test/java/growthbook/sdk/java/FeatureResultTest.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import growthbook.sdk.java.model.FeatureResult;
 import growthbook.sdk.java.model.FeatureResultSource;
 import growthbook.sdk.java.model.GBContext;
+import growthbook.sdk.java.repository.GBFeaturesRepository;
 import growthbook.sdk.java.util.GrowthBookJsonUtils;
 import org.junit.jupiter.api.Test;
 
@@ -207,7 +208,18 @@ class FeatureResultTest {
                 "{\"test\":{\"defaultValue\":[],\"rules\":[{\"force\":[\"line1\",\"line2\"]}]}}")
             .build();
 
-        GrowthBook growthBook = new GrowthBook(ctx);
+        GBFeaturesRepository featuresRepository = new GBFeaturesRepository(
+                "https://cdn.growthbook.io",
+                "java_NsrWldWd5bxQJZftGsWKl7R2yD2LtAK8C8EUYh9L8",
+                null,
+                null,
+                null,
+                null,
+                true,
+                null,
+                null
+        );
+        GrowthBook growthBook = new GrowthBook(ctx, featuresRepository);
 
         String featureName = "test";
 

--- a/lib/src/test/java/growthbook/sdk/java/GrowthBookTest.java
+++ b/lib/src/test/java/growthbook/sdk/java/GrowthBookTest.java
@@ -29,6 +29,7 @@ import growthbook.sdk.java.model.FeatureResult;
 import growthbook.sdk.java.model.FeatureResultSource;
 import growthbook.sdk.java.model.GBContext;
 import growthbook.sdk.java.multiusermode.util.TransformationUtil;
+import growthbook.sdk.java.repository.GBFeaturesRepository;
 import growthbook.sdk.java.testhelpers.PaperCupsConfig;
 import growthbook.sdk.java.testhelpers.TestCasesJsonHelper;
 import growthbook.sdk.java.testhelpers.TestContext;
@@ -46,6 +47,18 @@ class GrowthBookTest {
 
     final TestCasesJsonHelper helper = TestCasesJsonHelper.getInstance();
     final GrowthBookJsonUtils jsonUtils = GrowthBookJsonUtils.getInstance();
+
+    final static GBFeaturesRepository repository = new GBFeaturesRepository(
+            "https://cdn.growthbook.io",
+            "java_NsrWldWd5bxQJZftGsWKl7R2yD2LtAK8C8EUYh9L8",
+            null,
+            null,
+            null,
+            null,
+            true,
+            null,
+            null
+    );
 
     @Test
     void test_evalFeature() {
@@ -88,7 +101,7 @@ class GrowthBookTest {
             String featureKey = testCase.get(2).getAsString();
 //            String type = testCase.get("type").getAsString();
 
-            GrowthBook subject = new GrowthBook(context);
+            GrowthBook subject = new GrowthBook(context, repository);
             JsonElement expected = testCase.get(3).getAsJsonObject();
 //            System.out.printf("\n\n Expected result (string): %s", expectedString);
             FeatureResult expectedResult = jsonUtils.gson.fromJson(expected, FeatureResult.class);
@@ -187,7 +200,7 @@ class GrowthBookTest {
                 .featuresJson(features)
                 .featureUsageCallback(featureUsageCallback)
                 .build();
-        GrowthBook subject = new GrowthBook(context);
+        GrowthBook subject = new GrowthBook(context, repository);
 
         String value = subject.getFeatureValue("h1-title", "unknown feature key");
 
@@ -202,7 +215,7 @@ class GrowthBookTest {
 
     @Test
     void run_executesExperimentResultCallbacks() {
-        GrowthBook subject = new GrowthBook();
+        GrowthBook subject = new GrowthBook(repository);
         ExperimentRunCallback mockCallback1 = mock(ExperimentRunCallback.class);
         ExperimentRunCallback mockCallback2 = mock(ExperimentRunCallback.class);
         Experiment<String> mockExperiment = Experiment.<String>builder().build();
@@ -217,7 +230,7 @@ class GrowthBookTest {
 
     @Test
     void run_executesExperimentResultCallbacksOnceWhenRunInvokeMultipleTimes() {
-        GrowthBook subject = new GrowthBook();
+        GrowthBook subject = new GrowthBook(repository);
         ExperimentRunCallback mockCallback = mock(ExperimentRunCallback.class);
         Experiment<String> mockExperiment = Experiment.<String>builder().build();
 
@@ -236,7 +249,7 @@ class GrowthBookTest {
                 mock(GBContext.class),
                 mock(FeatureEvaluator.class),
                 null,
-                experimentEvaluator);
+                experimentEvaluator, repository);
 
         ExperimentRunCallback mockCallback = mock(ExperimentRunCallback.class);
         Experiment<String> mockExperiment1 = Experiment.<String>builder()
@@ -375,7 +388,7 @@ class GrowthBookTest {
                     }
                 }
 
-                GrowthBook subject = new GrowthBook(context);
+                GrowthBook subject = new GrowthBook(context, repository);
                 ExperimentResult result = subject.run(experiment);
                 ExperimentResult expectedResult = new ExperimentResult<>(itemArray.get(3), null, itemArray.get(4).getAsBoolean(), null, null, null, itemArray.get(5).getAsBoolean(), null, null, null, null, null);
                 String json = expectedResult.toJson();
@@ -423,7 +436,7 @@ class GrowthBookTest {
                 .featuresJson(features)
                 .attributesJson(attributes)
                 .build();
-        GrowthBook subject = new GrowthBook(context);
+        GrowthBook subject = new GrowthBook(context, repository);
 
         FeatureResult feature = subject.evalFeature(featureKey, Object.class);
 
@@ -444,7 +457,7 @@ class GrowthBookTest {
                 .featuresJson(features)
                 .attributesJson(attributes)
                 .build();
-        GrowthBook subject = new GrowthBook(context);
+        GrowthBook subject = new GrowthBook(context, repository);
 
         assertFalse(subject.isOn(featureKey));
         assertTrue(subject.isOff(featureKey));
@@ -465,7 +478,7 @@ class GrowthBookTest {
         .features(stringFeatureMap)
         .build();
         
-        GrowthBook subject = new GrowthBook(context);
+        GrowthBook subject = new GrowthBook(context, repository);
         assertTrue(subject.isOn(featureKey));
         assertTrue(subject.isOn(featureKey));
     }
@@ -481,7 +494,7 @@ class GrowthBookTest {
                 .featuresJson(features)
                 .attributesJson(attributes)
                 .build();
-        GrowthBook subject = new GrowthBook(context);
+        GrowthBook subject = new GrowthBook(context, repository);
 
         Boolean result = subject.getFeatureValue(featureKey, false);
 
@@ -499,7 +512,7 @@ class GrowthBookTest {
                 .featuresJson(features)
                 .attributesJson(attributes)
                 .build();
-        GrowthBook subject = new GrowthBook(context);
+        GrowthBook subject = new GrowthBook(context, repository);
 
         String result = subject.getFeatureValue(featureKey, "nope");
 
@@ -517,7 +530,7 @@ class GrowthBookTest {
                 .featuresJson(features)
                 .attributesJson(attributes)
                 .build();
-        GrowthBook subject = new GrowthBook(context);
+        GrowthBook subject = new GrowthBook(context, repository);
 
         String result = subject.getFeatureValue(featureKey, "nope");
 
@@ -535,7 +548,7 @@ class GrowthBookTest {
                 .featuresJson(features)
                 .attributesJson(attributes)
                 .build();
-        GrowthBook subject = new GrowthBook(context);
+        GrowthBook subject = new GrowthBook(context, repository);
 
         Double result = subject.getFeatureValue(featureKey, Double.valueOf(999));
 
@@ -553,7 +566,7 @@ class GrowthBookTest {
                 .featuresJson(features)
                 .attributesJson(attributes)
                 .build();
-        GrowthBook subject = new GrowthBook(context);
+        GrowthBook subject = new GrowthBook(context, repository);
 
         Integer result = subject.getFeatureValue(featureKey, 999);
 
@@ -571,7 +584,7 @@ class GrowthBookTest {
                 .featuresJson(features)
                 .attributesJson(attributes)
                 .build();
-        GrowthBook subject = new GrowthBook(context);
+        GrowthBook subject = new GrowthBook(context, repository);
 
         Float result = subject.getFeatureValue(featureKey, 0.00f);
 
@@ -589,7 +602,7 @@ class GrowthBookTest {
                 .featuresJson(features)
                 .attributesJson(attributes)
                 .build();
-        GrowthBook subject = new GrowthBook(context);
+        GrowthBook subject = new GrowthBook(context, repository);
 
         Object defaultConfig = new PaperCupsConfig("abc123", "My Chat", true);
         Object resultObject = subject.getFeatureValue(featureKey, defaultConfig);
@@ -613,7 +626,7 @@ class GrowthBookTest {
                 .featuresJson(features)
                 .attributesJson(attributes)
                 .build();
-        GrowthBook subject = new GrowthBook(context);
+        GrowthBook subject = new GrowthBook(context, repository);
 
         PaperCupsConfig defaultConfig = new PaperCupsConfig("abc123", "My Chat", true);
         PaperCupsConfig resultConfig = subject.getFeatureValue(featureKey, defaultConfig, PaperCupsConfig.class);
@@ -634,7 +647,7 @@ class GrowthBookTest {
                 .featuresJson(encryptedFeaturesJson)
                 .encryptionKey(encryptionKey)
                 .build();
-        GrowthBook subject = new GrowthBook(context);
+        GrowthBook subject = new GrowthBook(context, repository);
 
         String result = subject.getFeatureValue("greeting", "hello");
         String expected = "hola";
@@ -656,7 +669,7 @@ class GrowthBookTest {
         JsonObject conditionJson = GrowthBookJsonUtils.getInstance().gson.fromJson(conditionJsonStr, JsonObject.class);
         JsonObject savedGroupsJson = GrowthBookJsonUtils.getInstance().gson.fromJson(savedGroups, JsonObject.class);
 
-        GrowthBook subject = new GrowthBook(context, mockFeatureEvaluator, mockConditionEvaluator, mockExperimentEvaluator);
+        GrowthBook subject = new GrowthBook(context, mockFeatureEvaluator, mockConditionEvaluator, mockExperimentEvaluator, repository);
         context.setSavedGroups(savedGroupsJson);
 
         subject.evaluateCondition(attrJsonStr, conditionJsonStr);
@@ -669,13 +682,13 @@ class GrowthBookTest {
         String attributes = "{\"name\": \"world\"}";
         String condition = "[\"$not\": { \"name\": \"hello\" }]";
 
-        GrowthBook growthBook = new GrowthBook();
+        GrowthBook growthBook = new GrowthBook(repository);
         assertFalse(growthBook.evaluateCondition(attributes, condition));
     }
 
     @Test
     void test_destroyClearsCallbacks() {
-        GrowthBook subject = new GrowthBook();
+        GrowthBook subject = new GrowthBook(repository);
         ExperimentRunCallback mockCallback1 = mock(ExperimentRunCallback.class);
         ExperimentRunCallback mockCallback2 = mock(ExperimentRunCallback.class);
         Experiment<String> mockExperiment = Experiment.<String>builder().build();
@@ -711,7 +724,7 @@ class GrowthBookTest {
                 .featuresJson(features)
                 .attributesJson(attributes)
                 .build();
-        GrowthBook subject = new GrowthBook(context);
+        GrowthBook subject = new GrowthBook(context, repository);
 
         String result = subject.getFeatureValue(featureKey, "my fallback value");
 
@@ -730,7 +743,7 @@ class GrowthBookTest {
                 .featuresJson(features)
                 .attributesJson(attributes)
                 .build();
-        GrowthBook subject = new GrowthBook(context);
+        GrowthBook subject = new GrowthBook(context, repository);
 
         Float result = subject.getFeatureValue(featureKey, 10.0f);
 
@@ -749,7 +762,7 @@ class GrowthBookTest {
                 .featuresJson(features)
                 .attributesJson(attributes)
                 .build();
-        GrowthBook subject = new GrowthBook(context);
+        GrowthBook subject = new GrowthBook(context, repository);
 
         Integer result = subject.getFeatureValue(featureKey, 99);
 
@@ -768,7 +781,7 @@ class GrowthBookTest {
                 .featuresJson(features)
                 .attributesJson(attributes)
                 .build();
-        GrowthBook subject = new GrowthBook(context);
+        GrowthBook subject = new GrowthBook(context, repository);
 
         Double result = subject.getFeatureValue(featureKey, Double.valueOf(101));
 
@@ -787,7 +800,7 @@ class GrowthBookTest {
                 .featuresJson(features)
                 .attributesJson(attributes)
                 .build();
-        GrowthBook subject = new GrowthBook(context);
+        GrowthBook subject = new GrowthBook(context, repository);
 
         PaperCupsConfig defaultConfig = new PaperCupsConfig("abc123", "My Chat", true);
         PaperCupsConfig result = subject.getFeatureValue(featureKey, defaultConfig, PaperCupsConfig.class);
@@ -814,7 +827,7 @@ class GrowthBookTest {
                 .url(url)
                 .allowUrlOverrides(true)
                 .build();
-        GrowthBook subject = new GrowthBook(context);
+        GrowthBook subject = new GrowthBook(context, repository);
 
         Boolean result = subject.getFeatureValue("dark_mode", false);
 
@@ -834,7 +847,7 @@ class GrowthBookTest {
                 .url(url)
                 .allowUrlOverrides(true)
                 .build();
-        GrowthBook subject = new GrowthBook(context);
+        GrowthBook subject = new GrowthBook(context, repository);
 
         Boolean result = subject.getFeatureValue("dark_mode", false);
 
@@ -854,7 +867,7 @@ class GrowthBookTest {
                 .url(url)
                 .allowUrlOverrides(true)
                 .build();
-        GrowthBook subject = new GrowthBook(context);
+        GrowthBook subject = new GrowthBook(context, repository);
 
         Boolean result = subject.getFeatureValue("dark_mode", false);
 
@@ -874,7 +887,7 @@ class GrowthBookTest {
                 .url(url)
                 .allowUrlOverrides(true)
                 .build();
-        GrowthBook subject = new GrowthBook(context);
+        GrowthBook subject = new GrowthBook(context, repository);
 
         Boolean result = subject.getFeatureValue("dark_mode", true);
 
@@ -894,7 +907,7 @@ class GrowthBookTest {
                 .url(url)
                 .allowUrlOverrides(true)
                 .build();
-        GrowthBook subject = new GrowthBook(context);
+        GrowthBook subject = new GrowthBook(context, repository);
 
         Boolean result = subject.getFeatureValue("dark_mode", true);
 
@@ -914,7 +927,7 @@ class GrowthBookTest {
                 .url(url)
                 .allowUrlOverrides(true)
                 .build();
-        GrowthBook subject = new GrowthBook(context);
+        GrowthBook subject = new GrowthBook(context, repository);
 
         Boolean result = subject.getFeatureValue("dark_mode", true);
 
@@ -934,7 +947,7 @@ class GrowthBookTest {
                 .url(url)
                 .allowUrlOverrides(true)
                 .build();
-        GrowthBook subject = new GrowthBook(context);
+        GrowthBook subject = new GrowthBook(context, repository);
 
         Integer result = subject.getFeatureValue("donut_price", 999);
 
@@ -953,7 +966,7 @@ class GrowthBookTest {
                 .url(url)
                 .allowUrlOverrides(true)
                 .build();
-        GrowthBook subject = new GrowthBook(context);
+        GrowthBook subject = new GrowthBook(context, repository);
 
         Float result = subject.getFeatureValue("donut_price", 9999f);
 
@@ -972,7 +985,7 @@ class GrowthBookTest {
                 .url(url)
                 .allowUrlOverrides(true)
                 .build();
-        GrowthBook subject = new GrowthBook(context);
+        GrowthBook subject = new GrowthBook(context, repository);
 
         String result = subject.getFeatureValue("banner_text", "???");
         assertEquals("Hello, everyone! I hope you are all doing well!", result);
@@ -992,7 +1005,7 @@ class GrowthBookTest {
                 .url(url)
                 .allowUrlOverrides(true)
                 .build();
-        GrowthBook subject = new GrowthBook(context);
+        GrowthBook subject = new GrowthBook(context, repository);
 
         MealOrder emptyMealOrder = new MealOrder(MealType.STANDARD, "Donut");
 
@@ -1016,7 +1029,7 @@ class GrowthBookTest {
                 .url(url)
                 .allowUrlOverrides(true)
                 .build();
-        GrowthBook subject = new GrowthBook(context);
+        GrowthBook subject = new GrowthBook(context, repository);
 
         String resultAsString = subject.getFeatureValue("meal_overrides_gluten_free", "{\"meal_type\": \"standard\", \"dessert\": \"Donut\"}");
         // Custom deserialization example
@@ -1039,7 +1052,7 @@ class GrowthBookTest {
                 .url(url)
                 .allowUrlOverrides(true)
                 .build();
-        GrowthBook subject = new GrowthBook(context);
+        GrowthBook subject = new GrowthBook(context, repository);
 
         // We try to deserialize an unsupported class from the URL, but it cannot deserialize properly, so we get the default value
         GBTestingFoo defaultFoo = new GBTestingFoo();
@@ -1111,7 +1124,7 @@ class GrowthBookTest {
                 .url(url)
                 .allowUrlOverrides(true)
                 .build();
-        GrowthBook subject = new GrowthBook(context);
+        GrowthBook subject = new GrowthBook(context, repository);
 
         FeatureResult<Boolean> result = subject.evalFeature("dark_mode", Boolean.class);
 
@@ -1133,7 +1146,7 @@ class GrowthBookTest {
                 .url(url)
                 .allowUrlOverrides(true)
                 .build();
-        GrowthBook subject = new GrowthBook(context);
+        GrowthBook subject = new GrowthBook(context, repository);
 
         FeatureResult<String> result = subject.evalFeature("banner_text", String.class);
 
@@ -1153,7 +1166,7 @@ class GrowthBookTest {
                 .url(url)
                 .allowUrlOverrides(true)
                 .build();
-        GrowthBook subject = new GrowthBook(context);
+        GrowthBook subject = new GrowthBook(context, repository);
 
         FeatureResult<Float> result = subject.evalFeature("donut_price", Float.class);
 
@@ -1173,7 +1186,7 @@ class GrowthBookTest {
                 .url(url)
                 .allowUrlOverrides(true)
                 .build();
-        GrowthBook subject = new GrowthBook(context);
+        GrowthBook subject = new GrowthBook(context, repository);
 
         FeatureResult<Integer> result = subject.evalFeature("donut_price", Integer.class);
 

--- a/lib/src/test/java/growthbook/sdk/java/testhelpers/SSETestServer.java
+++ b/lib/src/test/java/growthbook/sdk/java/testhelpers/SSETestServer.java
@@ -55,7 +55,7 @@ public class SSETestServer {
             GBContext context = GBContext.builder()
                     .featuresJson(featuresRepository.getFeaturesJson())
                     .build();
-            GrowthBook growthBook = new GrowthBook(context);
+            GrowthBook growthBook = new GrowthBook(context, featuresRepository);
 
             // Get a feature value
             String randomString = growthBook.getFeatureValue("greeting", "????");


### PR DESCRIPTION
The issue was that feature flags were never refreshed after the initial load. I fixed this by triggering a feature refresh whenever the evaluation context is set or updated.

This follows a stale-while-revalidate approach — it uses the cached features immediately, while asynchronously fetching and applying the latest ones in the background.