### PR TITLE
fix: remove duplicate rollout check in force rule evaluation

### DIFF
--- a/lib/src/main/java/growthbook/sdk/java/evaluators/FeatureEvaluator.java
+++ b/lib/src/main/java/growthbook/sdk/java/evaluators/FeatureEvaluator.java
@@ -296,25 +296,6 @@ public class FeatureEvaluator implements IFeatureEvaluator {
                         );
                     }
 
-                    if (rule.getRange() == null) {
-                        if (rule.getCoverage() != null) {
-                            String attributeValue = context.getUser().getAttributes().get(ruleKey) == null
-                                    ? null : context.getUser().getAttributes().get(ruleKey).getAsString();
-
-                            if (attributeValue == null || attributeValue.isEmpty()) {
-                                continue;
-                            }
-
-                            Float hashFNV = GrowthBookUtils.hash(attributeValue, 1, key);
-                            if (hashFNV == null) {
-                                hashFNV = 0f;
-                            }
-                            if (hashFNV > rule.getCoverage()) {
-                                continue;
-                            }
-                        }
-                    }
-
                     ValueType value = (ValueType) GrowthBookJsonUtils.unwrap(rule.getForce().getValue());
 
                     // Apply the force rule

--- a/lib/src/main/java/growthbook/sdk/java/util/GrowthBookUtils.java
+++ b/lib/src/main/java/growthbook/sdk/java/util/GrowthBookUtils.java
@@ -533,9 +533,14 @@ public class GrowthBookUtils {
         HashAttributeAndHashValue hashAttributeAndHashValue = GrowthBookUtils
                 .getHashAttribute(hashAttribute, fallbackAttribute, attributes);
 
+        String hashValue = hashAttributeAndHashValue.getHashValue();
+        if (hashValue == null || hashValue.isEmpty()) {
+            return false;
+        }
+
         // Determine the bucket for the user
         Float hash = GrowthBookUtils.hash(
-                hashAttributeAndHashValue.getHashValue(),
+                hashValue,
                 hashVersion,
                 seed
         );


### PR DESCRIPTION
## Problem
In `FeatureEvaluator`, when a force rule defines a percentage rollout via `coverage`, users were hash-checked twice with independent seeds:

1. `isIncludedInRollout` — correct, uses `rule.seed` and `rule.hashVersion` ignoring rule configuration. 

Because both checks were independent gates, effective rollout shrunk to `coverage²`. A 50% rollout with a custom seed produced ~25% actual traffic.

## Changes
- **`FeatureEvaluator.java`** — removed the redundant `hash()` block (lines 299–316).  `isIncludedInRollout` already covers this gate correctly.
- **`GrowthBookUtils.isIncludedInRollout`** — added early `return false` when `hashValue` is empty, matching the JS reference implementation.