### PR TITLE
feat: added manual `.builder()` method to `UserContext`

### DIFF
--- a/lib/src/main/java/growthbook/sdk/java/multiusermode/configurations/UserContext.java
+++ b/lib/src/main/java/growthbook/sdk/java/multiusermode/configurations/UserContext.java
@@ -1,8 +1,8 @@
 package growthbook.sdk.java.multiusermode.configurations;
 
 import com.google.gson.JsonObject;
-import growthbook.sdk.java.multiusermode.util.TransformationUtil;
 import growthbook.sdk.java.model.StickyAssignmentsDocument;
+import growthbook.sdk.java.multiusermode.util.TransformationUtil;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 
@@ -39,6 +39,10 @@ public class UserContext {
         forcedVariationsMap = userContextBuilder.forcedVariationsMap;
         forcedFeatureValues = userContextBuilder.forcedFeatureValues;
         attributesJson = userContextBuilder.attributesJson;
+    }
+
+    public static UserContextBuilder builder() {
+        return new UserContextBuilder();
     }
 
     public UserContext witAttributesJson(String attributesJson) {


### PR DESCRIPTION
As discussed in #171, opening this PR to add the method.

Searched for usages of the `UserContextBuilder` constructor in the code but I decided not to change any of those since those are inside the SDK and this method feels like something for a user of the SDK rather than a developer.

More than happy to replace the usages also.