### PR TITLE
fix(perf) : use native type check for JsonNull

### DIFF
--- a/lib/src/main/java/growthbook/sdk/java/util/GrowthBookJsonUtils.java
+++ b/lib/src/main/java/growthbook/sdk/java/util/GrowthBookJsonUtils.java
@@ -143,7 +143,7 @@ public class GrowthBookJsonUtils {
         try {
             if (element == null) return DataType.UNDEFINED;
 
-            if (element.toString().equals("null")) {
+            if (element.isJsonNull()) {
                 return DataType.NULL;
             }
 

--- a/lib/src/test/java/growthbook/sdk/java/GrowthBookJsonUtilsTest.java
+++ b/lib/src/test/java/growthbook/sdk/java/GrowthBookJsonUtilsTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
+import com.google.gson.JsonNull;
 import growthbook.sdk.java.model.BucketRange;
 import growthbook.sdk.java.model.DataType;
 import growthbook.sdk.java.model.Namespace;
@@ -55,6 +56,7 @@ class GrowthBookJsonUtilsTest {
         Gson gson = GrowthBookJsonUtils.getInstance().gson;
 
         assertEquals(DataType.NULL, GrowthBookJsonUtils.getElementType(gson.fromJson("null", JsonElement.class)));
+        assertEquals(DataType.NULL, GrowthBookJsonUtils.getElementType(JsonNull.INSTANCE));
         assertEquals(DataType.ARRAY, GrowthBookJsonUtils.getElementType(gson.fromJson("[1]", JsonElement.class)));
         assertEquals(DataType.OBJECT, GrowthBookJsonUtils.getElementType(gson.fromJson("{ \"foo\": 2}", JsonElement.class)));
         assertEquals(DataType.BOOLEAN, GrowthBookJsonUtils.getElementType(gson.fromJson("true", JsonElement.class)));


### PR DESCRIPTION
- GrowthBookJsonUtils.getElementType function checks for element types
  - For the Null type, it converts the JsonElement to a String type and then does a String equality
  - Since in normal workloads, almost all the code paths execute this if-else condition, this toString() allocation becomes costly at scale.
  - Removal of these allocations reduces GC pressure and latency.
- Solution
  - Use the native type check provided by the Gson library to remove String allocations in this code path
  - Correctness of this solution can be validated by taking a look at the tests for `JsonNull` in Gson repositiory
    - https://github.com/google/gson/blob/main/gson/src/test/java/com/google/gson/JsonNullTest.java -> testToString() 


Stack Trace after performing test on version `0.10.3`

<img width="971" height="253" alt="image" src="https://github.com/user-attachments/assets/05e35686-0a73-4cc4-a1f8-92d177e1c1ae" />

Thanks
