### PR TITLE
fix: correct sticky bucketing logic in single-user and multi-user modes

### DIFF
--- a/lib/src/main/java/growthbook/sdk/java/GrowthBook.java
+++ b/lib/src/main/java/growthbook/sdk/java/GrowthBook.java
@@ -183,6 +183,9 @@ public class GrowthBook implements IGrowthBook {
     @Override
     public void setAttributes(String attributesJsonString) {
         this.context.setAttributesJson(attributesJsonString);
+        // Reload sticky docs for the new attributes before rebuilding the eval context,
+        // matching TypeScript/Kotlin/Swift behaviour.
+        refreshStickyBucketService(null);
         initializeEvalContext();
     }
 
@@ -236,6 +239,7 @@ public class GrowthBook implements IGrowthBook {
     @Override
     public void setOwnStickyBucketService(@Nullable StickyBucketService stickyBucketService) {
         this.context.setStickyBucketService(stickyBucketService);
+        refreshStickyBucketService(null);
         initializeEvalContext();
     }
 
@@ -245,6 +249,7 @@ public class GrowthBook implements IGrowthBook {
     @Override
     public void setInMemoryStickyBucketService() {
         this.context.setStickyBucketService(new InMemoryStickyBucketServiceImpl(new HashMap<>()));
+        refreshStickyBucketService(null);
         initializeEvalContext();
     }
 
@@ -511,10 +516,18 @@ public class GrowthBook implements IGrowthBook {
     }
 
     /**
-     * Update sticky bucketing configuration
-     * Method that get cached assignments
-     * and set it to Context's Sticky Bucket Assignments documents
-     * @param featuresDataModel Json in format of String. See info how it looks like here <a href="https://docs.growthbook.io/app/api#sdk-connection-endpoints">...</a>
+     * Call this whenever features are refreshed so that sticky bucket assignment docs are
+     * reloaded for the current user.  Unlike Swift/Kotlin where an equivalent method was
+     * invoked automatically via a delegate, in Java this must be wired up explicitly, e.g.:
+     * <pre>
+     *   repository.onFeaturesRefresh(gb::featuresAPIModelSuccessfully);
+     * </pre>
+     * Passing the new features JSON allows {@code deriveStickyBucketIdentifierAttributes} to
+     * pick up any new {@code hashAttribute}/{@code fallbackAttribute} values introduced by the
+     * updated feature definitions before re-fetching docs from the service.
+     *
+     * @param featuresDataModel JSON string returned by the GrowthBook SDK endpoint.
+     *                          See <a href="https://docs.growthbook.io/app/api#sdk-connection-endpoints">SDK Connection Endpoints</a>
      */
     @Override
     public void featuresAPIModelSuccessfully(String featuresDataModel) {
@@ -534,6 +547,10 @@ public class GrowthBook implements IGrowthBook {
     private void refreshStickyBucketService(@Nullable String featuresDataModel) {
         if (context.getStickyBucketService() != null) {
             GrowthBookUtils.refreshStickyBuckets(context, featuresDataModel, attributeOverrides);
+            // Sync updated docs into the evaluation context so the next evalFeature call sees them.
+            if (evaluationContext != null && evaluationContext.getUser() != null) {
+                evaluationContext.getUser().setStickyBucketAssignmentDocs(context.getStickyBucketAssignmentDocs());
+            }
         }
     }
 

--- a/lib/src/main/java/growthbook/sdk/java/GrowthBook.java
+++ b/lib/src/main/java/growthbook/sdk/java/GrowthBook.java
@@ -183,8 +183,9 @@ public class GrowthBook implements IGrowthBook {
     @Override
     public void setAttributes(String attributesJsonString) {
         this.context.setAttributesJson(attributesJsonString);
-        // Reload sticky docs for the new attributes before rebuilding the eval context,
-        // matching TypeScript/Kotlin/Swift behaviour.
+        // Keep attributeOverrides in sync with the new attributes so that
+        // refreshStickyBucketService fetches docs for the *new* user, not the old one.
+        this.attributeOverrides = this.context.getAttributes();
         refreshStickyBucketService(null);
         initializeEvalContext();
     }

--- a/lib/src/main/java/growthbook/sdk/java/GrowthBook.java
+++ b/lib/src/main/java/growthbook/sdk/java/GrowthBook.java
@@ -510,7 +510,7 @@ public class GrowthBook implements IGrowthBook {
     }
 
     /**
-     * This method add new calback to list of ExperimentRunCallback
+     * This method add new callback to list of ExperimentRunCallback
      * @param callback ExperimentRunCallback interface
      */
     @Override
@@ -520,8 +520,7 @@ public class GrowthBook implements IGrowthBook {
 
     /**
      * Call this whenever features are refreshed so that sticky bucket assignment docs are
-     * reloaded for the current user.  Unlike Swift/Kotlin where an equivalent method was
-     * invoked automatically via a delegate, in Java this must be wired up explicitly, e.g.:
+     * reloaded for the current user.
      * <pre>
      *   repository.onFeaturesRefresh(gb::featuresAPIModelSuccessfully);
      * </pre>

--- a/lib/src/main/java/growthbook/sdk/java/GrowthBook.java
+++ b/lib/src/main/java/growthbook/sdk/java/GrowthBook.java
@@ -69,6 +69,8 @@ public class GrowthBook implements IGrowthBook {
         this.experimentEvaluatorEvaluator = new ExperimentEvaluator();
         this.attributeOverrides = context.getAttributes() == null ? new JsonObject() : context.getAttributes();
 
+        // Load sticky bucket docs on construction if a service is configured,
+        refreshStickyBucketService(null);
         this.initializeEvalContext();
     }
 

--- a/lib/src/main/java/growthbook/sdk/java/model/GBContext.java
+++ b/lib/src/main/java/growthbook/sdk/java/model/GBContext.java
@@ -179,13 +179,6 @@ public class GBContext {
         this.attributes = (attributes == null) ? new JsonObject() : attributes;
     }
 
-    public void setStickyBucketIdentifierAttributes(@Nullable List<String> stickyBucketIdentifierAttributes) {
-        this.stickyBucketIdentifierAttributes = stickyBucketIdentifierAttributes;
-        if (stickyBucketIdentifierAttributes == null) {
-            this.stickyBucketIdentifierAttributesSignature = null;
-        }
-    }
-
     /**
      * Optional encryption key. If this is not null, featuresJson should be an encrypted payload.
      */
@@ -227,12 +220,6 @@ public class GBContext {
      */
     @Nullable
     private List<String> stickyBucketIdentifierAttributes;
-
-    /**
-     * Fingerprint of the feature payload used to derive sticky bucket identifiers.
-     */
-    @Nullable
-    private String stickyBucketIdentifierAttributesSignature;
 
     /**
      * The builder class to help create a context. You can use {@link #builder()} or the {@link GBContext} constructor

--- a/lib/src/main/java/growthbook/sdk/java/multiusermode/GrowthBookClient.java
+++ b/lib/src/main/java/growthbook/sdk/java/multiusermode/GrowthBookClient.java
@@ -20,6 +20,7 @@ import growthbook.sdk.java.repository.GBFeaturesRepository;
 import growthbook.sdk.java.sandbox.CacheManagerFactory;
 import growthbook.sdk.java.sandbox.CacheMode;
 import growthbook.sdk.java.sandbox.GbCacheManager;
+import growthbook.sdk.java.model.StickyAssignmentsDocument;
 import growthbook.sdk.java.util.GrowthBookJsonUtils;
 import lombok.extern.slf4j.Slf4j;
 
@@ -259,6 +260,22 @@ public class GrowthBookClient {
             }
         }
         UserContext updatedUserContext = userContext.withAttributes(merged);
+
+        // If a sticky bucket service is configured and the caller hasn't pre-loaded docs,
+        // fetch docs for this user's attributes now (one call per request).
+        if (this.options.getStickyBucketService() != null
+                && updatedUserContext.getStickyBucketAssignmentDocs() == null) {
+            Map<String, String> attrStrings = new HashMap<>();
+            for (Map.Entry<String, JsonElement> e : merged.entrySet()) {
+                if (e.getValue() != null && e.getValue().isJsonPrimitive()) {
+                    attrStrings.put(e.getKey(), e.getValue().getAsString());
+                }
+            }
+            Map<String, StickyAssignmentsDocument> docs =
+                    this.options.getStickyBucketService().getAllAssignments(attrStrings);
+            updatedUserContext.setStickyBucketAssignmentDocs(docs);
+        }
+
         return new EvaluationContext(this.globalContext, updatedUserContext, new EvaluationContext.StackContext(), this.options);
     }
 

--- a/lib/src/main/java/growthbook/sdk/java/multiusermode/GrowthBookClient.java
+++ b/lib/src/main/java/growthbook/sdk/java/multiusermode/GrowthBookClient.java
@@ -261,7 +261,7 @@ public class GrowthBookClient {
         }
         UserContext updatedUserContext = userContext.withAttributes(merged);
 
-        // If a sticky bucket service is configured and the caller hasn't pre-loaded docs,
+        // If a sticky bucket service is configured and the caller hasn't preloaded docs,
         // fetch docs for this user's attributes now (one call per request).
         if (this.options.getStickyBucketService() != null
                 && updatedUserContext.getStickyBucketAssignmentDocs() == null) {

--- a/lib/src/main/java/growthbook/sdk/java/util/GrowthBookUtils.java
+++ b/lib/src/main/java/growthbook/sdk/java/util/GrowthBookUtils.java
@@ -595,28 +595,8 @@ public class GrowthBookUtils {
                                                                 String featuresDataModel,
                                                                 JsonObject attributeOverrides) {
         Map<String, String> attributes = new HashMap<>();
-        List<String> identifierAttributes = context.getStickyBucketIdentifierAttributes();
 
-        if (identifierAttributes == null || identifierAttributes.isEmpty()) {
-            return attributes;
-        }
-
-        // 1. generate payload signature for sticky-bucket identifier derivation to re-use it later.
-        // context.getFeatures() - shouldn't be null!
-        String signature = Integer.toString(featuresDataModel == null
-                ? context.getFeatures().hashCode() : featuresDataModel.hashCode());
-
-        // 2. derive attributes only if the signature changes
-        boolean shouldDerive = !signature.equals(context.getStickyBucketIdentifierAttributesSignature());
-
-        if (shouldDerive) {
-            List<String> derived = deriveStickyBucketIdentifierAttributes(context, featuresDataModel);
-            identifierAttributes = derived;
-
-            // 3. store the derived attributes to re-use in evaluations.
-            context.setStickyBucketIdentifierAttributes(derived);
-            context.setStickyBucketIdentifierAttributesSignature(signature);
-        }
+        List<String> identifierAttributes = deriveStickyBucketIdentifierAttributes(context, featuresDataModel);
 
         for (String attr : identifierAttributes) {
             HashAttributeAndHashValue hashAttribute = getHashAttribute(
@@ -712,8 +692,8 @@ public class GrowthBookUtils {
                 + hashAttributeAndHashValueWithoutFallbackPass.getHashValue();
 
         HashAttributeAndHashValue hashAttributeAndHashValueWithFallbackAttribute = getHashAttribute(
-                null,
                 expFallbackAttribute,
+                null,
                 context.getUser().getAttributes()
         );
         String fallBackKey = hashAttributeAndHashValueWithFallbackAttribute.getHashValue().isEmpty()
@@ -723,25 +703,6 @@ public class GrowthBookUtils {
                 + hashAttributeAndHashValueWithFallbackAttribute.getHashValue();
 
         Map<String, StickyAssignmentsDocument> stickyAssignmentsDocuments = context.getUser().getStickyBucketAssignmentDocs();
-
-        if (context.getUser().getAttributes().get(expFallbackAttribute) != null) {
-            String leftOperand = stickyAssignmentsDocuments.get(
-                    expFallbackAttribute + "||" + context.getUser().getAttributes().get(expFallbackAttribute).getAsString()
-            ) == null
-                    ? null
-                    : stickyAssignmentsDocuments.get(
-                    expFallbackAttribute + "||" + context.getUser().getAttributes().get(expFallbackAttribute).getAsString()
-            ).getAttributeValue();
-
-            if (!Objects.equals(leftOperand, context.getUser().getAttributes().get(expFallbackAttribute).getAsString())) {
-                context.getUser().setStickyBucketAssignmentDocs(new HashMap<>());
-            }
-        }
-
-        if (context.getUser().getStickyBucketAssignmentDocs() != null) {
-            context.getUser().getStickyBucketAssignmentDocs().values()
-                    .forEach(it -> mergedAssignments.putAll(it.getAssignments()));
-        }
 
         if (fallBackKey != null) {
             if (stickyAssignmentsDocuments.get(fallBackKey) != null) {

--- a/lib/src/test/java/growthbook/sdk/java/EvaluateFeatureWithStickyBucketingFeatureTest.java
+++ b/lib/src/test/java/growthbook/sdk/java/EvaluateFeatureWithStickyBucketingFeatureTest.java
@@ -44,7 +44,7 @@ public class EvaluateFeatureWithStickyBucketingFeatureTest {
         List<Integer> failingIndexes = new ArrayList<>();
         JsonArray stickyBucketTestCases = helper.getStickyBucketTestCases();
         for (int i = 0; i < stickyBucketTestCases.size(); i++) {
-            // Create a fresh service per iteration — same as Kotlin test.
+
             stickyBucketService = new InMemoryStickyBucketServiceImpl(new HashMap<>());
             JsonArray testCase = stickyBucketTestCases.get(i).getAsJsonArray();
             // name of testcase
@@ -59,7 +59,7 @@ public class EvaluateFeatureWithStickyBucketingFeatureTest {
             String attributesJsonAsStringOrNull = attributesJson == null ? null : attributesJson.toString();
 
             // Write input docs to the service, then call getAllAssignments to get only
-            // docs that belong to the current user — same approach as TypeScript/Kotlin.
+            // docs that belong to the current user.
             JsonArray stickyAssignmentsJsonArray = testCase.get(2).getAsJsonArray();
             for (JsonElement element : stickyAssignmentsJsonArray) {
                 StickyAssignmentsDocument doc = utils.gson.fromJson(element, StickyAssignmentsDocument.class);

--- a/lib/src/test/java/growthbook/sdk/java/EvaluateFeatureWithStickyBucketingFeatureTest.java
+++ b/lib/src/test/java/growthbook/sdk/java/EvaluateFeatureWithStickyBucketingFeatureTest.java
@@ -6,6 +6,7 @@ import com.google.common.reflect.TypeToken;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonNull;
+import com.google.gson.JsonObject;
 import growthbook.sdk.java.model.ExperimentResult;
 import growthbook.sdk.java.model.FeatureResult;
 import growthbook.sdk.java.model.GBContext;
@@ -36,11 +37,6 @@ public class EvaluateFeatureWithStickyBucketingFeatureTest {
 
     }
 
-    @BeforeEach
-    void setUp() {
-        stickyBucketService = new InMemoryStickyBucketServiceImpl(new HashMap<>());
-    }
-
     @Test
     void testsStickyBucketingFeature() {
         List<String> passedTests = new ArrayList<>();
@@ -48,6 +44,8 @@ public class EvaluateFeatureWithStickyBucketingFeatureTest {
         List<Integer> failingIndexes = new ArrayList<>();
         JsonArray stickyBucketTestCases = helper.getStickyBucketTestCases();
         for (int i = 0; i < stickyBucketTestCases.size(); i++) {
+            // Create a fresh service per iteration — same as Kotlin test.
+            stickyBucketService = new InMemoryStickyBucketServiceImpl(new HashMap<>());
             JsonArray testCase = stickyBucketTestCases.get(i).getAsJsonArray();
             // name of testcase
             String description = testCase.get(0).getAsString();
@@ -60,22 +58,25 @@ public class EvaluateFeatureWithStickyBucketingFeatureTest {
             JsonElement attributesJson = testCase.get(1).getAsJsonObject().get("attributes");
             String attributesJsonAsStringOrNull = attributesJson == null ? null : attributesJson.toString();
 
-            // create sticky assignments document map for context
+            // Write input docs to the service, then call getAllAssignments to get only
+            // docs that belong to the current user — same approach as TypeScript/Kotlin.
             JsonArray stickyAssignmentsJsonArray = testCase.get(2).getAsJsonArray();
-            List<StickyAssignmentsDocument> stickyAssigmentList = new ArrayList<>();
             for (JsonElement element : stickyAssignmentsJsonArray) {
-                StickyAssignmentsDocument stickyAssignmentsDocument = utils.gson.fromJson(
-                        element,
-                        StickyAssignmentsDocument.class
-                );
-                stickyAssigmentList.add(stickyAssignmentsDocument);
+                StickyAssignmentsDocument doc = utils.gson.fromJson(element, StickyAssignmentsDocument.class);
+                stickyBucketService.saveAssignments(doc);
             }
 
-            Map<String, StickyAssignmentsDocument> initialStickyBucketAssignmentDocs = new HashMap<>();
-            for (StickyAssignmentsDocument doc : stickyAssigmentList) {
-                String key = doc.getAttributeName() + "||" + doc.getAttributeValue();
-                initialStickyBucketAssignmentDocs.put(key, doc);
+            JsonObject attrsJson = attributesJsonAsStringOrNull != null
+                    ? utils.gson.fromJson(attributesJsonAsStringOrNull, JsonObject.class)
+                    : new JsonObject();
+            Map<String, String> attributesAsStrings = new HashMap<>();
+            if (attrsJson != null) {
+                for (Map.Entry<String, JsonElement> entry : attrsJson.entrySet()) {
+                    attributesAsStrings.put(entry.getKey(), entry.getValue().getAsString());
+                }
             }
+            Map<String, StickyAssignmentsDocument> filteredDocs =
+                    stickyBucketService.getAllAssignments(attributesAsStrings);
 
             // initialize actual data
             GBContext context = GBContext
@@ -83,7 +84,7 @@ public class EvaluateFeatureWithStickyBucketingFeatureTest {
                     .featuresJson(featuresJsonAsStringOrNull)
                     .attributesJson(attributesJsonAsStringOrNull)
                     .stickyBucketService(stickyBucketService)
-                    .stickyBucketAssignmentDocs(initialStickyBucketAssignmentDocs)
+                    .stickyBucketAssignmentDocs(filteredDocs)
                     .build();
 
             GrowthBook subject = new GrowthBook(context);


### PR DESCRIPTION
## Problem

Sticky bucketing was not working correctly in several scenarios, mirroring bugs previously found and fixed in the Swift SDK and Kotlin SDK. 

## Root causes and fixes

### 1. Wrong argument order in `getStickyBucketAssignments` (GrowthBookUtils) 
`getHashAttribute` was called with `null` and `expFallbackAttribute` swapped, so the fallback attribute was never used for hash lookup. Users with a fallback attribute (e.g., `deviceId`) were not matched to their existing sticky assignments.

### 2. Invalid sticky doc invalidation (GrowthBookUtils) 
A block that compared fallback attribute values was incorrectly clearing all sticky assignment docs when the values didn't match, discarding valid assignments for other experiments running in parallel. This was the root cause of Swift issue - sticky bucketing breaks when more than one experiment is running simultaneously.

### 3. `attributeOverrides` not synced in `setAttributes` (GrowthBook)
When `setAttributes` was called to switch users, `attributeOverrides` still held the previous user's attributes. The subsequent `refreshStickyBucketService` call was fetching docs for the wrong user.

### 4. Sticky docs not loaded in `GrowthBook` constructor (GrowthBook)
Sticky bucket docs were not fetched eagerly on construction, so the second request to the same endpoint always showed `stickyBucketUsed: false`. This matches the behaviour of the TypeScript and Swift SDKs, which fetch docs at construction time.

### 5. No per-request sticky doc loading in `GrowthBookClient` (multi-user mode) 
`getEvalContext` was not loading sticky assignment docs for the current user's attributes, so `stickyBucketUsed` was always `false` in multi-user mode.

### 6. Early return in `generateStickyBucketIdentifierAttributes` skipped doc lookups (GrowthBookUtils / GBContext)

If `stickyBucketIdentifierAttributes` was not explicitly set in Options, the function returned an empty map immediately instead of deriving attributes from features. This caused `getAllAssignments` to be called with an empty map, returning no docs. The signature-based cache (`stickyBucketIdentifierAttributesSignature`) was also removed from GBContext; identifier attributes are now derived fresh on every evaluation.