### PR TITLE
fix updating features without cache

### DIFF
--- a/lib/src/main/java/growthbook/sdk/java/multiusermode/GrowthBookClient.java
+++ b/lib/src/main/java/growthbook/sdk/java/multiusermode/GrowthBookClient.java
@@ -3,6 +3,8 @@ package growthbook.sdk.java.multiusermode;
 import java.util.*;
 
 import com.google.gson.JsonElement;
+import com.google.gson.reflect.TypeToken;
+
 import growthbook.sdk.java.callback.ExperimentRunCallback;
 import growthbook.sdk.java.callback.FeatureRefreshCallback;
 import growthbook.sdk.java.evaluators.ExperimentEvaluator;
@@ -11,6 +13,7 @@ import growthbook.sdk.java.exception.FeatureFetchException;
 import growthbook.sdk.java.model.AssignedExperiment;
 import growthbook.sdk.java.model.Experiment;
 import growthbook.sdk.java.model.ExperimentResult;
+import growthbook.sdk.java.model.Feature;
 import growthbook.sdk.java.model.FeatureResult;
 import growthbook.sdk.java.model.RequestBodyForRemoteEval;
 import growthbook.sdk.java.multiusermode.configurations.EvaluationContext;
@@ -204,8 +207,9 @@ public class GrowthBookClient {
             public void onRefresh(String featuresJson) {
                 // refer the global context with latest features & saved groups
                 if (globalContext != null) {
-                    globalContext.setFeatures(repository.getParsedFeatures());
-                    globalContext.setSavedGroups(repository.getParsedSavedGroups());
+                    Map<String, Feature<?>> features = GrowthBookJsonUtils.getInstance()
+                        .gson.fromJson(featuresJson, new TypeToken<Map<String, Feature<?>>>(){}.getType());
+                    globalContext.setFeatures(features);
                 } else {
                     // TBD:M This should never happen! Just to be cautious about race conditions at the time of initialization
                     globalContext = GlobalContext.builder()

--- a/lib/src/main/java/growthbook/sdk/java/repository/GBFeaturesRepository.java
+++ b/lib/src/main/java/growthbook/sdk/java/repository/GBFeaturesRepository.java
@@ -339,13 +339,16 @@ public class GBFeaturesRepository implements IGBFeaturesRepository {
     }
 
     public Map<String, Feature<?>> getParsedFeatures() {
-        //TBD: This auto-refresh implementation must be corrected.
-        if (this.refreshStrategy == FeatureRefreshStrategy.STALE_WHILE_REVALIDATE
-                && !isCacheDisabled
-                && isCacheExpired()
-        ) {
-            this.enqueueFeatureRefreshRequest();
-            this.refreshExpiresAt();
+        // TBD: This auto-refresh implementation must be corrected.
+        if (this.refreshStrategy == FeatureRefreshStrategy.STALE_WHILE_REVALIDATE) {
+            boolean shouldRefresh = (isCacheDisabled || isCacheExpired());
+
+            if (shouldRefresh) {
+                this.enqueueFeatureRefreshRequest();
+                if (!isCacheDisabled) {
+                    this.refreshExpiresAt();
+                }
+            }
         }
         return this.parsedFeatures;
     }


### PR DESCRIPTION
This PR ensures that feature updates continue to work even when `.isCacheDisabled(true)` is set. Previously, disabling the cache also stopped background refreshes. 

Also, a **cyclical call** to `repository.getParsedSavedGroups()` inside `onRefresh()` was removed to prevent unnecessary repeated calls and improve clarity.