### PR TITLE
feat: add feature refresh listeners

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ Next, add the dependency with the latest version to your project's dependencies:
 
 `GrowthBookClient` lets you share the same instance for all requests with an ability to accept the user attributes
 while calling the feature methods like `isOn()`. This `GrowthBookClient` instance is decoupled from the `GBContext`,
-creates a singleton featureRepository based on your refreshStrategy and uses the latest features at the time of
-evaluation, all managed internally.
+owns a feature repository based on your refresh strategy and uses the latest features at the time of evaluation,
+all managed internally.
 
 ```java
 
@@ -79,13 +79,33 @@ Options options = Options.builder()
 // Create growthbook instance using the options you need
 GrowthBookClient gb = new GrowthBookClient(options);
 
+// Optional metadata-only listener for successful and failed feature refreshes
+FeatureRefreshSubscription refreshSubscription = gb.subscribeFeatureRefreshListener(event -> {
+    if (event.isSuccessful()) {
+        System.out.println("Refresh source: " + event.getSource());
+        System.out.println("Features changed: " + event.isFeaturesChanged());
+        System.out.println("Loaded from cache: " + event.isLoadedFromCache());
+        System.out.println("Refresh duration: " + event.getDurationMillis() + " ms");
+        System.out.println("Active features: " + event.getActiveFeatureCount());
+    } else {
+        System.out.println("Feature refresh failed: " + event.getError());
+    }
+});
+
 // call the init method to load features 
 gb.initialize();
 
 gb.isOn("featureKey", UserContext.builder()
     .attributesJson("{\"id\" : \"123\"}").build()
 );
+
+// Stop receiving refresh events when no longer needed
+refreshSubscription.close();
 ```
+
+Feature refresh listeners are dispatched off the refresh thread on a dedicated daemon thread owned by
+the client. Supply your own executor with
+`Options.builder().featureRefreshListenerExecutor(executor).build()` to control the threading yourself.
 
 ### Manually create separate instance of GBContext, Repository and Growthbook classes
 
@@ -98,18 +118,17 @@ GBFeaturesRepository featuresRepository = GBFeaturesRepository
     .refreshStrategy(FeatureRefreshStrategy.SERVER_SENT_EVENTS) // optional; options: STALE_WHILE_REVALIDATE, SERVER_SENT_EVENTS (default: STALE_WHILE_REVALIDATE)
     .build();
 
-// Optional callback for getting updates when features are refreshed
-featuresRepository.onFeaturesRefresh(new FeatureRefreshCallback() {
-    @Override
-    public void onRefresh(String featuresJson) {
+// Optional listener for getting metadata when features are refreshed
+FeatureRefreshListener refreshListener = event -> {
+    if (event.isSuccessful()) {
         System.out.println("Features have been refreshed");
-        System.out.println(featuresJson);
-    }
-    @Override
-    public void onError(Throwable throwable) {
+        System.out.println("Features changed: " + event.isFeaturesChanged());
+    } else {
         System.out.println("Features refreshed with error");
+        System.out.println(event.getError());
     }
-});
+};
+featuresRepository.addFeatureRefreshListener(refreshListener);
 
 try {
     featuresRepository.initialize();
@@ -150,7 +169,7 @@ With the SWR strategy, the repository will:
 
 - Perform an initial synchronous fetch during `initialize()`.
 - Start a lightweight background poller that revalidates features on a fixed delay (by default equal to the TTL). The poller is protected against overlapping runs and logs start/end of each polling cycle.
-- Keep the latest features in memory and invoke registered `FeatureRefreshCallback`s when updated so the `GlobalContext` stays fresh.
+- Keep the latest features in memory and publish `FeatureRefreshListener` events when updated so the `GlobalContext` stays fresh.
 
 For SSE connections, the repository establishes a server‑sent events stream and updates as changes arrive; the SWR poller is not used.
 
@@ -185,7 +204,8 @@ public Boolean isOff(String featureKey, UserContext userContext);
 public <ValueType> ExperimentResult<ValueType> run(Experiment<ValueType> experiment, UserContext userContext);
 ```
 
-- If you changed, added or removed any features, you can call the `refreshCache()` / `refreshCacheForRemoteEval()` method to clear the cache and download the latest feature definitions.
+- If you changed, added or removed any features, call `refreshFeature()` to download the latest feature definitions.
+  For remote evaluation payloads, use `refreshForRemoteEval(...)`.
 
 ```java
 public void refreshFeature();

--- a/lib/src/main/java/growthbook/sdk/java/callback/ExperimentRunCallback.java
+++ b/lib/src/main/java/growthbook/sdk/java/callback/ExperimentRunCallback.java
@@ -12,5 +12,5 @@ public interface ExperimentRunCallback {
      *
      * @param experimentResult {@link ExperimentResult}
      */
-    <ValueType> void onRun(Experiment<ValueType> experiment, ExperimentResult<ValueType> experimentResult);
+    <T> void onRun(Experiment<T> experiment, ExperimentResult<T> experimentResult);
 }

--- a/lib/src/main/java/growthbook/sdk/java/callback/FeatureRefreshCallback.java
+++ b/lib/src/main/java/growthbook/sdk/java/callback/FeatureRefreshCallback.java
@@ -1,23 +1,36 @@
 package growthbook.sdk.java.callback;
 
+import growthbook.sdk.java.listener.FeatureRefreshListener;
+import growthbook.sdk.java.model.FeatureRefreshEvent;
+import growthbook.sdk.java.multiusermode.GrowthBookClient;
 import growthbook.sdk.java.repository.GBFeaturesRepository;
 
 /**
- * See {@link GBFeaturesRepository#onFeaturesRefresh(FeatureRefreshCallback)}
+ * Legacy callback invoked after feature refresh attempts.
+ *
+ * @deprecated Use {@link FeatureRefreshListener} with
+ * {@link GrowthBookClient#addFeatureRefreshListener(FeatureRefreshListener)},
+ * {@link GrowthBookClient#subscribeFeatureRefreshListener(FeatureRefreshListener)}, or
+ * {@link GBFeaturesRepository#addFeatureRefreshListener(FeatureRefreshListener)}.
  */
+@Deprecated
 public interface FeatureRefreshCallback {
 
     /**
-     * See {@link GBFeaturesRepository#onFeaturesRefresh(FeatureRefreshCallback)}
+     * Invoked when features refresh successfully.
      *
      * @param featuresJson Features as JSON string
+     * @deprecated Use {@link FeatureRefreshListener#onRefresh(FeatureRefreshEvent)}.
      */
+    @Deprecated
     void onRefresh(String featuresJson);
 
     /**
-     * See {@link GBFeaturesRepository#onFeaturesRefresh(FeatureRefreshCallback)}
+     * Invoked when features fail to refresh.
      *
      * @param throwable Exception on refreshCallback
+     * @deprecated Use {@link FeatureRefreshListener#onRefresh(FeatureRefreshEvent)}.
      */
+    @Deprecated
     void onError(Throwable throwable);
 }

--- a/lib/src/main/java/growthbook/sdk/java/callback/FeatureUsageCallback.java
+++ b/lib/src/main/java/growthbook/sdk/java/callback/FeatureUsageCallback.java
@@ -6,5 +6,5 @@ import growthbook.sdk.java.model.FeatureResult;
  * Listen for feature usage events
  */
 public interface FeatureUsageCallback {
-    <ValueType> void onFeatureUsage(String featureKey, FeatureResult<ValueType> result);
+    <T> void onFeatureUsage(String featureKey, FeatureResult<T> result);
 }

--- a/lib/src/main/java/growthbook/sdk/java/callback/TrackingCallback.java
+++ b/lib/src/main/java/growthbook/sdk/java/callback/TrackingCallback.java
@@ -11,7 +11,7 @@ public interface TrackingCallback {
      * This callback is called with the {@link Experiment} and {@link ExperimentResult} when an experiment is evaluated.
      * @param experiment the {@link Experiment}
      * @param experimentResult the {@link ExperimentResult}
-     * @param <ValueType> the value type for the experiment
+     * @param <T> the value type for the experiment
      */
-    <ValueType> void onTrack(Experiment<ValueType> experiment, ExperimentResult<ValueType> experimentResult);
+    <T> void onTrack(Experiment<T> experiment, ExperimentResult<T> experimentResult);
 }

--- a/lib/src/main/java/growthbook/sdk/java/evaluators/Condition.java
+++ b/lib/src/main/java/growthbook/sdk/java/evaluators/Condition.java
@@ -1,0 +1,68 @@
+package growthbook.sdk.java.evaluators;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import lombok.Getter;
+
+import javax.annotation.Nullable;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * <b>INTERNAL</b>: Top-level logical operators that may appear as keys in a condition object.
+ *
+ * <p>Each constant carries the strategy that combines its operand against the user attributes.
+ * Conditions are recursive, so a strategy receives the {@link IConditionEvaluator} and calls back
+ * into it for nested sub-conditions (the Interpreter pattern). Adding a logical operator is a
+ * single entry here.</p>
+ */
+@Getter
+public enum Condition {
+
+    OR("$or", (attributes, value, savedGroups, evaluator) ->
+            ConditionArrayMatcher.anyMatches(attributes, value.getAsJsonArray(), savedGroups, evaluator)),
+    NOR("$nor", (attributes, value, savedGroups, evaluator) ->
+            !ConditionArrayMatcher.anyMatches(attributes, value.getAsJsonArray(), savedGroups, evaluator)),
+    AND("$and", (attributes, value, savedGroups, evaluator) ->
+            ConditionArrayMatcher.allMatch(attributes, value.getAsJsonArray(), savedGroups, evaluator)),
+    NOT("$not", (attributes, value, savedGroups, evaluator) ->
+            !evaluator.evaluateCondition(attributes, value.getAsJsonObject(), savedGroups));
+
+    /**
+     * Combines a logical operator's operand against the user attributes, recursing through the
+     * evaluator for nested sub-conditions.
+     */
+    @FunctionalInterface
+    interface Strategy {
+        boolean apply(JsonObject attributes, JsonElement value, @Nullable JsonObject savedGroups, IConditionEvaluator evaluator);
+    }
+
+    private static final Map<String, Condition> BY_VALUE = new HashMap<>();
+
+    static {
+        for (Condition condition : values()) {
+            BY_VALUE.put(condition.conditionValue, condition);
+        }
+    }
+
+    private final String conditionValue;
+    private final Strategy strategy;
+
+    Condition(String conditionValue, Strategy strategy) {
+        this.conditionValue = conditionValue;
+        this.strategy = strategy;
+    }
+
+    /**
+     * @param key a condition entry key (e.g. {@code "$or"})
+     * @return the matching logical operator, or {@code null} if the key is an attribute path
+     */
+    @Nullable
+    public static Condition fromValue(String key) {
+        return BY_VALUE.get(key);
+    }
+
+    boolean apply(JsonObject attributes, JsonElement value, @Nullable JsonObject savedGroups, IConditionEvaluator evaluator) {
+        return strategy.apply(attributes, value, savedGroups, evaluator);
+    }
+}

--- a/lib/src/main/java/growthbook/sdk/java/evaluators/ConditionArrayMatcher.java
+++ b/lib/src/main/java/growthbook/sdk/java/evaluators/ConditionArrayMatcher.java
@@ -1,0 +1,47 @@
+package growthbook.sdk.java.evaluators;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import lombok.experimental.UtilityClass;
+
+import javax.annotation.Nullable;
+
+/**
+ * <b>INTERNAL</b>: Shared array-of-conditions matching used by the {@code $or}/{@code $nor}/{@code $and}
+ * logical operators. Each nested condition is delegated back to the {@link IConditionEvaluator}.
+ */
+@UtilityClass
+final class ConditionArrayMatcher {
+
+    /**
+     * @return true if any condition matches (an empty array matches, mirroring {@code $or} semantics)
+     */
+    static boolean anyMatches(JsonObject attributes, JsonArray conditions, @Nullable JsonObject savedGroups, IConditionEvaluator evaluator) {
+        if (conditions.isEmpty()) {
+            return true;
+        }
+        for (JsonElement condition : conditions) {
+            if (Boolean.TRUE.equals(evaluator.evaluateCondition(safe(attributes), condition.getAsJsonObject(), savedGroups))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * @return true if every condition matches (an empty array matches, mirroring {@code $and} semantics)
+     */
+    static boolean allMatch(JsonObject attributes, JsonArray conditions, @Nullable JsonObject savedGroups, IConditionEvaluator evaluator) {
+        for (JsonElement condition : conditions) {
+            if (!Boolean.TRUE.equals(evaluator.evaluateCondition(safe(attributes), condition.getAsJsonObject(), savedGroups))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static JsonObject safe(@Nullable JsonObject attributes) {
+        return attributes == null ? new JsonObject() : attributes;
+    }
+}

--- a/lib/src/main/java/growthbook/sdk/java/evaluators/ConditionEvaluator.java
+++ b/lib/src/main/java/growthbook/sdk/java/evaluators/ConditionEvaluator.java
@@ -4,7 +4,6 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
-import com.google.gson.JsonSyntaxException;
 import growthbook.sdk.java.util.GrowthBookJsonUtils;
 import growthbook.sdk.java.model.Operator;
 import growthbook.sdk.java.util.StringUtils;
@@ -12,15 +11,10 @@ import growthbook.sdk.java.model.DataType;
 import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.Nullable;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.regex.PatternSyntaxException;
 
 /**
  * <b>INTERNAL</b>: Implementation of condition evaluation
@@ -40,71 +34,33 @@ public class ConditionEvaluator implements IConditionEvaluator {
      * @return Whether the condition should be true for the user
      */
     @Override
-    public Boolean evaluateCondition(JsonObject attributes, JsonObject conditionJson, @Nullable JsonObject savedGroups) {
+    public Boolean evaluateCondition(
+        JsonObject attributes,
+        JsonObject conditionJson,
+        @Nullable JsonObject savedGroups) {
         try {
-            // Loop through the conditionObj key/value pairs
-            for (Map.Entry<String, JsonElement> entry : conditionJson.entrySet()) {
-                String key = entry.getKey();
-                JsonElement value = entry.getValue();
-
-                switch (key) {
-                    case "$or":
-                        // If conditionObj has a key $or, return evalOr(attributes, condition["$or"])
-                        JsonArray orTargetItems = value.getAsJsonArray();
-                        if (orTargetItems != null) {
-                            if (!evalOr(attributes, orTargetItems, savedGroups)) {
-                                return false;
-                            }
-                        }
-                        break;
-                    case "$nor":
-                        // If conditionObj has a key $nor, return !evalOr(attributes, condition["$nor"])
-                        JsonArray norTargetItems = value.getAsJsonArray();
-                        if (norTargetItems != null) {
-                            if (evalOr(attributes, norTargetItems, savedGroups)) {
-                                return false;
-                            }
-                        }
-                        break;
-                    case "$and":
-                        // If conditionObj has a key $and, return !evalAnd(attributes, condition["$and"])
-                        JsonArray andTargetItems = value.getAsJsonArray();
-                        if (andTargetItems != null) {
-                            if (!evalAnd(attributes, andTargetItems, savedGroups)) {
-                                return false;
-                            }
-                        }
-                        break;
-                    case "$not":
-                        // If conditionObj has a key $not, return !evalCondition(attributes, condition["$not"])
-                        if (value != null) {
-                            if (evaluateCondition(attributes, value.getAsJsonObject(), savedGroups)) {
-                                return false;
-                            }
-                        }
-                        break;
-                    default:
-                        JsonElement element = (JsonElement) getPath(attributes, key);
-                        // If evalConditionValue(value, getPath(attributes, key)) is false,
-                        // break out of loop and return false
-                        if (!evalConditionValue(value, element, savedGroups)) {
-                            return false;
-                        }
-                        break;
-                }
-            }
-            // If none of the entries failed their checks, `evalCondition` returns true
-            return true;
-        } catch (JsonSyntaxException jsonSyntaxException) {
-            log.error(jsonSyntaxException.getMessage(), jsonSyntaxException);
-            return false;
-        } catch (PatternSyntaxException patternSyntaxException) {
-            log.error(patternSyntaxException.getMessage(), patternSyntaxException);
-            return false;
-        } catch (Exception exception) { // for the case if something was missed
+            return conditionJson.entrySet().stream()
+                    .allMatch(entry ->
+                        matchesConditionEntry(entry.getKey(), entry.getValue(), attributes, savedGroups));
+        } catch (Exception exception) {
             log.error(exception.getMessage(), exception);
             return false;
         }
+    }
+
+    /**
+     * Evaluates a single top-level condition entry: a logical operator ($or/$nor/$and/$not) is
+     * handled by its strategy (recursing back through this evaluator); any other key is treated as
+     * an attribute path and compared as a leaf value.
+     */
+    private boolean matchesConditionEntry(
+        String key, JsonElement value,
+        JsonObject attributes,
+        @Nullable JsonObject savedGroups) {
+        Condition operator = Condition.fromValue(key);
+        return operator != null
+                ? operator.apply(attributes, value, savedGroups, this)
+                : evalConditionValue(value, (JsonElement) getPath(attributes, key), savedGroups);
     }
 
     /**
@@ -117,19 +73,8 @@ public class ConditionEvaluator implements IConditionEvaluator {
         if (!object.isJsonObject()) {
             return false;
         }
-
-        Set<Map.Entry<String, JsonElement>> entries = ((JsonObject) object).entrySet();
-
-        if (entries.isEmpty()) {
-            return true;
-        }
-
-        long without$Prefix = entries
-                .stream()
-                .filter(o -> !o.getKey().startsWith("$"))
-                .count();
-
-        return without$Prefix == 0;
+        return object.getAsJsonObject().entrySet().stream()
+                .allMatch(entry -> entry.getKey().startsWith("$"));
     }
 
     /**
@@ -141,85 +86,37 @@ public class ConditionEvaluator implements IConditionEvaluator {
      */
     @Nullable
     public Object getPath(JsonElement attributes, String path) {
-        if (Objects.equals(path, "")) return null;
-
-        ArrayList<String> paths = new ArrayList<>();
-
-        if (path.contains(".")) {
-            String[] pathSegments = path.split("\\.");
-
-            Collections.addAll(paths, pathSegments);
-        } else {
-            paths.add(path);
+        if (Objects.equals(path, "")) {
+            return null;
         }
 
         JsonElement element = attributes;
-
-        for (String segment : paths) {
-            if (element == null || element instanceof JsonArray) {
+        for (String segment : path.split("\\.")) {
+            if (!(element instanceof JsonObject)) {
                 return null;
             }
-            if (element instanceof JsonObject) {
-                element = ((JsonObject) element).get(segment);
-            } else {
-                return null;
-            }
+            element = ((JsonObject) element).get(segment);
         }
-
         return element;
     }
 
-
     /**
-     * Evaluates the condition using the operator. For example, if you provide the following condition:
+     * Evaluates a single operator condition (the {@code attributeValue {op} conditionValue} form).
      *
-     * <pre>
-     * {
-     *   "$not": {
-     *     "country": "usa"
-     *   }
-     * }
-     * </pre>
-     * <p>
-     * And the following attributes:
+     * <p>Operators fall into a few families:</p>
+     * <ul>
+     *   <li>comparison: <code>$eq, $ne, $lt, $lte, $gt, $gte, $regex</code></li>
+     *   <li>array conditionValue: <code>$in, $nin</code></li>
+     *   <li>array attributeValue: <code>$elemMatch, $size</code></li>
+     *   <li>both arrays: <code>$all</code></li>
+     *   <li>version: <code>$vgt, $vgte, $vlt, $vlte, $vne, $veq</code></li>
+     *   <li>saved groups: <code>$inGroup, $notInGroup</code></li>
+     *   <li>other: <code>$exists, $type, $not</code></li>
+     * </ul>
      *
-     * <pre>
-     * {
-     *   "country": "canada"
-     * }
-     * </pre>
-     * <p>
-     * It will evaluate to true because the <code>country</code> is not <code>usa</code>.
-     * </p>
-     *
-     * <p>
-     * There are basic comparison operators in the form attributeValue {op} conditionValue,
-     * i.e. <code>$eq, $ne, $lt, $lte, $gt, $gte, $regex</code>
-     * </p>
-     *
-     * <p>
-     * There are 2 operators where conditionValue is an array,
-     * i.e. <code>$in, $nin</code>
-     * </p>
-     *
-     * <p>
-     * There are 2 operators where attributeValue is an array,
-     * i.e. <code>$elemMatch, $size</code>
-     * </p>
-     *
-     * <p>
-     * There is 1 operator where both attributeValue and conditionValue are arrays,
-     * i.e. <code>$all</code>
-     * </p>
-     *
-     * <p>
-     * There are 3 other operators,
-     * i.e. <code>$exists, $type, $not</code>
-     * </p>
-     *
-     * @param actual         Nullable JSON element
      * @param operatorString String value of the operator
-     * @param expected       The conditions to use to verify that the attributes match, based on the operator
+     * @param actual         Nullable attribute value
+     * @param expected       The condition value to compare against
      * @return if it's a match
      */
     Boolean evalOperatorCondition(String operatorString, @Nullable JsonElement actual, JsonElement expected, @Nullable JsonObject savedGroups) {
@@ -230,89 +127,23 @@ public class ConditionEvaluator implements IConditionEvaluator {
 
         switch (operator) {
             case IN:
-                if (actual == null) return false;
-                if (!expected.isJsonArray()) return false;
-                return isIn(actual, expected.getAsJsonArray(), false);
-
             case INI:
-                if (actual == null) return false;
-                if (!expected.isJsonArray()) return false;
-                return isIn(actual, expected.getAsJsonArray(), true);
-
             case NIN:
-                if (actual == null) return false;
-                if (!expected.isJsonArray()) return false;
-                return !isIn(actual, expected.getAsJsonArray(), false);
-
             case NINI:
-                if (actual == null) return false;
-                if (!expected.isJsonArray()) return false;
-                return !isIn(actual, expected.getAsJsonArray(), true);
+                return evalMembership(operator, actual, expected);
 
             case GT:
-                if (actual == null || DataType.NULL.equals(attributeDataType)) {
-                    return (!expected.isJsonPrimitive() || expected.getAsJsonPrimitive().isNumber())
-                            && 0.0 > expected.getAsDouble();
-                }
-                if (actual.getAsJsonPrimitive().isNumber()) {
-                    return actual.getAsNumber().floatValue() > expected.getAsNumber().floatValue();
-                }
-                if (actual.getAsJsonPrimitive().isString()) {
-                    return actual.getAsString().compareTo(expected.getAsString()) > 0;
-                }
-                break;
-
             case GTE:
-                if (actual == null || DataType.NULL.equals(attributeDataType)) {
-                    return (!expected.isJsonPrimitive() || expected.getAsJsonPrimitive().isNumber())
-                            && 0.0 >= expected.getAsDouble();
-                }
-                if (actual.getAsJsonPrimitive().isNumber()) {
-                    return actual.getAsNumber().floatValue() >= expected.getAsNumber().floatValue();
-                }
-                if (actual.getAsJsonPrimitive().isString()) {
-                    return actual.getAsString().compareTo(expected.getAsString()) >= 0;
-                }
-                break;
-
             case LT:
-                if (actual == null || DataType.NULL.equals(attributeDataType)) {
-                    return (!expected.isJsonPrimitive() || expected.getAsJsonPrimitive().isNumber())
-                            && 0.0 < expected.getAsDouble();
-                }
-                if (actual.getAsString().toLowerCase().matches("\\d+")) {
-                    return Double.parseDouble(actual.getAsString()) < expected.getAsDouble();
-                }
-                if (actual.getAsJsonPrimitive().isNumber()) {
-                    return actual.getAsNumber().floatValue() < expected.getAsNumber().floatValue();
-                }
-                if (actual.getAsJsonPrimitive().isString()) {
-                    return actual.getAsString().compareTo(expected.getAsString()) < 0;
-                }
-                break;
-
             case LTE:
-                if (actual == null || DataType.NULL.equals(attributeDataType)) {
-                    return (!expected.isJsonPrimitive() || expected.getAsJsonPrimitive().isNumber())
-                            && 0.0 <= expected.getAsDouble();
-                }
-                if (actual.getAsJsonPrimitive().isNumber()) {
-                    return actual.getAsNumber().floatValue() <= expected.getAsNumber().floatValue();
-                }
-                if (actual.getAsJsonPrimitive().isString()) {
-                    return actual.getAsString().compareTo(expected.getAsString()) <= 0;
-                }
-                break;
+                return evalComparison(operator, actual, expected, attributeDataType);
 
             case REGEX:
                 return evalRegex(actual, expected, attributeDataType, false, false);
-
             case REGEX_I:
                 return evalRegex(actual, expected, attributeDataType, true, false);
-
             case NOT_REGEX:
                 return evalRegex(actual, expected, attributeDataType, false, true);
-
             case NOT_REGEX_I:
                 return evalRegex(actual, expected, attributeDataType, true, true);
 
@@ -326,22 +157,17 @@ public class ConditionEvaluator implements IConditionEvaluator {
 
             case SIZE:
                 if (actual == null || !actual.isJsonArray()) return false;
-                JsonArray attributeValueArrayForSize = (JsonArray) actual;
-                JsonElement size = new JsonPrimitive(attributeValueArrayForSize.size());
-                return evalConditionValue(expected, size, savedGroups);
+                return evalConditionValue(expected, new JsonPrimitive(actual.getAsJsonArray().size()), savedGroups);
 
             case ELEMENT_MATCH:
                 if (actual == null) return false;
                 return elemMatch(actual, expected, savedGroups);
 
             case ALL:
-                if (actual == null || !actual.isJsonArray()) return false;
-                if (!expected.isJsonArray()) return false;
+                if (actual == null || !actual.isJsonArray() || !expected.isJsonArray()) return false;
                 return isInAll(actual.getAsJsonArray(), expected.getAsJsonArray(), savedGroups, false);
-
             case ALLI:
-                if (actual == null || !actual.isJsonArray()) return false;
-                if (!expected.isJsonArray()) return false;
+                if (actual == null || !actual.isJsonArray() || !expected.isJsonArray()) return false;
                 return isInAll(actual.getAsJsonArray(), expected.getAsJsonArray(), savedGroups, true);
 
             case NOT:
@@ -351,78 +177,104 @@ public class ConditionEvaluator implements IConditionEvaluator {
                 return GrowthBookJsonUtils.getElementType(actual).toString().equals(expected.getAsString());
 
             case EXISTS:
-                boolean exists = expected.getAsBoolean();
-
-                if (exists) {
-                    // Ensure it's present
-                    return actual != null;
-                } else {
-                    // Ensure it's not present
-                    return actual == null || actual.isJsonNull();
-                }
+                return expected.getAsBoolean() ? actual != null : (actual == null || actual.isJsonNull());
 
             case VERSION_GT:
-                if (actual == null || expected == null || DataType.NULL.equals(attributeDataType))
-                    return false;
-
-                return StringUtils.paddedVersionString(actual.getAsString())
-                        .compareTo(StringUtils.paddedVersionString(expected.getAsString())) > 0;
-
             case VERSION_GTE:
-                if (actual == null || expected == null || DataType.NULL.equals(attributeDataType))
-                    return false;
-
-                return StringUtils.paddedVersionString(actual.getAsString())
-                        .compareTo(StringUtils.paddedVersionString(expected.getAsString())) >= 0;
-
             case VERSION_LT:
-                if (actual == null || expected == null || DataType.NULL.equals(attributeDataType))
-                    return false;
-
-                return StringUtils.paddedVersionString(actual.getAsString())
-                        .compareTo(StringUtils.paddedVersionString(expected.getAsString())) < 0;
-
             case VERSION_LTE:
-                if (actual == null || expected == null || DataType.NULL.equals(attributeDataType))
-                    return false;
-
-                return StringUtils.paddedVersionString(actual.getAsString())
-                        .compareTo(StringUtils.paddedVersionString(expected.getAsString())) <= 0;
-
             case VERSION_NE:
-                if (actual == null || expected == null || DataType.NULL.equals(attributeDataType))
-                    return false;
-
-                return StringUtils.paddedVersionString(actual.getAsString())
-                        .compareTo(StringUtils.paddedVersionString(expected.getAsString())) != 0;
-
             case VERSION_EQ:
-                if (actual == null || expected == null || DataType.NULL.equals(attributeDataType))
-                    return false;
-
-                return StringUtils.paddedVersionString(actual.getAsString())
-                        .compareTo(StringUtils.paddedVersionString(expected.getAsString())) == 0;
+                return evalVersion(operator, actual, expected, attributeDataType);
 
             case IN_GROUP:
-                if (actual != null && expected != null) {
-                    JsonElement jsonElement = savedGroups != null ? savedGroups.get(expected.getAsString()) : null;
-                    if (jsonElement != null) {
-                        return isIn(actual, jsonElement.getAsJsonArray(), false);
-                    }
-                    return isIn(actual, new JsonArray(), false);
-                }
             case NOT_IN_GROUP:
-                if (actual != null && expected != null) {
-                    JsonElement jsonElement = savedGroups != null ? savedGroups.get(expected.getAsString()) : null;
-                    if (jsonElement != null) {
-                        return !isIn(actual, jsonElement.getAsJsonArray(), false);
-                    }
-                    return !isIn(actual, new JsonArray(), false);
-                }
+                return evalSavedGroup(operator, actual, expected, savedGroups);
+
             default:
                 return false;
         }
+    }
+
+    /**
+     * {@code $in}/{@code $nin} (and their case-insensitive variants): tests array membership.
+     */
+    private Boolean evalMembership(Operator operator, @Nullable JsonElement actual, JsonElement expected) {
+        if (actual == null || !expected.isJsonArray()) {
+            return false;
+        }
+        boolean caseInsensitive = operator == Operator.INI || operator == Operator.NINI;
+        boolean negate = operator == Operator.NIN || operator == Operator.NINI;
+        return negate != isIn(actual, expected.getAsJsonArray(), caseInsensitive);
+    }
+
+    /**
+     * {@code $gt}/{@code $gte}/{@code $lt}/{@code $lte}: numeric or lexical comparison.
+     */
+    private Boolean evalComparison(Operator operator, @Nullable JsonElement actual, JsonElement expected, DataType attributeDataType) {
+        if (actual == null || DataType.NULL.equals(attributeDataType)) {
+            if (expected.isJsonPrimitive() && !expected.getAsJsonPrimitive().isNumber()) {
+                return false;
+            }
+            return matchesSign(operator, Double.compare(0.0, expected.getAsDouble()));
+        }
+        if (operator == Operator.LT && actual.getAsString().toLowerCase().matches("\\d+")) {
+            return Double.parseDouble(actual.getAsString()) < expected.getAsDouble();
+        }
+        if (actual.getAsJsonPrimitive().isNumber()) {
+            return matchesSign(operator, Float.compare(actual.getAsNumber().floatValue(), expected.getAsNumber().floatValue()));
+        }
+        if (actual.getAsJsonPrimitive().isString()) {
+            return matchesSign(operator, actual.getAsString().compareTo(expected.getAsString()));
+        }
         return false;
+    }
+
+    /**
+     * {@code $vgt}/{@code $vgte}/{@code $vlt}/{@code $vlte}/{@code $vne}/{@code $veq}:
+     * compares padded semantic-version strings.
+     */
+    private Boolean evalVersion(Operator operator, @Nullable JsonElement actual, JsonElement expected, DataType attributeDataType) {
+        if (actual == null || expected == null || DataType.NULL.equals(attributeDataType)) {
+            return false;
+        }
+        int cmp = StringUtils.paddedVersionString(actual.getAsString())
+                .compareTo(StringUtils.paddedVersionString(expected.getAsString()));
+        switch (operator) {
+            case VERSION_GT:  return cmp > 0;
+            case VERSION_GTE: return cmp >= 0;
+            case VERSION_LT:  return cmp < 0;
+            case VERSION_LTE: return cmp <= 0;
+            case VERSION_NE:  return cmp != 0;
+            case VERSION_EQ:  return cmp == 0;
+            default:          return false;
+        }
+    }
+
+    /**
+     * {@code $inGroup}/{@code $notInGroup}: membership in a named saved group (empty if unknown).
+     */
+    private Boolean evalSavedGroup(Operator operator, @Nullable JsonElement actual, @Nullable JsonElement expected, @Nullable JsonObject savedGroups) {
+        if (actual == null || expected == null) {
+            return false;
+        }
+        JsonElement group = savedGroups != null ? savedGroups.get(expected.getAsString()) : null;
+        JsonArray groupValues = group != null ? group.getAsJsonArray() : new JsonArray();
+        boolean inGroup = isIn(actual, groupValues, false);
+        return operator == Operator.NOT_IN_GROUP ? !inGroup : inGroup;
+    }
+
+    /**
+     * Maps a {@link Integer#compare}-style sign to the requested comparison operator.
+     */
+    private static boolean matchesSign(Operator operator, int comparison) {
+        switch (operator) {
+            case GT:  return comparison > 0;
+            case GTE: return comparison >= 0;
+            case LT:  return comparison < 0;
+            case LTE: return comparison <= 0;
+            default:  return false;
+        }
     }
 
     /**
@@ -530,7 +382,6 @@ public class ConditionEvaluator implements IConditionEvaluator {
         }
 
         JsonArray actualArray = actual.getAsJsonArray();
-
         boolean isOperator = isOperatorObject(expected);
 
         for (JsonElement actualElement : actualArray) {
@@ -544,47 +395,6 @@ public class ConditionEvaluator implements IConditionEvaluator {
         }
 
         return false;
-    }
-
-
-    /**
-     * @param attributes User attributes
-     * @param conditions an array of condition objects
-     * @return if matches
-     */
-    Boolean evalOr(JsonElement attributes, JsonArray conditions, @Nullable JsonObject savedGroups) {
-        if (conditions.isEmpty()) {
-            return true;
-        }
-
-        for (JsonElement condition : conditions) {
-            JsonObject attributesObj = (null == attributes) ? new JsonObject() : attributes.getAsJsonObject();
-            Boolean matches = evaluateCondition(attributesObj, condition.getAsJsonObject(), savedGroups);
-
-            if (matches) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    /**
-     * @param attributes User attributes
-     * @param conditions an array of condition objects
-     * @return if matches
-     */
-    Boolean evalAnd(JsonElement attributes, JsonArray conditions, @Nullable JsonObject savedGroups) {
-        for (JsonElement condition : conditions) {
-            JsonObject attributesObj = (null == attributes) ? new JsonObject() : attributes.getAsJsonObject();
-            Boolean matches = evaluateCondition(attributesObj, condition.getAsJsonObject(), savedGroups);
-
-            if (!matches) {
-                return false;
-            }
-        }
-
-        return true;
     }
 
     private Boolean isIn(JsonElement actual, JsonArray expected, boolean inSensitive) {
@@ -648,7 +458,6 @@ public class ConditionEvaluator implements IConditionEvaluator {
         return true;
     }
 
-
     private <T> boolean isMatchingPrimitive(
             JsonElement conditionValue,
             JsonElement attributeValue,
@@ -662,10 +471,10 @@ public class ConditionEvaluator implements IConditionEvaluator {
     }
 
     private static Boolean evalRegex(@Nullable JsonElement actual,
-                                              JsonElement expected,
-                                              DataType attributeDataType,
-                                              boolean caseInsensitive,
-                                              boolean negate) {
+                                     JsonElement expected,
+                                     DataType attributeDataType,
+                                     boolean caseInsensitive,
+                                     boolean negate) {
         if (actual == null || DataType.NULL.equals(attributeDataType)) return negate;
 
         int flags = caseInsensitive ? Pattern.CASE_INSENSITIVE : 0;
@@ -681,8 +490,8 @@ public class ConditionEvaluator implements IConditionEvaluator {
     }
 
     /**
-     * Folds a JsonElement to lowercase if it's a string and inSensitive is true.
-     * Used where you need a folded value rather than a comparison.
+     * Folds a JsonElement to lowercase if it's a string. Used where you need a folded value
+     * rather than a comparison.
      */
     private JsonElement caseFold(@Nullable JsonElement value) {
         if (value != null

--- a/lib/src/main/java/growthbook/sdk/java/evaluators/ConditionEvaluator.java
+++ b/lib/src/main/java/growthbook/sdk/java/evaluators/ConditionEvaluator.java
@@ -34,7 +34,6 @@ public class ConditionEvaluator implements IConditionEvaluator {
     @Override
     public Boolean evaluateCondition(JsonObject attributes, JsonObject conditionJson, @Nullable JsonObject savedGroups) {
         try {
-            // The condition matches only if every top-level entry is satisfied.
             return conditionJson.entrySet().stream()
                     .allMatch(entry -> matchesConditionEntry(entry.getKey(), entry.getValue(), attributes, savedGroups));
         } catch (Exception exception) {
@@ -82,7 +81,6 @@ public class ConditionEvaluator implements IConditionEvaluator {
 
         JsonElement element = attributes;
         for (String segment : path.split("\\.")) {
-            // Only objects can be descended into; null, arrays and primitives mean "no value here".
             if (!(element instanceof JsonObject)) {
                 return null;
             }
@@ -209,7 +207,6 @@ public class ConditionEvaluator implements IConditionEvaluator {
             }
             return matchesSign(operator, Double.compare(0.0, expected.getAsDouble()));
         }
-        // Preserved quirk: $lt treats a digit-only attribute string as a number.
         if (operator == Operator.LT && actual.getAsString().toLowerCase().matches("\\d+")) {
             return Double.parseDouble(actual.getAsString()) < expected.getAsDouble();
         }

--- a/lib/src/main/java/growthbook/sdk/java/evaluators/ConditionEvaluator.java
+++ b/lib/src/main/java/growthbook/sdk/java/evaluators/ConditionEvaluator.java
@@ -22,8 +22,6 @@ import java.util.regex.Pattern;
 @Slf4j
 public class ConditionEvaluator implements IConditionEvaluator {
 
-    private final GrowthBookJsonUtils jsonUtils = GrowthBookJsonUtils.getInstance();
-
     /**
      * Evaluate a condition for a set of user attributes based on the provided condition.
      * The condition syntax closely resembles MongoDB's syntax.
@@ -34,14 +32,11 @@ public class ConditionEvaluator implements IConditionEvaluator {
      * @return Whether the condition should be true for the user
      */
     @Override
-    public Boolean evaluateCondition(
-        JsonObject attributes,
-        JsonObject conditionJson,
-        @Nullable JsonObject savedGroups) {
+    public Boolean evaluateCondition(JsonObject attributes, JsonObject conditionJson, @Nullable JsonObject savedGroups) {
         try {
+            // The condition matches only if every top-level entry is satisfied.
             return conditionJson.entrySet().stream()
-                    .allMatch(entry ->
-                        matchesConditionEntry(entry.getKey(), entry.getValue(), attributes, savedGroups));
+                    .allMatch(entry -> matchesConditionEntry(entry.getKey(), entry.getValue(), attributes, savedGroups));
         } catch (Exception exception) {
             log.error(exception.getMessage(), exception);
             return false;
@@ -53,23 +48,18 @@ public class ConditionEvaluator implements IConditionEvaluator {
      * handled by its strategy (recursing back through this evaluator); any other key is treated as
      * an attribute path and compared as a leaf value.
      */
-    private boolean matchesConditionEntry(
-        String key, JsonElement value,
-        JsonObject attributes,
-        @Nullable JsonObject savedGroups) {
+    private boolean matchesConditionEntry(String key, JsonElement value, JsonObject attributes, @Nullable JsonObject savedGroups) {
         Condition operator = Condition.fromValue(key);
         return operator != null
                 ? operator.apply(attributes, value, savedGroups, this)
-                : evalConditionValue(value, (JsonElement) getPath(attributes, key), savedGroups);
+                : evalConditionValue(value, getPath(attributes, key), savedGroups);
     }
 
     /**
-     * This accepts a parsed JSON object as input and returns true if every key in the object starts with $.
-     *
      * @param object The object to evaluate
-     * @return if all keys start with $
+     * @return true if the object is empty or every key is an operator (starts with {@code $})
      */
-    public Boolean isOperatorObject(JsonElement object) {
+    public boolean isOperatorObject(JsonElement object) {
         if (!object.isJsonObject()) {
             return false;
         }
@@ -78,20 +68,21 @@ public class ConditionEvaluator implements IConditionEvaluator {
     }
 
     /**
-     * Given attributes and a dot-separated path string,
+     * Resolves a dot-separated path against the attributes.
      *
      * @param attributes User attributes
-     * @param path       String path, e.g. path.to.something
-     * @return the value at that path (or null if the path doesn't exist)
+     * @param path       String path, e.g. {@code path.to.something}
+     * @return the value at that path, or {@code null} if the path doesn't exist
      */
     @Nullable
-    public Object getPath(JsonElement attributes, String path) {
+    public JsonElement getPath(JsonElement attributes, String path) {
         if (Objects.equals(path, "")) {
             return null;
         }
 
         JsonElement element = attributes;
         for (String segment : path.split("\\.")) {
+            // Only objects can be descended into; null, arrays and primitives mean "no value here".
             if (!(element instanceof JsonObject)) {
                 return null;
             }
@@ -119,7 +110,7 @@ public class ConditionEvaluator implements IConditionEvaluator {
      * @param expected       The condition value to compare against
      * @return if it's a match
      */
-    Boolean evalOperatorCondition(String operatorString, @Nullable JsonElement actual, JsonElement expected, @Nullable JsonObject savedGroups) {
+    boolean evalOperatorCondition(String operatorString, @Nullable JsonElement actual, JsonElement expected, @Nullable JsonObject savedGroups) {
         Operator operator = Operator.fromString(operatorString);
         if (operator == null) return false;
 
@@ -199,7 +190,7 @@ public class ConditionEvaluator implements IConditionEvaluator {
     /**
      * {@code $in}/{@code $nin} (and their case-insensitive variants): tests array membership.
      */
-    private Boolean evalMembership(Operator operator, @Nullable JsonElement actual, JsonElement expected) {
+    private boolean evalMembership(Operator operator, @Nullable JsonElement actual, JsonElement expected) {
         if (actual == null || !expected.isJsonArray()) {
             return false;
         }
@@ -211,18 +202,19 @@ public class ConditionEvaluator implements IConditionEvaluator {
     /**
      * {@code $gt}/{@code $gte}/{@code $lt}/{@code $lte}: numeric or lexical comparison.
      */
-    private Boolean evalComparison(Operator operator, @Nullable JsonElement actual, JsonElement expected, DataType attributeDataType) {
+    private boolean evalComparison(Operator operator, @Nullable JsonElement actual, JsonElement expected, DataType attributeDataType) {
         if (actual == null || DataType.NULL.equals(attributeDataType)) {
             if (expected.isJsonPrimitive() && !expected.getAsJsonPrimitive().isNumber()) {
                 return false;
             }
             return matchesSign(operator, Double.compare(0.0, expected.getAsDouble()));
         }
+        // Preserved quirk: $lt treats a digit-only attribute string as a number.
         if (operator == Operator.LT && actual.getAsString().toLowerCase().matches("\\d+")) {
             return Double.parseDouble(actual.getAsString()) < expected.getAsDouble();
         }
         if (actual.getAsJsonPrimitive().isNumber()) {
-            return matchesSign(operator, Float.compare(actual.getAsNumber().floatValue(), expected.getAsNumber().floatValue()));
+            return matchesSign(operator, Double.compare(actual.getAsNumber().doubleValue(), expected.getAsNumber().doubleValue()));
         }
         if (actual.getAsJsonPrimitive().isString()) {
             return matchesSign(operator, actual.getAsString().compareTo(expected.getAsString()));
@@ -234,7 +226,7 @@ public class ConditionEvaluator implements IConditionEvaluator {
      * {@code $vgt}/{@code $vgte}/{@code $vlt}/{@code $vlte}/{@code $vne}/{@code $veq}:
      * compares padded semantic-version strings.
      */
-    private Boolean evalVersion(Operator operator, @Nullable JsonElement actual, JsonElement expected, DataType attributeDataType) {
+    private boolean evalVersion(Operator operator, @Nullable JsonElement actual, JsonElement expected, DataType attributeDataType) {
         if (actual == null || expected == null || DataType.NULL.equals(attributeDataType)) {
             return false;
         }
@@ -254,14 +246,14 @@ public class ConditionEvaluator implements IConditionEvaluator {
     /**
      * {@code $inGroup}/{@code $notInGroup}: membership in a named saved group (empty if unknown).
      */
-    private Boolean evalSavedGroup(Operator operator, @Nullable JsonElement actual, @Nullable JsonElement expected, @Nullable JsonObject savedGroups) {
+    private boolean evalSavedGroup(Operator operator, @Nullable JsonElement actual, @Nullable JsonElement expected, @Nullable JsonObject savedGroups) {
         if (actual == null || expected == null) {
             return false;
         }
         JsonElement group = savedGroups != null ? savedGroups.get(expected.getAsString()) : null;
         JsonArray groupValues = group != null ? group.getAsJsonArray() : new JsonArray();
-        boolean inGroup = isIn(actual, groupValues, false);
-        return operator == Operator.NOT_IN_GROUP ? !inGroup : inGroup;
+        boolean negate = operator == Operator.NOT_IN_GROUP;
+        return negate != isIn(actual, groupValues, false);
     }
 
     /**
@@ -278,50 +270,32 @@ public class ConditionEvaluator implements IConditionEvaluator {
     }
 
     /**
-     * Compares two primitives for equality.
-     *
-     * @param a        left side primitive
-     * @param b        right side primitive
-     * @param dataType The data type of the primitives
-     * @return if they are equal
+     * Compares two primitives for equality, based on their data type.
      */
-    Boolean arePrimitivesEqual(JsonPrimitive a, JsonPrimitive b, DataType dataType) {
+    private boolean arePrimitivesEqual(JsonPrimitive a, JsonPrimitive b, DataType dataType) {
         switch (dataType) {
             case STRING:
                 return a.getAsString().equals(b.getAsString());
-
             case NUMBER:
-                return Objects.equals(a.getAsNumber(), b.getAsNumber());
-
+                return Double.compare(a.getAsDouble(), b.getAsDouble()) == 0;
             case BOOLEAN:
                 return a.getAsBoolean() == b.getAsBoolean();
-
-            case ARRAY:
-            case OBJECT:
-            case NULL:
-            case UNDEFINED:
-            case UNKNOWN:
-                //
+            default:
+                log.info("Unsupported data type {}", dataType);
+                return false;
         }
-
-        log.info("\nUnsupported data type {}", dataType);
-
-        return false;
     }
 
     /**
-     * If conditionValue is an object and isOperatorObject(conditionValue) is true
-     * Loop over each key/value pair
-     * If evalOperatorCondition(key, attributeValue, value) is false, return false
-     * Return true
-     * Else, do a deep comparison between attributeValue and conditionValue.
+     * If conditionValue is an operator object, every operator must match the attributeValue.
+     * Otherwise this is a deep equality comparison between the two values.
      *
      * @param conditionValue Object or primitive
      * @param attributeValue Object or primitive
-     * @return true if equal
+     * @param inSensitive    if true, top-level string comparisons are case-insensitive
+     * @return true if equal / matched
      */
-    Boolean evalConditionValue(JsonElement conditionValue, @Nullable JsonElement attributeValue, @Nullable JsonObject savedGroups, boolean inSensitive) {
-
+    boolean evalConditionValue(JsonElement conditionValue, @Nullable JsonElement attributeValue, @Nullable JsonObject savedGroups, boolean inSensitive) {
         if (conditionValue == null) {
             return attributeValue == null;
         }
@@ -336,7 +310,7 @@ public class ConditionEvaluator implements IConditionEvaluator {
 
         switch (conditionValueElementType) {
             case STRING:
-                return isMatchingPrimitive(conditionValue, attributeValue, JsonPrimitive::getAsJsonPrimitive);
+                return isMatchingPrimitive(conditionValue, attributeValue, JsonPrimitive::getAsString);
 
             case NUMBER:
                 return isMatchingPrimitive(conditionValue, attributeValue, JsonPrimitive::getAsDouble);
@@ -346,25 +320,20 @@ public class ConditionEvaluator implements IConditionEvaluator {
 
             case ARRAY:
                 return attributeValue != null && attributeValue.isJsonArray()
-                        && jsonUtils.gson.toJson(conditionValue).equals(jsonUtils.gson.toJson(attributeValue));
+                        && conditionValue.equals(attributeValue);
 
             case OBJECT:
                 JsonObject conditionValueObject = conditionValue.getAsJsonObject();
                 if (isOperatorObject(conditionValueObject)) {
                     return conditionValueObject.entrySet().stream()
-                            .allMatch(entry -> evalOperatorCondition(
-                                            entry.getKey(),
-                                            attributeValue,
-                                            entry.getValue(),
-                                            savedGroups
-                                    )
-                            );
+                            .allMatch(entry -> evalOperatorCondition(entry.getKey(), attributeValue, entry.getValue(), savedGroups));
                 }
-                return attributeValue != null && attributeValue.isJsonObject() &&
-                        jsonUtils.gson.toJson(conditionValue).equals(jsonUtils.gson.toJson(attributeValue));
+                return attributeValue != null && attributeValue.isJsonObject()
+                        && conditionValue.equals(attributeValue);
 
             case NULL:
                 return attributeValue == null || attributeValue.isJsonNull();
+
             case UNDEFINED:
             case UNKNOWN:
             default:
@@ -372,131 +341,108 @@ public class ConditionEvaluator implements IConditionEvaluator {
         }
     }
 
-    Boolean evalConditionValue(JsonElement conditionValue, @Nullable JsonElement attributeValue, @Nullable JsonObject savedGroups) {
+    boolean evalConditionValue(JsonElement conditionValue, @Nullable JsonElement attributeValue, @Nullable JsonObject savedGroups) {
         return evalConditionValue(conditionValue, attributeValue, savedGroups, false);
     }
 
-    Boolean elemMatch(JsonElement actual, JsonElement expected, @Nullable JsonObject savedGroups) {
+    /**
+     * {@code $elemMatch}: true if any element of the {@code actual} array matches the expected
+     * operator object / nested condition.
+     */
+    private boolean elemMatch(JsonElement actual, JsonElement expected, @Nullable JsonObject savedGroups) {
         if (!actual.isJsonArray()) {
             return false;
         }
-
-        JsonArray actualArray = actual.getAsJsonArray();
         boolean isOperator = isOperatorObject(expected);
-
-        for (JsonElement actualElement : actualArray) {
-            if (isOperator) {
-                if (evalConditionValue(expected, actualElement, savedGroups)) {
-                    return true;
-                }
-            } else if (evaluateCondition(actualElement.getAsJsonObject(), expected.getAsJsonObject(), savedGroups)) {
+        for (JsonElement element : actual.getAsJsonArray()) {
+            boolean matched = isOperator
+                    ? evalConditionValue(expected, element, savedGroups)
+                    : evaluateCondition(element.getAsJsonObject(), expected.getAsJsonObject(), savedGroups);
+            if (matched) {
                 return true;
-            }
-        }
-
-        return false;
-    }
-
-    private Boolean isIn(JsonElement actual, JsonArray expected, boolean inSensitive) {
-        if (actual == null) return false;
-
-        if (!actual.isJsonArray()) {
-            // actual is a primitive — check if expected contains it
-            if (inSensitive) {
-                for (JsonElement exp : expected) {
-                    if (caseFold(actual).equals(caseFold(exp))) {
-                        return true;
-                    }
-                }
-                return false;
-            }
-            return expected.contains(actual);
-        }
-
-        // actual is an array — check if any actual element matches any expected element
-        JsonArray actualArr = actual.getAsJsonArray();
-
-        if (actualArr.isEmpty()) return false;
-
-        for (JsonElement actualItem : actualArr) {
-            for (JsonElement expectedItem : expected) {
-                if (inSensitive) {
-                    if (caseFold(actualItem).equals(caseFold(expectedItem))) {
-                        return true;
-                    }
-                } else {
-                    if (Objects.equals(actualItem, expectedItem)) {
-                        return true;
-                    }
-                }
             }
         }
         return false;
     }
 
     /**
-     * Checks that for every element in expected, there is at least one matching element in actual.
-     * Uses evalConditionValue for comparison, which supports operator objects.
-     *
-     * @param actual      the attribute value (must be an array)
-     * @param expected    the condition array — every item must match at least one in actual
-     * @param savedGroups saved groups for group-based conditions
-     * @param inSensitive if true, string comparisons are case-insensitive
-     * @return true if all expected items are matched
+     * Tests whether {@code actual} (a primitive or array) is contained in the {@code expected} array.
      */
-    private Boolean isInAll(JsonArray actual, JsonArray expected, @Nullable JsonObject savedGroups, boolean inSensitive) {
-        for (int i = 0; i < expected.size(); i++) {
-            boolean passed = false;
-            for (int j = 0; j < actual.size(); j++) {
-                if (evalConditionValue(expected.get(i), actual.get(j), savedGroups, inSensitive)) {
-                    passed = true;
+    private boolean isIn(JsonElement actual, JsonArray expected, boolean caseInsensitive) {
+        if (actual == null) {
+            return false;
+        }
+        if (!actual.isJsonArray()) {
+            return containsElement(expected, actual, caseInsensitive);
+        }
+        for (JsonElement item : actual.getAsJsonArray()) {
+            if (containsElement(expected, item, caseInsensitive)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean containsElement(JsonArray candidates, JsonElement value, boolean caseInsensitive) {
+        for (JsonElement candidate : candidates) {
+            if (elementsEqual(value, candidate, caseInsensitive)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean elementsEqual(JsonElement a, JsonElement b, boolean caseInsensitive) {
+        return caseInsensitive
+                ? Objects.equals(caseFold(a), caseFold(b))
+                : Objects.equals(a, b);
+    }
+
+    /**
+     * {@code $all}/{@code $allI}: every expected element must match at least one actual element.
+     */
+    private boolean isInAll(JsonArray actual, JsonArray expected, @Nullable JsonObject savedGroups, boolean inSensitive) {
+        for (JsonElement expectedItem : expected) {
+            boolean matched = false;
+            for (JsonElement actualItem : actual) {
+                if (evalConditionValue(expectedItem, actualItem, savedGroups, inSensitive)) {
+                    matched = true;
                     break;
                 }
             }
-            if (!passed) return false;
+            if (!matched) {
+                return false;
+            }
         }
         return true;
     }
 
-    private <T> boolean isMatchingPrimitive(
-            JsonElement conditionValue,
-            JsonElement attributeValue,
-            Function<JsonPrimitive, T> extractor) {
+    private <T> boolean isMatchingPrimitive(JsonElement conditionValue, @Nullable JsonElement attributeValue, Function<JsonPrimitive, T> extractor) {
         return attributeValue != null
                 && attributeValue.isJsonPrimitive()
-                && extractor.apply(
-                        conditionValue.getAsJsonPrimitive())
-                .equals(extractor.apply(
-                        attributeValue.getAsJsonPrimitive()));
+                && extractor.apply(conditionValue.getAsJsonPrimitive())
+                        .equals(extractor.apply(attributeValue.getAsJsonPrimitive()));
     }
 
-    private static Boolean evalRegex(@Nullable JsonElement actual,
-                                     JsonElement expected,
-                                     DataType attributeDataType,
-                                     boolean caseInsensitive,
-                                     boolean negate) {
-        if (actual == null || DataType.NULL.equals(attributeDataType)) return negate;
-
+    private static boolean evalRegex(@Nullable JsonElement actual, JsonElement expected, DataType attributeDataType, boolean caseInsensitive, boolean negate) {
+        if (actual == null || DataType.NULL.equals(attributeDataType)) {
+            return negate;
+        }
         int flags = caseInsensitive ? Pattern.CASE_INSENSITIVE : 0;
-
         try {
-            Pattern pattern = Pattern.compile(expected.getAsString(), flags);
-            Matcher matcher = pattern.matcher(actual.getAsString());
-            boolean matches = matcher.find();
-            return negate != matches;
+            Matcher matcher = Pattern.compile(expected.getAsString(), flags).matcher(actual.getAsString());
+            return negate != matcher.find();
         } catch (Exception e) {
             return negate;
         }
     }
 
     /**
-     * Folds a JsonElement to lowercase if it's a string. Used where you need a folded value
-     * rather than a comparison.
+     * Lowercases a string primitive; other elements (including {@code null}) are returned unchanged.
      */
-    private JsonElement caseFold(@Nullable JsonElement value) {
-        if (value != null
-                && value.isJsonPrimitive()
-                && value.getAsJsonPrimitive().isString()) {
+    @Nullable
+    private static JsonElement caseFold(@Nullable JsonElement value) {
+        if (value != null && value.isJsonPrimitive() && value.getAsJsonPrimitive().isString()) {
             return new JsonPrimitive(value.getAsString().toLowerCase());
         }
         return value;

--- a/lib/src/main/java/growthbook/sdk/java/evaluators/IConditionEvaluator.java
+++ b/lib/src/main/java/growthbook/sdk/java/evaluators/IConditionEvaluator.java
@@ -4,6 +4,14 @@ import com.google.gson.JsonObject;
 
 import javax.annotation.Nullable;
 
-interface IConditionEvaluator {
+/**
+ * <b>INTERNAL</b>: Recursion entry point for condition evaluation.
+ *
+ * <p>Logical-operator strategies receive an instance of this interface and call back into
+ * {@link #evaluateCondition} for nested sub-conditions, so the recursion funnels through a
+ * single point (the Interpreter pattern) instead of each strategy depending on the concrete
+ * evaluator.</p>
+ */
+public interface IConditionEvaluator {
     Boolean evaluateCondition(JsonObject attributesJson, JsonObject conditionJson, @Nullable JsonObject savedGroups);
 }

--- a/lib/src/main/java/growthbook/sdk/java/exception/GrowthBookInitializationException.java
+++ b/lib/src/main/java/growthbook/sdk/java/exception/GrowthBookInitializationException.java
@@ -1,0 +1,16 @@
+package growthbook.sdk.java.exception;
+
+import lombok.Getter;
+
+/**
+ * Indicates that a GrowthBook client could not initialize its features repository.
+ */
+@Getter
+public class GrowthBookInitializationException extends RuntimeException {
+    private final FeatureFetchException.FeatureFetchErrorCode errorCode;
+
+    public GrowthBookInitializationException(FeatureFetchException cause) {
+        super("Failed to initialize features repository", cause);
+        this.errorCode = cause.getErrorCode();
+    }
+}

--- a/lib/src/main/java/growthbook/sdk/java/listener/FeatureRefreshListener.java
+++ b/lib/src/main/java/growthbook/sdk/java/listener/FeatureRefreshListener.java
@@ -1,0 +1,17 @@
+package growthbook.sdk.java.listener;
+
+import growthbook.sdk.java.model.FeatureRefreshEvent;
+
+/**
+ * Listener for metadata-only feature refresh events exposed by the client-level API.
+ *
+ * <p>Client-level listeners are dispatched off the refresh thread: on a dedicated daemon thread by
+ * default, or on {@code Options.featureRefreshListenerExecutor} when supplied. Listeners added
+ * directly on a repository always run synchronously on the refresh thread. Anything a listener
+ * throws — exceptions and errors alike — is logged and isolated, and never fails the SDK refresh
+ * operation.
+ */
+@FunctionalInterface
+public interface FeatureRefreshListener {
+    void onRefresh(FeatureRefreshEvent event);
+}

--- a/lib/src/main/java/growthbook/sdk/java/listener/FeatureRefreshSubscription.java
+++ b/lib/src/main/java/growthbook/sdk/java/listener/FeatureRefreshSubscription.java
@@ -1,0 +1,10 @@
+package growthbook.sdk.java.listener;
+
+/**
+ * Handle used to unsubscribe a feature refresh listener.
+ */
+@FunctionalInterface
+public interface FeatureRefreshSubscription extends AutoCloseable {
+    @Override
+    void close();
+}

--- a/lib/src/main/java/growthbook/sdk/java/listener/internal/FeatureRefreshListenerDispatcher.java
+++ b/lib/src/main/java/growthbook/sdk/java/listener/internal/FeatureRefreshListenerDispatcher.java
@@ -1,0 +1,149 @@
+package growthbook.sdk.java.listener.internal;
+
+import growthbook.sdk.java.listener.FeatureRefreshListener;
+import growthbook.sdk.java.listener.FeatureRefreshSubscription;
+import growthbook.sdk.java.model.FeatureRefreshEvent;
+import lombok.extern.slf4j.Slf4j;
+
+import javax.annotation.Nullable;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.Executor;
+import java.util.concurrent.RejectedExecutionException;
+
+/**
+ * Internal dispatcher for feature refresh listeners.
+ * Listener failures are isolated from the SDK refresh flow: a failing listener is logged and
+ * remaining listeners are still notified. Executor rejection falls back to synchronous dispatch
+ * instead of surfacing through repository or client refresh APIs.
+ */
+@Slf4j
+public final class FeatureRefreshListenerDispatcher {
+
+    private final CopyOnWriteArrayList<FeatureRefreshListener> listeners = new CopyOnWriteArrayList<>();
+
+    /**
+     * Adds a listener if it is non-null and not already registered.
+     *
+     * @param listener listener to register
+     */
+    public void add(FeatureRefreshListener listener) {
+        if (listener != null) {
+            listeners.addIfAbsent(listener);
+        }
+    }
+
+    /**
+     * Adds a listener and returns an idempotent subscription handle that removes it.
+     *
+     * @param listener listener to register
+     * @return subscription handle
+     */
+    public FeatureRefreshSubscription subscribe(FeatureRefreshListener listener) {
+        if (listener == null || !listeners.addIfAbsent(listener)) {
+            return () -> {
+            };
+        }
+        return () -> listeners.remove(listener);
+    }
+
+    /**
+     * Removes a registered listener.
+     *
+     * @param listener listener to remove
+     */
+    public void remove(FeatureRefreshListener listener) {
+        if (listener != null) {
+            listeners.remove(listener);
+        }
+    }
+
+    /**
+     * Removes all registered listeners.
+     */
+    public void clear() {
+        listeners.clear();
+    }
+
+    /**
+     * @return true when no listeners are registered
+     */
+    public boolean hasNoListeners() {
+        return listeners.isEmpty();
+    }
+
+    /**
+     * Publishes an event synchronously.
+     *
+     * @param event refresh event to publish
+     */
+    public void publish(FeatureRefreshEvent event) {
+        publish(event, null);
+    }
+
+    /**
+     * Publishes an event using the supplied executor when present, otherwise synchronously.
+     *
+     * @param event refresh event to publish
+     * @param executor optional executor for listener callbacks
+     */
+    public void publish(FeatureRefreshEvent event, @Nullable Executor executor) {
+        for (FeatureRefreshListener listener : listeners) {
+            Runnable notification = () -> notifyListener(listener, event);
+            if (executor == null) {
+                notification.run();
+                continue;
+            }
+            scheduleNotification(executor, listener, event, notification);
+        }
+    }
+
+    private void scheduleNotification(
+            Executor executor,
+            FeatureRefreshListener listener,
+            FeatureRefreshEvent event,
+            Runnable notification
+    ) {
+        try {
+            executor.execute(notification);
+        } catch (RejectedExecutionException e) {
+            log.warn(
+                    "Feature refresh listener executor rejected listener={}; running synchronously. source={}, successful={}, featuresChanged={}",
+                    listenerName(listener),
+                    event.getSource(),
+                    event.isSuccessful(),
+                    event.isFeaturesChanged(),
+                    e
+            );
+            notification.run();
+        } catch (RuntimeException e) {
+            log.warn(
+                    "Unable to schedule feature refresh listener={}; running synchronously. source={}, successful={}, featuresChanged={}",
+                    listenerName(listener),
+                    event.getSource(),
+                    event.isSuccessful(),
+                    event.isFeaturesChanged(),
+                    e
+            );
+            notification.run();
+        }
+    }
+
+    private void notifyListener(FeatureRefreshListener listener, FeatureRefreshEvent event) {
+        try {
+            listener.onRefresh(event);
+        } catch (Throwable e) {
+            log.warn(
+                    "Feature refresh listener {} failed while handling source={}, successful={}, featuresChanged={}",
+                    listenerName(listener),
+                    event.getSource(),
+                    event.isSuccessful(),
+                    event.isFeaturesChanged(),
+                    e
+            );
+        }
+    }
+
+    private String listenerName(FeatureRefreshListener listener) {
+        return listener == null ? "<null>" : listener.getClass().getName();
+    }
+}

--- a/lib/src/main/java/growthbook/sdk/java/model/FeatureRefreshEvent.java
+++ b/lib/src/main/java/growthbook/sdk/java/model/FeatureRefreshEvent.java
@@ -1,0 +1,134 @@
+package growthbook.sdk.java.model;
+
+import java.time.Instant;
+import javax.annotation.Nullable;
+
+import growthbook.sdk.java.listener.FeatureRefreshListener;
+import growthbook.sdk.java.repository.FeatureRefreshStrategy;
+import lombok.Getter;
+import lombok.ToString;
+
+/**
+ * Metadata-only event delivered to {@link FeatureRefreshListener}s after a feature refresh attempt.
+ * A cache fallback after an upstream failure is unsuccessful with {@code loadedFromCache} set to true.
+ *
+ * <p>This is an immutable value carrier; identity equality is used. It intentionally does not define
+ * field-based {@code equals}/{@code hashCode}, since the {@code error} and {@code timestamp} fields
+ * make two refresh attempts effectively never equal.
+ */
+@Getter
+@ToString
+public class FeatureRefreshEvent {
+    private final boolean successful;
+    private final boolean featuresChanged;
+    private final boolean loadedFromCache;
+    @Nullable
+    private final Throwable error;
+    private final int activeFeatureCount;
+    private final FeatureRefreshSource source;
+    @Nullable
+    private final FeatureRefreshStrategy refreshStrategy;
+    private final long durationMillis;
+    private final Instant timestamp;
+
+    public FeatureRefreshEvent(
+            boolean successful,
+            boolean featuresChanged,
+            boolean loadedFromCache,
+            @Nullable Throwable error,
+            int activeFeatureCount,
+            FeatureRefreshSource source,
+            @Nullable FeatureRefreshStrategy refreshStrategy,
+            long durationMillis,
+            Instant timestamp
+    ) {
+        this.successful = successful;
+        this.featuresChanged = featuresChanged;
+        this.loadedFromCache = loadedFromCache;
+        this.error = error;
+        this.activeFeatureCount = activeFeatureCount;
+        this.source = source;
+        this.refreshStrategy = refreshStrategy;
+        this.durationMillis = Math.max(0, durationMillis);
+        this.timestamp = timestamp == null ? Instant.now() : timestamp;
+    }
+
+    public static FeatureRefreshEvent success(
+            boolean featuresChanged,
+            boolean loadedFromCache,
+            int activeFeatureCount,
+            FeatureRefreshSource source,
+            @Nullable FeatureRefreshStrategy refreshStrategy
+    ) {
+        return success(
+                featuresChanged,
+                loadedFromCache,
+                activeFeatureCount,
+                source,
+                refreshStrategy,
+                0
+        );
+    }
+
+    public static FeatureRefreshEvent success(
+            boolean featuresChanged,
+            boolean loadedFromCache,
+            int activeFeatureCount,
+            FeatureRefreshSource source,
+            @Nullable FeatureRefreshStrategy refreshStrategy,
+            long durationMillis
+    ) {
+        return new FeatureRefreshEvent(
+                true,
+                featuresChanged,
+                loadedFromCache,
+                null,
+                activeFeatureCount,
+                source,
+                refreshStrategy,
+                durationMillis,
+                Instant.now()
+        );
+    }
+
+    public static FeatureRefreshEvent failure(
+            Throwable error,
+            boolean featuresChanged,
+            boolean loadedFromCache,
+            int activeFeatureCount,
+            FeatureRefreshSource source,
+            @Nullable FeatureRefreshStrategy refreshStrategy
+    ) {
+        return failure(
+                error,
+                featuresChanged,
+                loadedFromCache,
+                activeFeatureCount,
+                source,
+                refreshStrategy,
+                0
+        );
+    }
+
+    public static FeatureRefreshEvent failure(
+            Throwable error,
+            boolean featuresChanged,
+            boolean loadedFromCache,
+            int activeFeatureCount,
+            FeatureRefreshSource source,
+            @Nullable FeatureRefreshStrategy refreshStrategy,
+            long durationMillis
+    ) {
+        return new FeatureRefreshEvent(
+                false,
+                featuresChanged,
+                loadedFromCache,
+                error,
+                activeFeatureCount,
+                source,
+                refreshStrategy,
+                durationMillis,
+                Instant.now()
+        );
+    }
+}

--- a/lib/src/main/java/growthbook/sdk/java/model/FeatureRefreshSource.java
+++ b/lib/src/main/java/growthbook/sdk/java/model/FeatureRefreshSource.java
@@ -1,0 +1,15 @@
+package growthbook.sdk.java.model;
+
+/**
+ * Identifies what triggered a feature refresh.
+ *
+ * <p>The source reflects the trigger only. Whether the delivered data came from cache is reported
+ * separately by {@link FeatureRefreshEvent#isLoadedFromCache()}.
+ */
+public enum FeatureRefreshSource {
+    INITIALIZATION,
+    MANUAL,
+    POLLING,
+    SSE,
+    REMOTE_EVALUATION
+}

--- a/lib/src/main/java/growthbook/sdk/java/multiusermode/GrowthBookClient.java
+++ b/lib/src/main/java/growthbook/sdk/java/multiusermode/GrowthBookClient.java
@@ -1,169 +1,218 @@
 package growthbook.sdk.java.multiusermode;
 
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
 import growthbook.sdk.java.callback.ExperimentRunCallback;
-import growthbook.sdk.java.callback.FeatureRefreshCallback;
 import growthbook.sdk.java.evaluators.ExperimentEvaluator;
 import growthbook.sdk.java.evaluators.FeatureEvaluator;
 import growthbook.sdk.java.exception.FeatureFetchException;
-import growthbook.sdk.java.model.AssignedExperiment;
+import growthbook.sdk.java.listener.FeatureRefreshListener;
+import growthbook.sdk.java.listener.FeatureRefreshSubscription;
 import growthbook.sdk.java.model.Experiment;
 import growthbook.sdk.java.model.ExperimentResult;
+import growthbook.sdk.java.model.FeatureRefreshEvent;
 import growthbook.sdk.java.model.FeatureResult;
 import growthbook.sdk.java.model.RequestBodyForRemoteEval;
 import growthbook.sdk.java.multiusermode.configurations.EvaluationContext;
-import growthbook.sdk.java.multiusermode.configurations.GlobalContext;
 import growthbook.sdk.java.multiusermode.configurations.Options;
 import growthbook.sdk.java.multiusermode.configurations.UserContext;
+import growthbook.sdk.java.multiusermode.internal.ExperimentSubscriptionManager;
+import growthbook.sdk.java.multiusermode.internal.FeatureRefreshListenerRegistry;
+import growthbook.sdk.java.multiusermode.internal.FeatureRepositoryProvider;
+import growthbook.sdk.java.multiusermode.internal.GlobalContextManager;
+import growthbook.sdk.java.multiusermode.internal.ManagedListenerExecutor;
 import growthbook.sdk.java.repository.GBFeaturesRepository;
-import growthbook.sdk.java.sandbox.CacheManagerFactory;
-import growthbook.sdk.java.sandbox.CacheMode;
-import growthbook.sdk.java.sandbox.GbCacheManager;
 import growthbook.sdk.java.util.GrowthBookJsonUtils;
 import lombok.extern.slf4j.Slf4j;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.Objects;
-import java.util.stream.Collectors;
 
+/**
+ * Multi-user GrowthBook SDK facade.
+ *
+ * <p>The client owns one feature repository per instance. Repository initialization is lazy,
+ * idempotent, and shared by concurrent callers. Feature evaluation reads from the most recent
+ * global context built from repository data.
+ */
 @Slf4j
 public class GrowthBookClient {
 
     private final Options options;
     private final FeatureEvaluator featureEvaluator;
-    private final ExperimentEvaluator experimentEvaluatorEvaluator;
-    private static GBFeaturesRepository repository;
-    private List<ExperimentRunCallback> callbacks;
-    private final Map<String, AssignedExperiment> assigned;
-    private GlobalContext globalContext;
+    private final ExperimentEvaluator experimentEvaluator;
+    private final GlobalContextManager globalContextManager;
+    private final ExperimentSubscriptionManager experimentSubscriptions;
+    private final FeatureRefreshListenerRegistry featureRefreshListeners;
+    private final FeatureRepositoryProvider featureRepositoryProvider;
+    private final ManagedListenerExecutor listenerExecutor;
 
+    /**
+     * Creates a client with default options.
+     */
     public GrowthBookClient() {
         this(Options.builder().build());
     }
 
+    /**
+     * Creates a client with the supplied options.
+     *
+     * @param opts client options; null falls back to default options
+     */
     public GrowthBookClient(Options opts) {
         this.options = opts == null ? Options.builder().build() : opts;
 
-        this.assigned = new HashMap<>();
-        this.callbacks = new ArrayList<>();
         this.featureEvaluator = new FeatureEvaluator();
-        this.experimentEvaluatorEvaluator = new ExperimentEvaluator();
-        this.callbacks = new ArrayList<>();
+        this.experimentEvaluator = new ExperimentEvaluator();
+        this.globalContextManager = new GlobalContextManager(this.options);
+        this.experimentSubscriptions = new ExperimentSubscriptionManager();
+        this.listenerExecutor = ManagedListenerExecutor.resolve(this.options.getFeatureRefreshListenerExecutor());
+        this.featureRefreshListeners = new FeatureRefreshListenerRegistry(listenerExecutor.executor());
+        this.featureRepositoryProvider = new FeatureRepositoryProvider(
+                this.options,
+                this::registerRefreshHandlers,
+                this.globalContextManager::initialize
+        );
     }
 
+    /**
+     * Initializes the feature repository and global evaluation context.
+     *
+     * <p>Calling this method multiple times is safe. Concurrent calls share the same repository
+     * initialization attempt. If initialization fails, a later call may try to initialize again.
+     *
+     * @return true when the repository is initialized and ready for evaluation
+     */
     public boolean initialize() {
-        boolean isReady = false;
-        try {
-
-            if (repository == null) {
-                GbCacheManager cm = this.options.getCacheManager() != null
-                        ? this.options.getCacheManager()
-                        : CacheManagerFactory.create(this.options.getCacheMode(), this.options.getCacheDirectory()
-                        );
-
-                repository = GBFeaturesRepository.builder()
-                        .apiHost(this.options.getApiHost())
-                        .clientKey(this.options.getClientKey())
-                        .decryptionKey(this.options.getDecryptionKey())
-                        .refreshStrategy(this.options.getRefreshStrategy())
-                        .swrTtlSeconds(this.options.getSwrTtlSeconds())
-                        .isCacheDisabled(this.options.getIsCacheDisabled() || this.options.getCacheMode() == CacheMode.NONE)
-                        .cacheManager(cm)
-                        // if we don't want to pre-fetch for remote eval we can delete this line
-                        .requestBodyForRemoteEval(configurePayloadForRemoteEval(this.options))
-                        .build();
-
-                // Add featureRefreshCallback
-                repository.onFeaturesRefresh(this.options.getFeatureRefreshCallback());
-
-                // Add a callback to refresh the global context
-                repository.onFeaturesRefresh(this.refreshGlobalContext());
-
-                try {
-                    repository.initialize();
-                } catch (FeatureFetchException e) {
-                    log.error("Failed to initialize features repository", e);
-                    throw new RuntimeException(e);
-                }
-
-                // instantiate a global context that holds features & savedGroups.
-                this.globalContext = GlobalContext.builder()
-                        .features(repository.getParsedFeatures())
-                        .savedGroups(repository.getParsedSavedGroups())
-                        .enabled(this.options.getEnabled())
-                        .qaMode(this.options.getIsQaMode())
-                        .forcedFeatureValues(this.options.getGlobalForcedFeatureValues())
-                        .forcedVariations(this.options.getGlobalForcedVariationsMap())
-                        .build();
-
-                isReady = repository.getInitialized();
-                log.info("GrowthBookClient initialized repository and registered feature refresh callbacks.");
-            }
-        } catch (Exception e) {
-            log.error("Failed to initialize growthbook instance", e);
-        }
-        return isReady;
+        GBFeaturesRepository repository = featureRepositoryProvider.initialize();
+        return repository != null && repository.getInitialized();
     }
 
+    /**
+     * Replaces global attributes used for future evaluations.
+     *
+     * @param attributes JSON string containing global attributes
+     */
     public void setGlobalAttributes(String attributes) {
         this.options.setGlobalAttributes(attributes);
     }
 
+    /**
+     * Replaces globally forced feature values used for future evaluations.
+     *
+     * @param forceFeatures feature key to forced value map
+     */
     public void setGlobalForceFeatures(Map<String, Object> forceFeatures) {
         this.options.setGlobalForcedFeatureValues(forceFeatures);
     }
 
+    /**
+     * Replaces globally forced variations used for future experiment evaluations.
+     *
+     * @param forceVariations experiment key to forced variation index map
+     */
     public void setGlobalForceVariations(Map<String, Integer> forceVariations) {
         this.options.setGlobalForcedVariationsMap(forceVariations);
     }
 
+    /**
+     * Fetches the latest feature definitions using the default refresh path.
+     *
+     * <p>The client must be initialized first. Calling this method before initialization logs a
+     * warning and returns without throwing.
+     */
     public void refreshFeature() {
+        GBFeaturesRepository repositorySnapshot = currentRepository();
+        if (repositorySnapshot == null) {
+            log.warn("Cannot refresh features before GrowthBookClient is initialized.");
+            return;
+        }
+
         try {
-            repository.fetchFeatures();
+            repositorySnapshot.fetchFeatures();
         } catch (FeatureFetchException e) {
             log.error("Refreshing wasn't successful. Message is: {}", e.getMessage(), e);
         }
     }
 
+    /**
+     * Refreshes feature definitions using remote evaluation payload.
+     *
+     * <p>The client must be initialized first. Calling this method before initialization logs a
+     * warning and returns without throwing.
+     *
+     * @param requestBodyForRemoteEval remote evaluation request payload
+     */
     public void refreshForRemoteEval(RequestBodyForRemoteEval requestBodyForRemoteEval) {
+        GBFeaturesRepository repositorySnapshot = currentRepository();
+        if (repositorySnapshot == null) {
+            log.warn("Cannot refresh remote evaluation features before GrowthBookClient is initialized.");
+            return;
+        }
+
         try {
-            repository.fetchForRemoteEval(requestBodyForRemoteEval);
+            repositorySnapshot.fetchForRemoteEval(requestBodyForRemoteEval);
         } catch (FeatureFetchException e) {
             log.error("Refreshing for remote eval wasn't successful. Message is: {}", e.getMessage(), e);
         }
     }
 
-    public <ValueType> FeatureResult<ValueType> evalFeature(String key,
-                                                            Class<ValueType> valueTypeClass,
-                                                            UserContext userContext) {
+    /**
+     * Evaluates a feature for a user.
+     *
+     * @param key feature key
+     * @param valueTypeClass expected value class
+     * @param userContext user context
+     * @param <T> feature value type
+     * @return feature evaluation result
+     */
+    public <T> FeatureResult<T> evalFeature(String key,
+                                            Class<T> valueTypeClass,
+                                            UserContext userContext) {
         return featureEvaluator.evaluateFeature(key, getEvalContext(userContext), valueTypeClass);
     }
 
+    /**
+     * Checks whether a feature evaluates to on for a user.
+     *
+     * @param featureKey feature key
+     * @param userContext user context
+     * @return true when the feature is on
+     */
     public Boolean isOn(String featureKey, UserContext userContext) {
         return this.featureEvaluator.evaluateFeature(featureKey, getEvalContext(userContext), Object.class).isOn();
     }
 
+    /**
+     * Checks whether a feature evaluates to off for a user.
+     *
+     * @param featureKey feature key
+     * @param userContext user context
+     * @return true when the feature is off
+     */
     public Boolean isOff(String featureKey, UserContext userContext) {
         return this.featureEvaluator.evaluateFeature(featureKey, getEvalContext(userContext), Object.class).isOff();
     }
 
-    public <ValueType> ValueType getFeatureValue(String featureKey, ValueType defaultValue,
-                                                 Class<ValueType> gsonDeserializableClass,
-                                                 UserContext userContext) {
+    /**
+     * Evaluates a feature and returns its value, falling back to the supplied default on missing or invalid values.
+     *
+     * @param featureKey feature key
+     * @param defaultValue fallback value
+     * @param gsonDeserializableClass expected value class
+     * @param userContext user context
+     * @param <T> feature value type
+     * @return evaluated feature value or default value
+     */
+    public <T> T getFeatureValue(String featureKey, T defaultValue,
+                                 Class<T> gsonDeserializableClass,
+                                 UserContext userContext) {
         try {
-            Object maybeValue = this.featureEvaluator
+            Object evaluatedValue = this.featureEvaluator
                     .evaluateFeature(featureKey, getEvalContext(userContext), gsonDeserializableClass).getValue();
 
-            if (maybeValue == null) {
+            if (evaluatedValue == null) {
                 return defaultValue;
             }
 
-            String stringValue = GrowthBookJsonUtils.getInstance().gson.toJson(maybeValue);
+            String stringValue = GrowthBookJsonUtils.getInstance().gson.toJson(evaluatedValue);
 
             return GrowthBookJsonUtils.getInstance().gson.fromJson(stringValue, gsonDeserializableClass);
         } catch (Exception e) {
@@ -172,103 +221,114 @@ public class GrowthBookClient {
         }
     }
 
-    public <ValueType> ExperimentResult<ValueType> run(Experiment<ValueType> experiment, UserContext userContext) {
-        ExperimentResult<ValueType> result = experimentEvaluatorEvaluator
+    /**
+     * Runs an experiment for a user and notifies experiment subscribers when assignment changes.
+     *
+     * @param experiment experiment to evaluate
+     * @param userContext user context
+     * @param <T> experiment value type
+     * @return experiment evaluation result
+     */
+    public <T> ExperimentResult<T> run(Experiment<T> experiment, UserContext userContext) {
+        ExperimentResult<T> result = experimentEvaluator
                 .evaluateExperiment(experiment, getEvalContext(userContext), null);
 
-        fireSubscriptions(experiment, result);
+        experimentSubscriptions.publishIfChanged(experiment, result);
 
         return result;
     }
 
+    /**
+     * Registers an experiment run callback.
+     *
+     * @param callback callback invoked when an experiment assignment changes
+     */
     public void subscribe(ExperimentRunCallback callback) {
-        this.callbacks.add(callback);
+        this.experimentSubscriptions.subscribe(callback);
     }
 
+    /**
+     * Adds a listener that is notified after a feature refresh succeeds or fails.
+     *
+     * <p>Listener failures are isolated from SDK refresh processing. Notifications are dispatched off
+     * the refresh thread: through the executor configured in {@link Options} when supplied, otherwise
+     * on a dedicated daemon thread owned by this client.
+     *
+     * <p>To observe the initial {@code INITIALIZATION} refresh, register the listener before
+     * calling {@link #initialize()}; events emitted before registration are not replayed.
+     *
+     * @param listener listener to add
+     */
+    public void addFeatureRefreshListener(FeatureRefreshListener listener) {
+        this.featureRefreshListeners.add(listener);
+    }
+
+    /**
+     * Adds a listener and returns an idempotent handle that removes it.
+     *
+     * <p>To observe the initial {@code INITIALIZATION} refresh, register the listener before
+     * calling {@link #initialize()}; events emitted before registration are not replayed.
+     *
+     * @param listener listener to add
+     * @return subscription handle
+     */
+    public FeatureRefreshSubscription subscribeFeatureRefreshListener(FeatureRefreshListener listener) {
+        return this.featureRefreshListeners.subscribe(listener);
+    }
+
+    /**
+     * Removes a previously registered feature refresh listener.
+     *
+     * @param listener listener to remove
+     */
+    public void removeFeatureRefreshListener(FeatureRefreshListener listener) {
+        this.featureRefreshListeners.remove(listener);
+    }
+
+    /**
+     * Stops repository background work and releases repository resources.
+     *
+     * <p>This method is idempotent. If initialization is still in progress, the client cancels its
+     * ownership of that initialization and closes the repository once the initialization attempt
+     * exits.
+     */
     public void shutdown() {
-      if (repository != null) {
-        repository.shutdown();
-        repository = null;
-        log.info("Repository shut down");
-      }
+        featureRepositoryProvider.shutdown();
+        listenerExecutor.shutdown();
     }
 
-    private <ValueType> void fireSubscriptions(Experiment<ValueType> experiment, ExperimentResult<ValueType> result) {
-        String key = experiment.getKey();
-        // If assigned variation has changed, fire subscriptions
-        AssignedExperiment prev = this.assigned.get(key);
-        if (prev == null
-                || !Objects.equals(prev.getInExperiment(), result.getInExperiment())
-                || !Objects.equals(prev.getVariationId(), result.getVariationId())) {
-            AssignedExperiment current = new AssignedExperiment(
-                    experiment.getKey(),
-                    result.getInExperiment(),
-                    result.getVariationId()
-            );
-            this.assigned.put(key, current);
-
-            for (ExperimentRunCallback cb : this.callbacks) {
-                try {
-                    cb.onRun(experiment, result);
-                } catch (Exception e) {
-                    log.error(e.getMessage());
-                }
-            }
+    private void handleInternalRefresh(GBFeaturesRepository repositorySnapshot, FeatureRefreshEvent event) {
+        if (event.isFeaturesChanged()) {
+            refreshGlobalContext(repositorySnapshot);
         }
+
+        featureRefreshListeners.publish(event);
     }
 
-    private FeatureRefreshCallback refreshGlobalContext() {
-        return new FeatureRefreshCallback() {
-            @Override
-            public void onRefresh(String featuresJson) {
-                // refer the global context with latest features & saved groups
-                if (globalContext != null) {
-                    globalContext.setFeatures(repository.getParsedFeatures());
-                    globalContext.setSavedGroups(repository.getParsedSavedGroups());
-                } else {
-                    // TBD:M This should never happen! Just to be cautious about race conditions at the time of initialization
-                    globalContext = GlobalContext.builder()
-                            .features(repository.getParsedFeatures())
-                            .savedGroups(repository.getParsedSavedGroups())
-                            .enabled(options.getEnabled())
-                            .qaMode(options.getIsQaMode())
-                            .forcedFeatureValues(options.getGlobalForcedFeatureValues())
-                            .forcedVariations(options.getGlobalForcedVariationsMap())
-                            .build();
-                }
-            }
-
-            @Override
-            public void onError(Throwable throwable) {
-                log.warn("Unable to refresh global context with latest features", throwable);
-            }
-        };
+    private void refreshGlobalContext(GBFeaturesRepository repositorySnapshot) {
+        if (repositorySnapshot == null) {
+            log.debug("Skipping global context refresh because repository is not available.");
+            return;
+        }
+        try {
+            globalContextManager.refresh(repositorySnapshot);
+        } catch (RuntimeException e) {
+            log.warn("Unable to refresh global context with latest features", e);
+        }
     }
 
     private EvaluationContext getEvalContext(UserContext userContext) {
-        // Merge attributes using JsonObject to avoid parse/serialize churn
-        JsonObject merged = new JsonObject();
-        if (this.options.getGlobalAttributes() != null) {
-            merged = GrowthBookJsonUtils.getInstance().gson.fromJson(this.options.getGlobalAttributes(), JsonObject.class);
-            if (merged == null) merged = new JsonObject();
-        }
-        JsonObject userAttrs = userContext.getAttributes();
-        if (userAttrs != null) {
-            for (Map.Entry<String, JsonElement> e : userAttrs.entrySet()) {
-                merged.add(e.getKey(), e.getValue());
-            }
-        }
-        UserContext updatedUserContext = userContext.withAttributes(merged);
-        return new EvaluationContext(this.globalContext, updatedUserContext, new EvaluationContext.StackContext(), this.options);
+        return this.globalContextManager.createEvaluationContext(userContext);
     }
 
-    private RequestBodyForRemoteEval configurePayloadForRemoteEval(Options options) {
-        List<List<Object>> forceFeaturesForPayload = new ArrayList<>();
-        if (options.getGlobalForcedFeatureValues() != null) {
-            forceFeaturesForPayload = options.getGlobalForcedFeatureValues().entrySet().stream()
-                    .map(entry -> Arrays.asList(entry.getKey(), entry.getValue()))
-                    .collect(Collectors.toList());
-        }
-        return new RequestBodyForRemoteEval(options.getGlobalAttributes(), forceFeaturesForPayload, options.getGlobalForcedVariationsMap(), options.getUrl());
+    @SuppressWarnings("deprecation")
+    private void registerRefreshHandlers(GBFeaturesRepository repository) {
+        repository.onFeaturesRefresh(this.options.getFeatureRefreshCallback());
+        repository.addFeatureRefreshListener(event -> handleInternalRefresh(repository, event));
     }
+
+    private GBFeaturesRepository currentRepository() {
+        return featureRepositoryProvider.currentRepository();
+    }
+
 }

--- a/lib/src/main/java/growthbook/sdk/java/multiusermode/configurations/Options.java
+++ b/lib/src/main/java/growthbook/sdk/java/multiusermode/configurations/Options.java
@@ -21,10 +21,58 @@ import javax.annotation.Nullable;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Executor;
 
 @Data
 @Slf4j
 public class Options {
+
+    public Options(@Nullable Boolean enabled,
+                   Boolean isQaMode,
+                   @Nullable Boolean isCacheDisabled,
+                   Boolean allowUrlOverrides,
+                   @Nullable String url,
+                   @Nullable String apiHost,
+                   @Nullable String clientKey,
+                   @Nullable String decryptionKey,
+                   @Nullable List<String> stickyBucketIdentifierAttributes,
+                   @Nullable StickyBucketService stickyBucketService,
+                   @Nullable TrackingCallbackWithUser trackingCallBackWithUser,
+                   @Nullable FeatureUsageCallbackWithUser featureUsageCallbackWithUser,
+                   @Nullable FeatureRefreshStrategy refreshStrategy,
+                   @Nullable Integer swrTtlSeconds,
+                   @Deprecated @Nullable FeatureRefreshCallback featureRefreshCallback,
+                   @Nullable JsonObject globalAttributes,
+                   @Nullable Map<String, Object> globalForcedFeatureValues,
+                   @Nullable Map<String, Integer> globalForcedVariationsMap,
+                   @Nullable GbCacheManager cacheManager,
+                   @Nullable CacheMode cacheMode,
+                   @Nullable String cacheDirectory) {
+        this(
+                enabled,
+                isQaMode,
+                isCacheDisabled,
+                allowUrlOverrides,
+                url,
+                apiHost,
+                clientKey,
+                decryptionKey,
+                stickyBucketIdentifierAttributes,
+                stickyBucketService,
+                trackingCallBackWithUser,
+                featureUsageCallbackWithUser,
+                refreshStrategy,
+                swrTtlSeconds,
+                featureRefreshCallback,
+                globalAttributes,
+                globalForcedFeatureValues,
+                globalForcedVariationsMap,
+                cacheManager,
+                cacheMode,
+                cacheDirectory,
+                null
+        );
+    }
 
     @Builder
     public Options(@Nullable Boolean enabled,
@@ -41,13 +89,14 @@ public class Options {
                    @Nullable FeatureUsageCallbackWithUser featureUsageCallbackWithUser,
                    @Nullable FeatureRefreshStrategy refreshStrategy,
                    @Nullable Integer swrTtlSeconds,
-                   @Nullable FeatureRefreshCallback featureRefreshCallback,
+                   @Deprecated @Nullable FeatureRefreshCallback featureRefreshCallback,
                    @Nullable JsonObject globalAttributes,
                    @Nullable Map<String, Object> globalForcedFeatureValues,
                    @Nullable Map<String, Integer> globalForcedVariationsMap,
                    @Nullable GbCacheManager cacheManager,
                    @Nullable CacheMode cacheMode,
-                   @Nullable String cacheDirectory
+                   @Nullable String cacheDirectory,
+                   @Nullable Executor featureRefreshListenerExecutor
 
     ) {
         this.enabled = enabled == null || enabled;
@@ -71,6 +120,7 @@ public class Options {
         this.cacheManager = cacheManager;
         this.cacheMode = cacheMode == null ? CacheMode.AUTO : cacheMode;
         this.cacheDirectory = cacheDirectory;
+        this.featureRefreshListenerExecutor = featureRefreshListenerExecutor;
     }
 
     /**
@@ -185,6 +235,13 @@ public class Options {
         return this.refreshStrategy;
     }
 
+    /**
+     * Legacy feature refresh callback.
+     *
+     * @deprecated Use {@code GrowthBookClient.addFeatureRefreshListener(...)} or
+     * {@code GrowthBookClient.subscribeFeatureRefreshListener(...)} after constructing the client.
+     */
+    @Deprecated
     @Nullable
     private FeatureRefreshCallback featureRefreshCallback;
 
@@ -196,6 +253,13 @@ public class Options {
 
     @Nullable
     private String cacheDirectory;
+
+    /**
+     * Optional executor for client-level feature refresh listeners. When not supplied, the client
+     * dispatches listener callbacks on a dedicated daemon thread it owns and shuts down.
+     */
+    @Nullable
+    private Executor featureRefreshListenerExecutor;
 
     public CacheMode getCacheMode() { return cacheMode == null ? CacheMode.AUTO : cacheMode; }
     @Nullable

--- a/lib/src/main/java/growthbook/sdk/java/multiusermode/configurations/Options.java
+++ b/lib/src/main/java/growthbook/sdk/java/multiusermode/configurations/Options.java
@@ -106,14 +106,16 @@ public class Options {
                    @Nullable GbCacheManager cacheManager,
                    @Nullable CacheMode cacheMode,
                    @Nullable String cacheDirectory,
-                   @Nullable Executor featureRefreshListenerExecutor,
-                   @Nullable Duration backgroundFetchInterval,
-                   @Nullable FeatureFetchRetryPolicy retryPolicy,
                    @Nullable Boolean remoteEval,
                    @Nullable List<String> cacheKeyAttributes,
                    @Nullable Integer remoteEvalCacheSize,
-                   @Nullable Integer remoteEvalCacheTtlSeconds
-
+                   @Nullable Integer remoteEvalCacheTtlSeconds,
+                   @Nullable Duration backgroundFetchInterval,
+                   @Nullable FeatureFetchRetryPolicy retryPolicy,
+                   // New in the refresh-listener work: appended last so the existing positional
+                   // constructor signature (remoteEval..retryPolicy after cacheDirectory) is preserved
+                   // for direct (non-builder) callers. Builder users get it via the generated setter.
+                   @Nullable Executor featureRefreshListenerExecutor
     ) {
         this.enabled = enabled == null || enabled;
         this.isQaMode = isQaMode != null && isQaMode;
@@ -136,13 +138,13 @@ public class Options {
         this.cacheManager = cacheManager;
         this.cacheMode = cacheMode == null ? CacheMode.AUTO : cacheMode;
         this.cacheDirectory = cacheDirectory;
-        this.featureRefreshListenerExecutor = featureRefreshListenerExecutor;
-        this.backgroundFetchInterval = backgroundFetchInterval;
-        this.retryPolicy = retryPolicy;
         this.remoteEval = remoteEval != null && remoteEval;
         this.cacheKeyAttributes = cacheKeyAttributes;
         this.remoteEvalCacheSize = RemoteEvalRequestBuilder.normalizeCacheSize(remoteEvalCacheSize);
         this.remoteEvalCacheTtlSeconds = remoteEvalCacheTtlSeconds;
+        this.backgroundFetchInterval = backgroundFetchInterval;
+        this.retryPolicy = retryPolicy;
+        this.featureRefreshListenerExecutor = featureRefreshListenerExecutor;
     }
 
     /**

--- a/lib/src/main/java/growthbook/sdk/java/multiusermode/configurations/Options.java
+++ b/lib/src/main/java/growthbook/sdk/java/multiusermode/configurations/Options.java
@@ -112,9 +112,6 @@ public class Options {
                    @Nullable Integer remoteEvalCacheTtlSeconds,
                    @Nullable Duration backgroundFetchInterval,
                    @Nullable FeatureFetchRetryPolicy retryPolicy,
-                   // New in the refresh-listener work: appended last so the existing positional
-                   // constructor signature (remoteEval..retryPolicy after cacheDirectory) is preserved
-                   // for direct (non-builder) callers. Builder users get it via the generated setter.
                    @Nullable Executor featureRefreshListenerExecutor
     ) {
         this.enabled = enabled == null || enabled;
@@ -276,7 +273,6 @@ public class Options {
     @Nullable
     private GbCacheManager cacheManager;
 
-    // New cache configuration
     private CacheMode cacheMode;
 
     @Nullable

--- a/lib/src/main/java/growthbook/sdk/java/multiusermode/internal/ExperimentSubscriptionManager.java
+++ b/lib/src/main/java/growthbook/sdk/java/multiusermode/internal/ExperimentSubscriptionManager.java
@@ -1,0 +1,75 @@
+package growthbook.sdk.java.multiusermode.internal;
+
+import growthbook.sdk.java.callback.ExperimentRunCallback;
+import growthbook.sdk.java.model.AssignedExperiment;
+import growthbook.sdk.java.model.Experiment;
+import growthbook.sdk.java.model.ExperimentResult;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Internal manager for experiment run subscriptions.
+ * It tracks the last emitted assignment per experiment and only notifies subscribers on assignment changes.
+ */
+@Slf4j
+public final class ExperimentSubscriptionManager {
+
+    private final List<ExperimentRunCallback> callbacks = new CopyOnWriteArrayList<>();
+    private final Map<String, AssignedExperiment> assigned = new ConcurrentHashMap<>();
+
+    /**
+     * Registers an experiment run callback.
+     *
+     * @param callback callback invoked when an experiment assignment changes
+     */
+    public void subscribe(ExperimentRunCallback callback) {
+        this.callbacks.add(callback);
+    }
+
+    /**
+     * Publishes an experiment result to callbacks when the assignment changed.
+     *
+     * @param experiment evaluated experiment
+     * @param result evaluation result
+     * @param <T> experiment value type
+     */
+    public <T> void publishIfChanged(Experiment<T> experiment, ExperimentResult<T> result) {
+        String key = experiment.getKey();
+        AssignedExperiment nextAssignment = new AssignedExperiment(
+                experiment.getKey(),
+                result.getInExperiment(),
+                result.getVariationId()
+        );
+        AtomicBoolean changed = new AtomicBoolean(false);
+
+        this.assigned.compute(key, (ignored, previous) -> {
+            boolean assignmentChanged = hasAssignmentChanged(previous, result);
+            changed.set(assignmentChanged);
+            return assignmentChanged ? nextAssignment : previous;
+        });
+
+        if (!changed.get()) {
+            return;
+        }
+
+        for (ExperimentRunCallback callback : this.callbacks) {
+            try {
+                callback.onRun(experiment, result);
+            } catch (RuntimeException e) {
+                log.error("Experiment run callback failed for experiment={}", experiment.getKey(), e);
+            }
+        }
+    }
+
+    private <T> boolean hasAssignmentChanged(AssignedExperiment previous, ExperimentResult<T> result) {
+        return previous == null
+                || !Objects.equals(previous.getInExperiment(), result.getInExperiment())
+                || !Objects.equals(previous.getVariationId(), result.getVariationId());
+    }
+}

--- a/lib/src/main/java/growthbook/sdk/java/multiusermode/internal/FeatureRefreshListenerRegistry.java
+++ b/lib/src/main/java/growthbook/sdk/java/multiusermode/internal/FeatureRefreshListenerRegistry.java
@@ -1,0 +1,66 @@
+package growthbook.sdk.java.multiusermode.internal;
+
+import growthbook.sdk.java.listener.FeatureRefreshListener;
+import growthbook.sdk.java.listener.FeatureRefreshSubscription;
+import growthbook.sdk.java.listener.internal.FeatureRefreshListenerDispatcher;
+import growthbook.sdk.java.model.FeatureRefreshEvent;
+
+import javax.annotation.Nullable;
+import java.util.concurrent.Executor;
+
+/**
+ * Internal listener registry for client-level feature refresh events.
+ * Handles duplicate registration, optional executor dispatch, and listener failure isolation.
+ */
+public final class FeatureRefreshListenerRegistry {
+
+    @Nullable
+    private final Executor executor;
+    private final FeatureRefreshListenerDispatcher dispatcher = new FeatureRefreshListenerDispatcher();
+
+    /**
+     * Creates a registry that dispatches through the given executor.
+     *
+     * @param executor executor for listener callbacks, or null for synchronous dispatch
+     */
+    public FeatureRefreshListenerRegistry(@Nullable Executor executor) {
+        this.executor = executor;
+    }
+
+    /**
+     * Adds a listener if it is non-null and not already registered.
+     *
+     * @param listener listener to register
+     */
+    public void add(FeatureRefreshListener listener) {
+        dispatcher.add(listener);
+    }
+
+    /**
+     * Adds a listener and returns a handle that removes it.
+     *
+     * @param listener listener to register
+     * @return idempotent subscription handle
+     */
+    public FeatureRefreshSubscription subscribe(FeatureRefreshListener listener) {
+        return dispatcher.subscribe(listener);
+    }
+
+    /**
+     * Removes a registered listener.
+     *
+     * @param listener listener to remove
+     */
+    public void remove(FeatureRefreshListener listener) {
+        dispatcher.remove(listener);
+    }
+
+    /**
+     * Publishes an event to all registered listeners.
+     *
+     * @param event refresh event to publish
+     */
+    public void publish(FeatureRefreshEvent event) {
+        dispatcher.publish(event, executor);
+    }
+}

--- a/lib/src/main/java/growthbook/sdk/java/multiusermode/internal/FeatureRepositoryProvider.java
+++ b/lib/src/main/java/growthbook/sdk/java/multiusermode/internal/FeatureRepositoryProvider.java
@@ -1,0 +1,212 @@
+package growthbook.sdk.java.multiusermode.internal;
+
+import growthbook.sdk.java.exception.FeatureFetchException;
+import growthbook.sdk.java.exception.GrowthBookInitializationException;
+import growthbook.sdk.java.multiusermode.configurations.Options;
+import growthbook.sdk.java.repository.GBFeaturesRepository;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+
+/**
+ * Provides the feature repository owned by {@code GrowthBookClient}.
+ *
+ * <p>This class hides lazy repository creation, initialization reuse, failed-initialization retry,
+ * and shutdown cleanup from the public client facade.
+ */
+@Slf4j
+public final class FeatureRepositoryProvider {
+
+    private final Options options;
+    private final Consumer<GBFeaturesRepository> onRepositoryReady;
+    private final Consumer<GBFeaturesRepository> configureRepository;
+    private final GrowthBookClientRepositoryFactory repositoryFactory;
+    private final AtomicReference<CompletableFuture<GBFeaturesRepository>> repositoryState = new AtomicReference<>();
+
+    /**
+     * Creates a provider using the default GrowthBook repository factory.
+     *
+     * @param options client options used to create the repository
+     * @param configureRepository callback invoked before repository initialization
+     * @param onRepositoryReady callback invoked after repository initialization succeeds
+     */
+    public FeatureRepositoryProvider(
+            Options options,
+            Consumer<GBFeaturesRepository> configureRepository,
+            Consumer<GBFeaturesRepository> onRepositoryReady
+    ) {
+        this(options, new GrowthBookClientRepositoryFactory(), configureRepository, onRepositoryReady);
+    }
+
+    FeatureRepositoryProvider(
+            Options options,
+            GrowthBookClientRepositoryFactory repositoryFactory,
+            Consumer<GBFeaturesRepository> configureRepository,
+            Consumer<GBFeaturesRepository> onRepositoryReady
+    ) {
+        this.options = options;
+        this.repositoryFactory = repositoryFactory;
+        this.configureRepository = configureRepository;
+        this.onRepositoryReady = onRepositoryReady;
+    }
+
+    /**
+     * Initializes the repository if needed and returns the initialized repository.
+     *
+     * @return initialized repository, or null when initialization failed or was cancelled
+     */
+    public GBFeaturesRepository initialize() {
+        try {
+            return repositoryFuture().join();
+        } catch (CancellationException e) {
+            log.debug("GrowthBookClient repository initialization was cancelled.", e);
+            return null;
+        } catch (CompletionException e) {
+            Throwable cause = e.getCause() == null ? e : e.getCause();
+            log.error("Failed to initialize GrowthBookClient repository", cause);
+            return null;
+        }
+    }
+
+    /**
+     * Returns the initialized repository when available.
+     *
+     * @return initialized repository, or null when the client is not ready
+     */
+    public GBFeaturesRepository currentRepository() {
+        CompletableFuture<GBFeaturesRepository> future = repositoryState.get();
+        if (future == null || !future.isDone()) {
+            return null;
+        }
+
+        try {
+            return future.getNow(null);
+        } catch (RuntimeException e) {
+            log.warn("GrowthBookClient repository initialization did not complete successfully.", e);
+            return null;
+        }
+    }
+
+    /**
+     * Detaches and shuts down the current repository.
+     */
+    public void shutdown() {
+        CompletableFuture<GBFeaturesRepository> future = repositoryState.get();
+        if (future == null || !repositoryState.compareAndSet(future, null)) {
+            return;
+        }
+
+        if (!future.isDone()) {
+            future.cancel(false);
+            return;
+        }
+
+        try {
+            GBFeaturesRepository repository = future.getNow(null);
+            if (repository != null) {
+                shutdownRepository(repository);
+                log.info("Repository shut down");
+            }
+        } catch (CancellationException | CompletionException e) {
+            log.debug("Skipping repository shutdown because initialization did not complete successfully.", e);
+        }
+    }
+
+    private CompletableFuture<GBFeaturesRepository> repositoryFuture() {
+        while (true) {
+            CompletableFuture<GBFeaturesRepository> currentFuture = repositoryState.get();
+            if (currentFuture != null) {
+                return currentFuture;
+            }
+
+            CompletableFuture<GBFeaturesRepository> newFuture = new CompletableFuture<>();
+            if (repositoryState.compareAndSet(null, newFuture)) {
+                runInitialization(newFuture);
+                return newFuture;
+            }
+        }
+    }
+
+    private void runInitialization(CompletableFuture<GBFeaturesRepository> future) {
+        GBFeaturesRepository repository = null;
+        try {
+            repository = repositoryFactory.create(this.options);
+            if (!activateRepository(future, repository)) {
+                shutdownRepository(repository);
+                return;
+            }
+
+            completeInitialization(future, repository);
+        } catch (RuntimeException initializationException) {
+            if (repository != null) {
+                shutdownRepository(repository);
+            }
+            future.completeExceptionally(initializationException);
+            repositoryState.compareAndSet(future, null);
+        }
+    }
+
+    private boolean activateRepository(
+            CompletableFuture<GBFeaturesRepository> future,
+            GBFeaturesRepository repository
+    ) {
+        return runIfInitializationActive(future, () -> configure(repository))
+                && runIfInitializationActive(future, () -> initializeRepository(repository))
+                && runIfInitializationActive(future, () -> notifyReady(repository));
+    }
+
+    private boolean runIfInitializationActive(CompletableFuture<GBFeaturesRepository> future, Runnable step) {
+        if (!isInitializationActive(future)) {
+            return false;
+        }
+
+        step.run();
+        return true;
+    }
+
+    private boolean isInitializationActive(CompletableFuture<GBFeaturesRepository> future) {
+        return !future.isCancelled() && repositoryState.get() == future;
+    }
+
+    private void configure(GBFeaturesRepository repository) {
+        if (configureRepository != null) {
+            configureRepository.accept(repository);
+        }
+    }
+
+    private void notifyReady(GBFeaturesRepository repository) {
+        if (onRepositoryReady != null) {
+            onRepositoryReady.accept(repository);
+        }
+    }
+
+    private void completeInitialization(CompletableFuture<GBFeaturesRepository> future,
+                                        GBFeaturesRepository repository) {
+        if (future.complete(repository)) {
+            log.info("GrowthBookClient initialized repository and registered feature refresh handlers.");
+            return;
+        }
+
+        shutdownRepository(repository);
+    }
+
+    private void initializeRepository(GBFeaturesRepository repository) {
+        try {
+            repository.initialize();
+        } catch (FeatureFetchException e) {
+            throw new GrowthBookInitializationException(e);
+        }
+    }
+
+    private void shutdownRepository(GBFeaturesRepository repository) {
+        try {
+            repository.shutdown();
+        } catch (RuntimeException shutdownException) {
+            log.warn("Failed to shut down repository", shutdownException);
+        }
+    }
+}

--- a/lib/src/main/java/growthbook/sdk/java/multiusermode/internal/GlobalContextManager.java
+++ b/lib/src/main/java/growthbook/sdk/java/multiusermode/internal/GlobalContextManager.java
@@ -1,0 +1,98 @@
+package growthbook.sdk.java.multiusermode.internal;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import growthbook.sdk.java.multiusermode.configurations.EvaluationContext;
+import growthbook.sdk.java.multiusermode.configurations.GlobalContext;
+import growthbook.sdk.java.multiusermode.configurations.Options;
+import growthbook.sdk.java.multiusermode.configurations.UserContext;
+import growthbook.sdk.java.repository.GBFeaturesRepository;
+import growthbook.sdk.java.util.GrowthBookJsonUtils;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Internal coordinator for the client-level {@link GlobalContext}.
+ * Keeps feature state updates and evaluation context creation outside of the public facade.
+ */
+public final class GlobalContextManager {
+    private final Options options;
+    private final AtomicReference<GlobalContext> globalContext = new AtomicReference<>();
+
+    /**
+     * Creates a manager bound to the client options instance.
+     *
+     * @param options client options used to build evaluation contexts
+     */
+    public GlobalContextManager(Options options) {
+        this.options = options;
+    }
+
+    /**
+     * Replaces the managed context with feature data from the initialized repository.
+     *
+     * @param repository initialized feature repository
+     */
+    public void initialize(GBFeaturesRepository repository) {
+        this.globalContext.set(createGlobalContext(repository));
+    }
+
+    /**
+     * Updates feature and saved-group data after a repository refresh.
+     *
+     * @param repository repository containing the latest parsed feature data
+     */
+    public void refresh(GBFeaturesRepository repository) {
+        this.globalContext.set(createGlobalContext(repository));
+    }
+
+    /**
+     * Creates an evaluation context for a specific user by overlaying user attributes on global attributes.
+     *
+     * @param userContext per-user evaluation context
+     * @return evaluation context used by feature and experiment evaluators
+     */
+    public EvaluationContext createEvaluationContext(UserContext userContext) {
+        UserContext updatedUserContext = userContext.withAttributes(mergeAttributes(userContext));
+        return new EvaluationContext(
+                this.globalContext.get(),
+                updatedUserContext,
+                new EvaluationContext.StackContext(),
+                this.options
+        );
+    }
+
+    private GlobalContext createGlobalContext(GBFeaturesRepository repository) {
+        return GlobalContext.builder()
+                .features(repository.getParsedFeatures())
+                .savedGroups(repository.getParsedSavedGroups())
+                .enabled(this.options.getEnabled())
+                .qaMode(this.options.getIsQaMode())
+                .forcedFeatureValues(this.options.getGlobalForcedFeatureValues())
+                .forcedVariations(this.options.getGlobalForcedVariationsMap())
+                .build();
+    }
+
+    private JsonObject mergeAttributes(UserContext userContext) {
+        JsonObject merged = getGlobalAttributes();
+        JsonObject userAttributes = userContext.getAttributes();
+        if (userAttributes != null) {
+            for (Map.Entry<String, JsonElement> entry : userAttributes.entrySet()) {
+                merged.add(entry.getKey(), entry.getValue());
+            }
+        }
+        return merged;
+    }
+
+    private JsonObject getGlobalAttributes() {
+        if (this.options.getGlobalAttributes() == null) {
+            return new JsonObject();
+        }
+
+        JsonObject globalAttributes = GrowthBookJsonUtils.getInstance()
+                .gson
+                .fromJson(this.options.getGlobalAttributes(), JsonObject.class);
+        return globalAttributes == null ? new JsonObject() : globalAttributes;
+    }
+}

--- a/lib/src/main/java/growthbook/sdk/java/multiusermode/internal/GlobalContextManager.java
+++ b/lib/src/main/java/growthbook/sdk/java/multiusermode/internal/GlobalContextManager.java
@@ -1,15 +1,11 @@
 package growthbook.sdk.java.multiusermode.internal;
 
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
 import growthbook.sdk.java.multiusermode.configurations.EvaluationContext;
 import growthbook.sdk.java.multiusermode.configurations.GlobalContext;
 import growthbook.sdk.java.multiusermode.configurations.Options;
 import growthbook.sdk.java.multiusermode.configurations.UserContext;
 import growthbook.sdk.java.repository.GBFeaturesRepository;
-import growthbook.sdk.java.util.GrowthBookJsonUtils;
 
-import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
@@ -54,7 +50,7 @@ public final class GlobalContextManager {
      * @return evaluation context used by feature and experiment evaluators
      */
     public EvaluationContext createEvaluationContext(UserContext userContext) {
-        UserContext updatedUserContext = userContext.withAttributes(mergeAttributes(userContext));
+        UserContext updatedUserContext = UserContextMerger.mergeAttributesAndPreloadSticky(this.options, userContext);
         return new EvaluationContext(
                 this.globalContext.get(),
                 updatedUserContext,
@@ -72,27 +68,5 @@ public final class GlobalContextManager {
                 .forcedFeatureValues(this.options.getGlobalForcedFeatureValues())
                 .forcedVariations(this.options.getGlobalForcedVariationsMap())
                 .build();
-    }
-
-    private JsonObject mergeAttributes(UserContext userContext) {
-        JsonObject merged = getGlobalAttributes();
-        JsonObject userAttributes = userContext.getAttributes();
-        if (userAttributes != null) {
-            for (Map.Entry<String, JsonElement> entry : userAttributes.entrySet()) {
-                merged.add(entry.getKey(), entry.getValue());
-            }
-        }
-        return merged;
-    }
-
-    private JsonObject getGlobalAttributes() {
-        if (this.options.getGlobalAttributes() == null) {
-            return new JsonObject();
-        }
-
-        JsonObject globalAttributes = GrowthBookJsonUtils.getInstance()
-                .gson
-                .fromJson(this.options.getGlobalAttributes(), JsonObject.class);
-        return globalAttributes == null ? new JsonObject() : globalAttributes;
     }
 }

--- a/lib/src/main/java/growthbook/sdk/java/multiusermode/internal/GlobalContextManager.java
+++ b/lib/src/main/java/growthbook/sdk/java/multiusermode/internal/GlobalContextManager.java
@@ -5,12 +5,13 @@ import growthbook.sdk.java.multiusermode.configurations.GlobalContext;
 import growthbook.sdk.java.multiusermode.configurations.Options;
 import growthbook.sdk.java.multiusermode.configurations.UserContext;
 import growthbook.sdk.java.repository.GBFeaturesRepository;
+import growthbook.sdk.java.util.UserContextUtils;
 
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Internal coordinator for the client-level {@link GlobalContext}.
- * Keeps feature state updates and evaluation context creation outside of the public facade.
+ * Keeps feature state updates and evaluation context creation outside the public facade.
  */
 public final class GlobalContextManager {
     private final Options options;
@@ -50,7 +51,7 @@ public final class GlobalContextManager {
      * @return evaluation context used by feature and experiment evaluators
      */
     public EvaluationContext createEvaluationContext(UserContext userContext) {
-        UserContext updatedUserContext = UserContextMerger.mergeAttributesAndPreloadSticky(this.options, userContext);
+        UserContext updatedUserContext = UserContextUtils.mergeAttributesAndPreloadSticky(this.options, userContext);
         return new EvaluationContext(
                 this.globalContext.get(),
                 updatedUserContext,

--- a/lib/src/main/java/growthbook/sdk/java/multiusermode/internal/GrowthBookClientRepositoryFactory.java
+++ b/lib/src/main/java/growthbook/sdk/java/multiusermode/internal/GrowthBookClientRepositoryFactory.java
@@ -1,0 +1,58 @@
+package growthbook.sdk.java.multiusermode.internal;
+
+import growthbook.sdk.java.model.RequestBodyForRemoteEval;
+import growthbook.sdk.java.multiusermode.configurations.Options;
+import growthbook.sdk.java.repository.GBFeaturesRepository;
+import growthbook.sdk.java.sandbox.CacheManagerFactory;
+import growthbook.sdk.java.sandbox.CacheMode;
+import growthbook.sdk.java.sandbox.GbCacheManager;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Internal factory for repositories used by {@code GrowthBookClient}.
+ * Keeps repository construction and option mapping out of the public client facade.
+ */
+public final class GrowthBookClientRepositoryFactory {
+
+    /**
+     * Creates a repository from client options.
+     *
+     * @param options client options
+     * @return configured feature repository
+     */
+    public GBFeaturesRepository create(Options options) {
+        GbCacheManager cacheManager = options.getCacheManager() != null
+                ? options.getCacheManager()
+                : CacheManagerFactory.create(options.getCacheMode(), options.getCacheDirectory());
+
+        return GBFeaturesRepository.builder()
+                .apiHost(options.getApiHost())
+                .clientKey(options.getClientKey())
+                .decryptionKey(options.getDecryptionKey())
+                .refreshStrategy(options.getRefreshStrategy())
+                .swrTtlSeconds(options.getSwrTtlSeconds())
+                .isCacheDisabled(options.getIsCacheDisabled() || options.getCacheMode() == CacheMode.NONE)
+                .cacheManager(cacheManager)
+                .requestBodyForRemoteEval(configurePayloadForRemoteEval(options))
+                .build();
+    }
+
+    private RequestBodyForRemoteEval configurePayloadForRemoteEval(Options options) {
+        List<List<Object>> forceFeaturesForPayload = new ArrayList<>();
+        if (options.getGlobalForcedFeatureValues() != null) {
+            forceFeaturesForPayload = options.getGlobalForcedFeatureValues().entrySet().stream()
+                    .map(entry -> Arrays.asList(entry.getKey(), entry.getValue()))
+                    .collect(Collectors.toList());
+        }
+        return new RequestBodyForRemoteEval(
+                options.getGlobalAttributes(),
+                forceFeaturesForPayload,
+                options.getGlobalForcedVariationsMap(),
+                options.getUrl()
+        );
+    }
+}

--- a/lib/src/main/java/growthbook/sdk/java/multiusermode/internal/ManagedListenerExecutor.java
+++ b/lib/src/main/java/growthbook/sdk/java/multiusermode/internal/ManagedListenerExecutor.java
@@ -1,0 +1,62 @@
+package growthbook.sdk.java.multiusermode.internal;
+
+import javax.annotation.Nullable;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Resolves the executor that dispatches client-level feature refresh listener callbacks.
+ *
+ * <p>A caller-supplied executor is used as-is and its lifecycle is left to the caller. When none is
+ * supplied, a dedicated daemon executor is created and owned here, so {@link #shutdown()} only stops
+ * what this instance created.
+ */
+public final class ManagedListenerExecutor {
+
+    private final Executor executor;
+
+    @Nullable
+    private final ExecutorService owned;
+
+    private ManagedListenerExecutor(Executor executor, @Nullable ExecutorService owned) {
+        this.executor = executor;
+        this.owned = owned;
+    }
+
+    /**
+     * @param configured caller-supplied executor, or null to own a default
+     * @return a managed executor wrapping the configured executor, or a newly owned daemon executor
+     */
+    public static ManagedListenerExecutor resolve(@Nullable Executor configured) {
+        if (configured != null) {
+            return new ManagedListenerExecutor(configured, null);
+        }
+        ExecutorService owned = Executors.newSingleThreadExecutor(daemonThreadFactory());
+        return new ManagedListenerExecutor(owned, owned);
+    }
+
+    public Executor executor() {
+        return executor;
+    }
+
+    /**
+     * Stops the executor only when it is owned by this instance.
+     */
+    public void shutdown() {
+        if (owned != null) {
+            owned.shutdown();
+        }
+    }
+
+    private static ThreadFactory daemonThreadFactory() {
+        AtomicInteger threadNumber = new AtomicInteger();
+        return runnable -> {
+            Thread thread = new Thread(runnable, "growthbook-feature-refresh-listener-" + threadNumber.incrementAndGet());
+            thread.setDaemon(true);
+            return thread;
+        };
+    }
+}

--- a/lib/src/main/java/growthbook/sdk/java/multiusermode/internal/RemoteEvalCoordinator.java
+++ b/lib/src/main/java/growthbook/sdk/java/multiusermode/internal/RemoteEvalCoordinator.java
@@ -1,6 +1,5 @@
 package growthbook.sdk.java.multiusermode.internal;
 
-import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import growthbook.sdk.java.exception.FeatureFetchException;
 import growthbook.sdk.java.model.Feature;
@@ -18,7 +17,6 @@ import growthbook.sdk.java.remoteeval.RemoteEvalResponse;
 import growthbook.sdk.java.remoteeval.RemoteEvalService;
 import growthbook.sdk.java.repository.FeatureRefreshStrategy;
 import growthbook.sdk.java.repository.GBFeaturesRepository;
-import growthbook.sdk.java.util.GrowthBookJsonUtils;
 import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.Nullable;
@@ -86,7 +84,7 @@ public final class RemoteEvalCoordinator {
      * @return evaluation context used by feature and experiment evaluators
      */
     public EvaluationContext createEvaluationContext(UserContext userContext) {
-        UserContext mergedUserContext = withMergedAttributes(userContext);
+        UserContext mergedUserContext = UserContextMerger.mergeAttributesAndPreloadSticky(this.options, userContext);
         if (this.shutdown.get()) {
             return fallbackEvaluationContext(mergedUserContext);
         }
@@ -111,7 +109,7 @@ public final class RemoteEvalCoordinator {
             return false;
         }
         try {
-            fetchResponse(withMergedAttributes(userContext));
+            fetchResponse(UserContextMerger.mergeAttributesAndPreloadSticky(this.options, userContext));
             return true;
         } catch (FeatureFetchException e) {
             log.warn("Unable to preload remote evaluation response", e);
@@ -216,23 +214,6 @@ public final class RemoteEvalCoordinator {
 
     private EvaluationContext fallbackEvaluationContext(UserContext userContext) {
         return new EvaluationContext(fallbackContext(), userContext, new EvaluationContext.StackContext(), this.options);
-    }
-
-    private UserContext withMergedAttributes(UserContext userContext) {
-        JsonObject merged = new JsonObject();
-        if (this.options.getGlobalAttributes() != null) {
-            merged = GrowthBookJsonUtils.getInstance().gson.fromJson(this.options.getGlobalAttributes(), JsonObject.class);
-            if (merged == null) {
-                merged = new JsonObject();
-            }
-        }
-        JsonObject userAttributes = userContext.getAttributes();
-        if (userAttributes != null) {
-            for (Map.Entry<String, JsonElement> entry : userAttributes.entrySet()) {
-                merged.add(entry.getKey(), entry.getValue());
-            }
-        }
-        return userContext.withAttributes(merged);
     }
 
     private RemoteEvalResponse fetchResponse(UserContext userContext) throws FeatureFetchException {

--- a/lib/src/main/java/growthbook/sdk/java/multiusermode/internal/RemoteEvalCoordinator.java
+++ b/lib/src/main/java/growthbook/sdk/java/multiusermode/internal/RemoteEvalCoordinator.java
@@ -17,6 +17,7 @@ import growthbook.sdk.java.remoteeval.RemoteEvalResponse;
 import growthbook.sdk.java.remoteeval.RemoteEvalService;
 import growthbook.sdk.java.repository.FeatureRefreshStrategy;
 import growthbook.sdk.java.repository.GBFeaturesRepository;
+import growthbook.sdk.java.util.UserContextUtils;
 import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.Nullable;
@@ -84,7 +85,7 @@ public final class RemoteEvalCoordinator {
      * @return evaluation context used by feature and experiment evaluators
      */
     public EvaluationContext createEvaluationContext(UserContext userContext) {
-        UserContext mergedUserContext = UserContextMerger.mergeAttributesAndPreloadSticky(this.options, userContext);
+        UserContext mergedUserContext = UserContextUtils.mergeAttributesAndPreloadSticky(this.options, userContext);
         if (this.shutdown.get()) {
             return fallbackEvaluationContext(mergedUserContext);
         }
@@ -109,7 +110,7 @@ public final class RemoteEvalCoordinator {
             return false;
         }
         try {
-            fetchResponse(UserContextMerger.mergeAttributesAndPreloadSticky(this.options, userContext));
+            fetchResponse(UserContextUtils.mergeAttributesAndPreloadSticky(this.options, userContext));
             return true;
         } catch (FeatureFetchException e) {
             log.warn("Unable to preload remote evaluation response", e);

--- a/lib/src/main/java/growthbook/sdk/java/multiusermode/internal/UserContextMerger.java
+++ b/lib/src/main/java/growthbook/sdk/java/multiusermode/internal/UserContextMerger.java
@@ -1,0 +1,92 @@
+package growthbook.sdk.java.multiusermode.internal;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import growthbook.sdk.java.model.StickyAssignmentsDocument;
+import growthbook.sdk.java.multiusermode.configurations.Options;
+import growthbook.sdk.java.multiusermode.configurations.UserContext;
+import growthbook.sdk.java.stickyBucketing.StickyBucketService;
+import growthbook.sdk.java.util.GrowthBookJsonUtils;
+
+import javax.annotation.Nullable;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Builds the per-request {@link UserContext} shared by the local and remote evaluation paths:
+ * overlays user attributes on the client's global attributes and, when a
+ * {@link StickyBucketService} is configured, preloads the user's sticky-bucket assignment
+ * documents.
+ *
+ * <p>The sticky preload preserves the assignment behaviour that {@code GrowthBookClient} relied on
+ * before evaluation was split across {@link GlobalContextManager} and {@link RemoteEvalCoordinator}.
+ * Without it, multi-user clients using a {@link StickyBucketService} would evaluate experiments
+ * without their persisted assignments, changing assignment behaviour and diverging from the
+ * sticky-bucketing contract shared across GrowthBook SDKs.
+ */
+final class UserContextMerger {
+
+    private UserContextMerger() {
+    }
+
+    /**
+     * Merges global and per-user attributes and preloads sticky-bucket assignments for the merged
+     * attributes when a {@link StickyBucketService} is configured and the caller has not already
+     * supplied assignment documents.
+     *
+     * @param options     client options (global attributes and optional sticky bucket service)
+     * @param userContext the per-request user context; {@code null} is treated as an empty context
+     * @return a new user context carrying the merged attributes and any preloaded sticky docs
+     */
+    static UserContext mergeAttributesAndPreloadSticky(Options options, @Nullable UserContext userContext) {
+        // Null-safe default: callers such as GrowthBookClient.preloadRemoteEval may pass null to warm
+        // the default/global response. Treat that as an empty context (the previous merge helper did).
+        UserContext safeUserContext = userContext == null ? UserContext.builder().build() : userContext;
+        JsonObject mergedAttributes = mergeAttributes(options, safeUserContext);
+        UserContext mergedUserContext = safeUserContext.withAttributes(mergedAttributes);
+        preloadStickyBucketAssignments(options, mergedUserContext, mergedAttributes);
+        return mergedUserContext;
+    }
+
+    private static JsonObject mergeAttributes(Options options, UserContext userContext) {
+        JsonObject merged = globalAttributes(options);
+        JsonObject userAttributes = userContext.getAttributes();
+        if (userAttributes != null) {
+            for (Map.Entry<String, JsonElement> entry : userAttributes.entrySet()) {
+                merged.add(entry.getKey(), entry.getValue());
+            }
+        }
+        return merged;
+    }
+
+    private static JsonObject globalAttributes(Options options) {
+        if (options.getGlobalAttributes() == null) {
+            return new JsonObject();
+        }
+        JsonObject globalAttributes = GrowthBookJsonUtils.getInstance()
+                .gson
+                .fromJson(options.getGlobalAttributes(), JsonObject.class);
+        return globalAttributes == null ? new JsonObject() : globalAttributes;
+    }
+
+    /**
+     * Fetches sticky-bucket assignment docs for the user's (string-valued) attributes once per
+     * request, unless the caller preloaded them. Mirrors the previous {@code GrowthBookClient}
+     * behaviour so a configured {@link StickyBucketService} keeps driving experiment assignments.
+     */
+    private static void preloadStickyBucketAssignments(Options options, UserContext userContext, JsonObject attributes) {
+        StickyBucketService stickyBucketService = options.getStickyBucketService();
+        if (stickyBucketService == null || userContext.getStickyBucketAssignmentDocs() != null) {
+            return;
+        }
+        Map<String, String> attributeStrings = new HashMap<>();
+        for (Map.Entry<String, JsonElement> entry : attributes.entrySet()) {
+            JsonElement value = entry.getValue();
+            if (value != null && value.isJsonPrimitive()) {
+                attributeStrings.put(entry.getKey(), value.getAsString());
+            }
+        }
+        Map<String, StickyAssignmentsDocument> docs = stickyBucketService.getAllAssignments(attributeStrings);
+        userContext.setStickyBucketAssignmentDocs(docs);
+    }
+}

--- a/lib/src/main/java/growthbook/sdk/java/multiusermode/util/TransformationUtil.java
+++ b/lib/src/main/java/growthbook/sdk/java/multiusermode/util/TransformationUtil.java
@@ -8,15 +8,16 @@ import com.google.gson.JsonSyntaxException;
 import growthbook.sdk.java.model.Feature;
 import growthbook.sdk.java.util.DecryptionUtils;
 import growthbook.sdk.java.util.GrowthBookJsonUtils;
+import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.Nullable;
 import java.lang.reflect.Type;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 
 @Slf4j
+@UtilityClass
 public class TransformationUtil {
     private static final Gson GSON = GrowthBookJsonUtils.getInstance().gson;
 

--- a/lib/src/main/java/growthbook/sdk/java/repository/GBFeaturesRepository.java
+++ b/lib/src/main/java/growthbook/sdk/java/repository/GBFeaturesRepository.java
@@ -4,12 +4,15 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import growthbook.sdk.java.callback.FeatureRefreshCallback;
 import growthbook.sdk.java.exception.FeatureFetchException;
+import growthbook.sdk.java.listener.FeatureRefreshListener;
 import growthbook.sdk.java.model.Feature;
+import growthbook.sdk.java.model.FeatureRefreshSource;
 import growthbook.sdk.java.model.FeatureResponseKey;
 import growthbook.sdk.java.model.GBContext;
 import growthbook.sdk.java.model.HttpHeaders;
 import growthbook.sdk.java.model.RequestBodyForRemoteEval;
 import growthbook.sdk.java.multiusermode.util.TransformationUtil;
+import growthbook.sdk.java.repository.internal.FeatureRefreshNotifier;
 import growthbook.sdk.java.sandbox.CacheManagerFactory;
 import growthbook.sdk.java.sandbox.CacheMode;
 import growthbook.sdk.java.sandbox.GbCacheManager;
@@ -35,10 +38,10 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.time.Instant;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -61,7 +64,7 @@ public class GBFeaturesRepository implements IGBFeaturesRepository {
     private static final String FEATURES_PATH_PATTERN = ".*/api/features/[^/]+";
 
     /**
-     * Thread-safe LRU cache with max 100 entries to prevent unbounded growth
+     * Thread-safe LRU cache wi<t>h max 100 entries to prevent unbounded growth
      */
     private final LruETagCache eTagCache = new LruETagCache(100);
 
@@ -121,9 +124,17 @@ public class GBFeaturesRepository implements IGBFeaturesRepository {
     private OkHttpClient sseHttpClient;
 
     /**
-     * Optional callbacks for getting updates when features are refreshed
+     * Legacy callbacks for getting updates when features are refreshed.
+     *
+     * @deprecated Use {@link #addFeatureRefreshListener(FeatureRefreshListener)}.
      */
-    private final ArrayList<FeatureRefreshCallback> refreshCallbacks = new ArrayList<>();
+    @Deprecated
+    private final CopyOnWriteArrayList<FeatureRefreshCallback> refreshCallbacks = new CopyOnWriteArrayList<>();
+
+    /**
+     * Metadata-only listeners used by the client-level refresh listener API.
+     */
+    private final FeatureRefreshNotifier featureRefreshNotifier = new FeatureRefreshNotifier(this::getActiveFeatureCount, () -> this.refreshStrategy);
 
     /**
      * Flag to know whether GBFeatureRepository is initialized
@@ -348,20 +359,49 @@ public class GBFeaturesRepository implements IGBFeaturesRepository {
      * This is called even if the features have not changed.
      *
      * @param callback This callback will be called when features are refreshed
+     * @deprecated Use {@link #addFeatureRefreshListener(FeatureRefreshListener)}.
      */
+    @Deprecated
     @Override
-    public synchronized void onFeaturesRefresh(FeatureRefreshCallback callback) {
+    public void onFeaturesRefresh(FeatureRefreshCallback callback) {
         if (callback == null) {
             return;
         }
-        if (!this.refreshCallbacks.contains(callback)) {
-            this.refreshCallbacks.add(callback);
+        this.refreshCallbacks.addIfAbsent(callback);
+    }
+
+    /**
+     * Clears legacy feature refresh callbacks.
+     *
+     * @deprecated Use listener-specific unsubscription with
+     * {@link #removeFeatureRefreshListener(FeatureRefreshListener)} where available.
+     */
+    @Deprecated
+    @Override
+    public void clearCallbacks() {
+        this.refreshCallbacks.clear();
+    }
+
+    /**
+     * Adds a metadata-only feature refresh listener.
+     *
+     * @param listener listener to add
+     */
+    public void addFeatureRefreshListener(FeatureRefreshListener listener) {
+        if (listener != null) {
+            this.featureRefreshNotifier.add(listener);
         }
     }
 
-    @Override
-    public synchronized void clearCallbacks() {
-        this.refreshCallbacks.clear();
+    /**
+     * Removes a previously registered feature refresh listener.
+     *
+     * @param listener listener to remove
+     */
+    public void removeFeatureRefreshListener(FeatureRefreshListener listener) {
+        if (listener != null) {
+            this.featureRefreshNotifier.remove(listener);
+        }
     }
 
     private GbCacheManager createCacheManager() {
@@ -391,7 +431,7 @@ public class GBFeaturesRepository implements IGBFeaturesRepository {
         long started = System.currentTimeMillis();
         try {
             log.debug("GrowthBook Features Refresh polling starts");
-            fetchFeatures();
+            fetchFeatures(FeatureRefreshSource.POLLING);
         } catch (Exception e) {
             log.error("Features Refresh polling failed.", e);
         } finally {
@@ -411,17 +451,17 @@ public class GBFeaturesRepository implements IGBFeaturesRepository {
 
         switch (this.refreshStrategy) {
             case STALE_WHILE_REVALIDATE:
-                fetchFeatures();
+                fetchFeatures(FeatureRefreshSource.INITIALIZATION);
                 schedulePolling();
                 break;
 
             case SERVER_SENT_EVENTS:
-                fetchFeatures();
+                fetchFeatures(FeatureRefreshSource.INITIALIZATION);
                 initializeSSE(retryOnFailure);
                 break;
 
             case REMOTE_EVAL_STRATEGY:
-                fetchForRemoteEval(this.requestBodyForRemoteEval);
+                fetchForRemoteEval(this.requestBodyForRemoteEval, FeatureRefreshSource.REMOTE_EVALUATION);
                 break;
         }
 
@@ -473,7 +513,7 @@ public class GBFeaturesRepository implements IGBFeaturesRepository {
 
                             @Override
                             public void onFeaturesResponse(String featuresJsonResponse) throws FeatureFetchException {
-                                onResponseJson(featuresJsonResponse, false);
+                                refreshFromJson(featuresJsonResponse, FeatureRefreshSource.SSE);
                             }
                         }
                 ) {
@@ -484,7 +524,7 @@ public class GBFeaturesRepository implements IGBFeaturesRepository {
                             createEventSourceListenerAndStartListening(true);
 
                             try {
-                                fetchFeatures();
+                                fetchFeatures(FeatureRefreshSource.SSE);
                             } catch (FeatureFetchException featureFetchException) {
                                 Logger.getAnonymousLogger()
                                         .throwing(
@@ -542,10 +582,15 @@ public class GBFeaturesRepository implements IGBFeaturesRepository {
      * This method will attempt to decrypt the encrypted features with the provided encryptionKey.
      */
     public void fetchFeatures() throws FeatureFetchException {
+        fetchFeatures(FeatureRefreshSource.MANUAL);
+    }
+
+    private void fetchFeatures(FeatureRefreshSource source) throws FeatureFetchException {
         if (this.featuresEndpoint == null) {
             throw new IllegalArgumentException("features endpoint cannot be null");
         }
 
+        long startedAtNanos = System.nanoTime();
         Request.Builder requestBuilder = new Request.Builder()
                 .url(this.featuresEndpoint);
 
@@ -562,15 +607,33 @@ public class GBFeaturesRepository implements IGBFeaturesRepository {
             String sseSupportHeader = response.header(HttpHeaders.X_SSE_SUPPORT.getHeader());
             this.sseAllowed = Objects.equals(sseSupportHeader, ENABLED);
 
-            this.onSuccess(response);
+            this.onSuccess(response, source, startedAtNanos);
         } catch (IOException e) {
             log.error(e.getMessage(), e);
+            boolean featuresChanged = false;
+            boolean loadedFromCache = false;
+            FeatureFetchException cacheFailure = null;
             if (!isCacheDisabled) {
-                String cachedData = getCachedFeatures();
-                onResponseJson(cachedData, true);
+                try {
+                    String cachedData = getCachedFeatures();
+                    featuresChanged = onResponseJson(cachedData, true);
+                    loadedFromCache = true;
+                } catch (FeatureFetchException exception) {
+                    cacheFailure = exception;
+                }
             }
-            // Notify listeners about network failure
+            long durationMillis = FeatureRefreshNotifier.elapsedMillis(startedAtNanos);
             this.onRefreshFailed(e);
+            this.featureRefreshNotifier.notifyFailure(
+                    e,
+                    source,
+                    featuresChanged,
+                    loadedFromCache,
+                    durationMillis
+            );
+            if (cacheFailure != null) {
+                throw cacheFailure;
+            }
         }
     }
 
@@ -579,7 +642,7 @@ public class GBFeaturesRepository implements IGBFeaturesRepository {
      *
      * @param responseJsonString JSON response object
      */
-    private void onResponseJson(String responseJsonString, boolean isFromCache) throws FeatureFetchException {
+    private boolean onResponseJson(String responseJsonString, boolean isFromCache) throws FeatureFetchException {
         try {
             if (!isFromCache && !isCacheDisabled && cacheManager != null) {
                 try {
@@ -640,19 +703,19 @@ public class GBFeaturesRepository implements IGBFeaturesRepository {
                 refreshedFeatures = featuresJsonElement.toString().trim();
             }
 
+            boolean featuresChanged = !Objects.equals(this.featuresJson, refreshedFeatures)
+                    || !Objects.equals(this.savedGroupsJson, refreshedSavedGroups);
+
+            Map<String, Feature<?>> newParsed = TransformationUtil.transformFeatures(refreshedFeatures);
+            JsonObject newSaved = TransformationUtil.transformSavedGroups(refreshedSavedGroups);
             this.featuresJson = refreshedFeatures;
             this.savedGroupsJson = refreshedSavedGroups;
-
-            Map<String, Feature<?>> newParsed = TransformationUtil.transformFeatures(this.featuresJson);
-            JsonObject newSaved = TransformationUtil.transformSavedGroups(this.savedGroupsJson);
             this.parsedFeatures = newParsed;
             this.parsedSavedGroups = newSaved == null ? new JsonObject() : newSaved;
 
-            if (!isFromCache) {
-                this.onRefreshSuccess(this.featuresJson);
-            }
             // bump TTL only after successful processing
             this.refreshExpiresAt();
+            return featuresChanged;
         } catch (DecryptionUtils.DecryptionException e) {
             log.error("FeatureFetchException: UNKNOWN feature fetch error code {}",
                     e.getMessage(), e);
@@ -664,20 +727,57 @@ public class GBFeaturesRepository implements IGBFeaturesRepository {
         }
     }
 
+    private void refreshFromJson(String responseJsonString, FeatureRefreshSource source) throws FeatureFetchException {
+        long startedAtNanos = System.nanoTime();
+        try {
+            boolean featuresChanged = onResponseJson(responseJsonString, false);
+            long durationMillis = FeatureRefreshNotifier.elapsedMillis(startedAtNanos);
+            this.onRefreshSuccess(this.featuresJson);
+            this.featureRefreshNotifier.notifySuccess(source, featuresChanged, false, durationMillis);
+        } catch (FeatureFetchException e) {
+            this.featureRefreshNotifier.notifyFailure(e, source, false, false, FeatureRefreshNotifier.elapsedMillis(startedAtNanos));
+            throw e;
+        }
+    }
+
+    /**
+     * Dispatches legacy feature refresh callbacks.
+     *
+     * @deprecated Use {@link FeatureRefreshNotifier}.
+     */
+    @Deprecated
     private void onRefreshSuccess(String featuresJson) {
         for (FeatureRefreshCallback callback : this.refreshCallbacks) {
             if (callback != null) {
-                callback.onRefresh(featuresJson);
+                try {
+                    callback.onRefresh(featuresJson);
+                } catch (Exception e) {
+                    log.warn("Feature refresh callback failed", e);
+                }
             }
         }
     }
 
+    /**
+     * Dispatches legacy feature refresh error callbacks.
+     *
+     * @deprecated Use {@link FeatureRefreshNotifier}.
+     */
+    @Deprecated
     private void onRefreshFailed(Throwable throwable) {
         for (FeatureRefreshCallback callback : this.refreshCallbacks) {
             if (callback != null) {
-                callback.onError(throwable);
+                try {
+                    callback.onError(throwable);
+                } catch (Exception e) {
+                    log.warn("Feature refresh error callback failed", e);
+                }
             }
         }
+    }
+
+    private int getActiveFeatureCount() {
+        return this.parsedFeatures == null ? 0 : this.parsedFeatures.size();
     }
 
     /**
@@ -685,14 +785,22 @@ public class GBFeaturesRepository implements IGBFeaturesRepository {
      *
      * @param response Successful response
      */
-    private void onSuccess(Response response) throws FeatureFetchException {
+    private void onSuccess(
+            Response response,
+            FeatureRefreshSource source,
+            long startedAtNanos
+    ) throws FeatureFetchException {
+        boolean refreshEventNotified = false;
         try {
             ResponseBody responseBody = response.body();
 
             if (response.code() == HttpURLConnection.HTTP_NOT_MODIFIED) {
                 log.info("Features not modified (304). Using existing data.");
                 this.refreshExpiresAt();
+                long durationMillis = FeatureRefreshNotifier.elapsedMillis(startedAtNanos);
                 this.onRefreshSuccess(this.featuresJson);
+                this.featureRefreshNotifier.notifySuccess(source, false, false, durationMillis);
+                refreshEventNotified = true;
                 return;
             }
 
@@ -705,37 +813,86 @@ public class GBFeaturesRepository implements IGBFeaturesRepository {
 
             // if response code is not 200 or response body is null - try cache
             if (response.code() != HttpURLConnection.HTTP_OK || responseBody == null) {
+                FeatureFetchException refreshFailure = new FeatureFetchException(
+                        responseBody == null
+                                ? FeatureFetchException.FeatureFetchErrorCode.NO_RESPONSE_ERROR
+                                : FeatureFetchException.FeatureFetchErrorCode.HTTP_RESPONSE_ERROR,
+                        "Failed to fetch data from server"
+                );
                 log.error("FeatureFetchException: {} with status {}, response: {}",
                         responseBody == null ? FeatureFetchException.FeatureFetchErrorCode.NO_RESPONSE_ERROR : FeatureFetchException.FeatureFetchErrorCode.HTTP_RESPONSE_ERROR,
                         response.code(),
                         responseBody != null ? responseBody.string() : "null");
 
                 if (isCacheDisabled) {
-                    throw new FeatureFetchException(
+                    FeatureFetchException cacheDisabledFailure = new FeatureFetchException(
                             FeatureFetchException.FeatureFetchErrorCode.HTTP_RESPONSE_ERROR,
                             "Failed to fetch data from server and cache is disabled"
                     );
+                    this.featureRefreshNotifier.notifyFailure(
+                            cacheDisabledFailure,
+                            source,
+                            false,
+                            false,
+                            FeatureRefreshNotifier.elapsedMillis(startedAtNanos)
+                    );
+                    refreshEventNotified = true;
+                    throw cacheDisabledFailure;
                 }
                 log.info("Fetching data from cache...");
 
                 String featuresFromCache = getCachedFeatures();
                 if (featuresFromCache.isEmpty()) {
-                    throw new FeatureFetchException(
+                    FeatureFetchException cacheFailure = new FeatureFetchException(
                             FeatureFetchException.FeatureFetchErrorCode.NO_RESPONSE_ERROR,
                             "Failed to fetch data from cache"
                     );
+                    this.featureRefreshNotifier.notifyFailure(
+                            cacheFailure,
+                            source,
+                            false,
+                            false,
+                            FeatureRefreshNotifier.elapsedMillis(startedAtNanos)
+                    );
+                    refreshEventNotified = true;
+                    throw cacheFailure;
                 }
-                onResponseJson(featuresFromCache, true);
+                boolean featuresChanged = onResponseJson(featuresFromCache, true);
+                this.featureRefreshNotifier.notifyFailure(
+                        refreshFailure,
+                        source,
+                        featuresChanged,
+                        true,
+                        FeatureRefreshNotifier.elapsedMillis(startedAtNanos)
+                );
+                refreshEventNotified = true;
                 return;
             }
-            onResponseJson(responseBody.string(), false);
+            boolean featuresChanged = onResponseJson(responseBody.string(), false);
+            long durationMillis = FeatureRefreshNotifier.elapsedMillis(startedAtNanos);
+            this.onRefreshSuccess(this.featuresJson);
+            this.featureRefreshNotifier.notifySuccess(source, featuresChanged, false, durationMillis);
+            refreshEventNotified = true;
 
         } catch (IOException e) {
             log.error("FeatureFetchException: UNKNOWN feature fetch error code {}", e.getMessage(), e);
-            throw new FeatureFetchException(
+            FeatureFetchException featureFetchException = new FeatureFetchException(
                     FeatureFetchException.FeatureFetchErrorCode.UNKNOWN,
                     e.getMessage()
             );
+            this.featureRefreshNotifier.notifyFailure(
+                    featureFetchException,
+                    source,
+                    false,
+                    false,
+                    FeatureRefreshNotifier.elapsedMillis(startedAtNanos)
+            );
+            throw featureFetchException;
+        } catch (FeatureFetchException e) {
+            if (!refreshEventNotified) {
+                this.featureRefreshNotifier.notifyFailure(e, source, false, false, FeatureRefreshNotifier.elapsedMillis(startedAtNanos));
+            }
+            throw e;
         }
     }
 
@@ -783,6 +940,9 @@ public class GBFeaturesRepository implements IGBFeaturesRepository {
     }
 
     public void shutdown() {
+        // release refresh callbacks and listeners so a shut-down repository holds no caller references
+        this.refreshCallbacks.clear();
+        this.featureRefreshNotifier.clear();
         // stop polling
         if (this.pollScheduler != null) {
             this.pollScheduler.shutdownNow();
@@ -819,9 +979,17 @@ public class GBFeaturesRepository implements IGBFeaturesRepository {
     }
 
     public void fetchForRemoteEval(RequestBodyForRemoteEval requestBodyForRemoteEval) throws FeatureFetchException {
+        fetchForRemoteEval(requestBodyForRemoteEval, FeatureRefreshSource.REMOTE_EVALUATION);
+    }
+
+    private void fetchForRemoteEval(
+            RequestBodyForRemoteEval requestBodyForRemoteEval,
+            FeatureRefreshSource source
+    ) throws FeatureFetchException {
         if (this.remoteEvalEndPoint == null) {
             throw new IllegalArgumentException("remote eval features endpoint cannot be null");
         }
+        long startedAtNanos = System.nanoTime();
         String jsonBody = GrowthBookJsonUtils.getInstance().gson.toJson(requestBodyForRemoteEval);
         RequestBody requestBody = RequestBody.create(
                 jsonBody,
@@ -834,12 +1002,16 @@ public class GBFeaturesRepository implements IGBFeaturesRepository {
 
         try (Response response = this.okHttpClient.newCall(request).execute()) {
             if (response.isSuccessful() && response.code() == 200) {
-                onSuccess(response);
+                onSuccess(response, source, startedAtNanos);
             } else {
-                onRefreshFailed(new Throwable("Response is not success, response code is:" + response.code() + ". And message is: " + response.message()));
+                Throwable error = new Throwable("Response is not success, response code is:" + response.code() + ". And message is: " + response.message());
+                long durationMillis = FeatureRefreshNotifier.elapsedMillis(startedAtNanos);
+                onRefreshFailed(error);
+                featureRefreshNotifier.notifyFailure(error, source, false, false, durationMillis);
             }
         } catch (IOException e) {
             log.error(e.getMessage(), e);
+            featureRefreshNotifier.notifyFailure(e, source, false, false, FeatureRefreshNotifier.elapsedMillis(startedAtNanos));
             throw new FeatureFetchException(FeatureFetchException.FeatureFetchErrorCode.NO_RESPONSE_ERROR, e.getMessage());
         }
     }

--- a/lib/src/main/java/growthbook/sdk/java/repository/IGBFeaturesRepository.java
+++ b/lib/src/main/java/growthbook/sdk/java/repository/IGBFeaturesRepository.java
@@ -2,6 +2,7 @@ package growthbook.sdk.java.repository;
 
 import growthbook.sdk.java.exception.FeatureFetchException;
 import growthbook.sdk.java.callback.FeatureRefreshCallback;
+import growthbook.sdk.java.listener.FeatureRefreshListener;
 
 /**
  * INTERNAL: Interface that is used internally for the {@link GBFeaturesRepository}
@@ -16,10 +17,29 @@ public interface IGBFeaturesRepository {
      */
     String getFeaturesJson();
 
+    /**
+     * Registers a legacy feature refresh callback.
+     *
+     * @param callback callback to register
+     * @deprecated Use {@link #addFeatureRefreshListener(FeatureRefreshListener)}.
+     */
+    @Deprecated
     void onFeaturesRefresh(FeatureRefreshCallback callback);
 
+    default void addFeatureRefreshListener(FeatureRefreshListener listener) {
+        // Optional for repository implementations that do not refresh features.
+    }
+
+    default void removeFeatureRefreshListener(FeatureRefreshListener listener) {
+        // Optional for repository implementations that do not refresh features.
+    }
+
     /**
-     * Clears the feature refresh callbacks
+     * Clears legacy feature refresh callbacks.
+     *
+     * @deprecated Use listener-specific unsubscription with
+     * {@link #removeFeatureRefreshListener(FeatureRefreshListener)} where available.
      */
+    @Deprecated
     void clearCallbacks();
 }

--- a/lib/src/main/java/growthbook/sdk/java/repository/LocalGbFeatureRepository.java
+++ b/lib/src/main/java/growthbook/sdk/java/repository/LocalGbFeatureRepository.java
@@ -3,23 +3,32 @@ package growthbook.sdk.java.repository;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonObject;
-import growthbook.sdk.java.exception.FeatureFetchException;
 import growthbook.sdk.java.callback.FeatureRefreshCallback;
+import growthbook.sdk.java.exception.FeatureFetchException;
+import growthbook.sdk.java.listener.FeatureRefreshListener;
 import growthbook.sdk.java.model.Feature;
+import growthbook.sdk.java.model.FeatureRefreshSource;
 import growthbook.sdk.java.multiusermode.util.TransformationUtil;
+import growthbook.sdk.java.repository.internal.FeatureRefreshNotifier;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
-import java.io.FileNotFoundException;
 import java.io.FileReader;
+import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
+import java.util.Objects;
 
 @Slf4j
 @RequiredArgsConstructor
 public class LocalGbFeatureRepository implements IGBFeaturesRepository {
+
+    private static final String PATH_DELIMITER = "/";
+
     private String featuresJson = "{}";
+    private final FeatureRefreshNotifier featureRefreshNotifier = new FeatureRefreshNotifier(this::getActiveFeatureCount, () -> null);
+
     /**
      * Pass path from source root
      */
@@ -32,28 +41,42 @@ public class LocalGbFeatureRepository implements IGBFeaturesRepository {
      */
     @Override
     public void initialize() throws FeatureFetchException {
+        long startedAtNanos = System.nanoTime();
         GsonBuilder gsonBuilder = new GsonBuilder();
         Gson gson = gsonBuilder.create();
 
         String resourcesDirectory = getResourceDirectoryPath();
         String fullPath = resourcesDirectory + validateUserJsonPath(jsonPath);
 
-        try {
-            JsonObject featuresJsonObject = gson.fromJson(
-                    new FileReader(fullPath),
-                    JsonObject.class
-            );
-            this.featuresJson = featuresJsonObject.toString();
+        try (FileReader reader = new FileReader(fullPath)) {
+            JsonObject featuresJsonObject = gson.fromJson(reader, JsonObject.class);
+            String refreshedFeatures = featuresJsonObject.toString();
+            boolean featuresChanged = !Objects.equals(this.featuresJson, refreshedFeatures);
+            this.featuresJson = refreshedFeatures;
             log.info("LocalGbFeatureRepository load features from {} successfully", fullPath);
             log.info("Features: {}", featuresJson);
-        } catch (FileNotFoundException e) {
+            featureRefreshNotifier.notifySuccess(
+                    FeatureRefreshSource.INITIALIZATION,
+                    featuresChanged,
+                    false,
+                    FeatureRefreshNotifier.elapsedMillis(startedAtNanos)
+            );
+        } catch (IOException e) {
             log.error("LocalGbFeatureRepository cannot load features from {}, Exception was: {}",
                     fullPath,
                     e.getMessage(),
                     e);
-            throw new FeatureFetchException(
+            FeatureFetchException featureFetchException = new FeatureFetchException(
                     FeatureFetchException.FeatureFetchErrorCode.CONFIGURATION_ERROR,
                     "Failed to load features from: " + fullPath);
+            featureRefreshNotifier.notifyFailure(
+                    featureFetchException,
+                    FeatureRefreshSource.INITIALIZATION,
+                    false,
+                    false,
+                    FeatureRefreshNotifier.elapsedMillis(startedAtNanos)
+            );
+            throw featureFetchException;
         }
 
     }
@@ -83,15 +106,36 @@ public class LocalGbFeatureRepository implements IGBFeaturesRepository {
 
     /**
      * Can be ignored for this implementation
+     *
+     * @deprecated Use {@link #addFeatureRefreshListener(FeatureRefreshListener)}.
      */
+    @Deprecated
     @Override
     public void onFeaturesRefresh(FeatureRefreshCallback callback) {
         // Not needed in this implementation
     }
 
+    @Override
+    public void addFeatureRefreshListener(FeatureRefreshListener listener) {
+        if (listener != null) {
+            this.featureRefreshNotifier.add(listener);
+        }
+    }
+
+    @Override
+    public void removeFeatureRefreshListener(FeatureRefreshListener listener) {
+        if (listener != null) {
+            this.featureRefreshNotifier.remove(listener);
+        }
+    }
+
     /**
      * Can be ignored for this implementation
+     *
+     * @deprecated Use listener-specific unsubscription with
+     * {@link #removeFeatureRefreshListener(FeatureRefreshListener)} where available.
      */
+    @Deprecated
     @Override
     public void clearCallbacks() {
         // Not needed in this implementation
@@ -103,12 +147,17 @@ public class LocalGbFeatureRepository implements IGBFeaturesRepository {
     }
 
     private String validateUserJsonPath(String jsonPath) {
-        if (!jsonPath.startsWith("/")) {
-            jsonPath = "/" + jsonPath;
+        if (!jsonPath.startsWith(PATH_DELIMITER)) {
+            jsonPath = PATH_DELIMITER + jsonPath;
         }
         if (!jsonPath.endsWith(".json")) {
             jsonPath += ".json";
         }
         return jsonPath;
+    }
+
+    private int getActiveFeatureCount() {
+        Map<String, Feature<?>> features = TransformationUtil.transformFeatures(this.featuresJson);
+        return features == null ? 0 : features.size();
     }
 }

--- a/lib/src/main/java/growthbook/sdk/java/repository/NativeJavaGbFeatureRepository.java
+++ b/lib/src/main/java/growthbook/sdk/java/repository/NativeJavaGbFeatureRepository.java
@@ -2,9 +2,10 @@ package growthbook.sdk.java.repository;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import growthbook.sdk.java.listener.FeatureRefreshListener;
 import growthbook.sdk.java.model.Feature;
+import growthbook.sdk.java.model.FeatureRefreshSource;
 import growthbook.sdk.java.multiusermode.util.TransformationUtil;
-import growthbook.sdk.java.sandbox.FileCachingManagerImpl;
 import growthbook.sdk.java.sandbox.GbCacheManager;
 import growthbook.sdk.java.util.DecryptionUtils;
 import growthbook.sdk.java.exception.FeatureFetchException;
@@ -16,6 +17,7 @@ import growthbook.sdk.java.model.HttpMethods;
 import growthbook.sdk.java.model.RequestBodyForRemoteEval;
 import growthbook.sdk.java.model.SseKey;
 import growthbook.sdk.java.model.GBContext;
+import growthbook.sdk.java.repository.internal.FeatureRefreshNotifier;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -31,6 +33,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -128,9 +131,16 @@ public class NativeJavaGbFeatureRepository implements IGBFeaturesRepository {
      */
     private final AtomicReference<String> featuresJson = new AtomicReference<>(EMPTY_JSON_OBJECT_STRING);
     /**
-     * Optional callbacks for getting updates when features are refreshed
+     * Legacy callbacks for getting updates when features are refreshed.
+     *
+     * @deprecated Use {@link #addFeatureRefreshListener(FeatureRefreshListener)}.
      */
+    @Deprecated
     private final CopyOnWriteArrayList<FeatureRefreshCallback> refreshCallbacks = new CopyOnWriteArrayList<>();
+    /**
+     * Metadata-only listeners used by the feature refresh listener API.
+     */
+    private final FeatureRefreshNotifier featureRefreshNotifier = new FeatureRefreshNotifier(this::getActiveFeatureCount, () -> this.refreshStrategy);
     /**
      * Lock for synchronize code and avoid race condition
      */
@@ -228,16 +238,16 @@ public class NativeJavaGbFeatureRepository implements IGBFeaturesRepository {
 
             switch (this.refreshStrategy) {
                 case STALE_WHILE_REVALIDATE:
-                    fetchFeatures();
+                    fetchFeatures(FeatureRefreshSource.INITIALIZATION);
                     break;
 
                 case SERVER_SENT_EVENTS:
-                    fetchFeatures();
+                    fetchFeatures(FeatureRefreshSource.INITIALIZATION);
                     initializeSSE(retryOnFailure);
                     break;
 
                 case REMOTE_EVAL_STRATEGY:
-                    fetchForRemoteEval(this.requestBodyForRemoteEval);
+                    fetchForRemoteEval(this.requestBodyForRemoteEval, FeatureRefreshSource.REMOTE_EVALUATION);
                     break;
             }
 
@@ -268,7 +278,7 @@ public class NativeJavaGbFeatureRepository implements IGBFeaturesRepository {
 
     private void enqueueFeatureRefreshRequest() {
         try {
-            fetchFeatures();
+            fetchFeatures(FeatureRefreshSource.POLLING);
         } catch (FeatureFetchException e) {
             log.error("FeatureFetchException occur with message - {}, Code is - {}", e.getMessage(), e.getErrorCode(), e);
         }
@@ -295,15 +305,48 @@ public class NativeJavaGbFeatureRepository implements IGBFeaturesRepository {
      * This is called even if the features have not changed.
      *
      * @param callback This callback will be called when features are refreshed
+     * @deprecated Use {@link #addFeatureRefreshListener(FeatureRefreshListener)}.
      */
+    @Deprecated
     @Override
     public void onFeaturesRefresh(FeatureRefreshCallback callback) {
-        this.refreshCallbacks.add(callback);
+        if (callback == null) {
+            return;
+        }
+        this.refreshCallbacks.addIfAbsent(callback);
+    }
+
+    /**
+     * Adds a metadata-only feature refresh listener.
+     *
+     * @param listener listener to add
+     */
+    @Override
+    public void addFeatureRefreshListener(FeatureRefreshListener listener) {
+        if (listener != null) {
+            this.featureRefreshNotifier.add(listener);
+        }
+    }
+
+    /**
+     * Removes a previously registered feature refresh listener.
+     *
+     * @param listener listener to remove
+     */
+    @Override
+    public void removeFeatureRefreshListener(FeatureRefreshListener listener) {
+        if (listener != null) {
+            this.featureRefreshNotifier.remove(listener);
+        }
     }
 
     /**
      * Clears the feature refresh callbacks
+     *
+     * @deprecated Use listener-specific unsubscription with
+     * {@link #removeFeatureRefreshListener(FeatureRefreshListener)} where available.
      */
+    @Deprecated
     @Override
     public void clearCallbacks() {
         this.refreshCallbacks.clear();
@@ -316,10 +359,15 @@ public class NativeJavaGbFeatureRepository implements IGBFeaturesRepository {
     }
 
     public void fetchFeatures() throws FeatureFetchException {
+        fetchFeatures(FeatureRefreshSource.MANUAL);
+    }
+
+    private void fetchFeatures(FeatureRefreshSource source) throws FeatureFetchException {
         if (this.featuresEndpoint == null) {
             throw new IllegalArgumentException("features endpoint cannot be null");
         }
 
+        long startedAtNanos = System.nanoTime();
         HttpURLConnection connection = null;
         BufferedReader reader = null;
 
@@ -341,6 +389,7 @@ public class NativeJavaGbFeatureRepository implements IGBFeaturesRepository {
                 log.info("Features not modified (304). Using existing data.");
                 this.refreshExpiresAt();
                 this.onRefreshSuccess(this.featuresJson.get());
+                this.featureRefreshNotifier.notifySuccess(source, false, false, FeatureRefreshNotifier.elapsedMillis(startedAtNanos));
                 return;
             }
 
@@ -360,20 +409,90 @@ public class NativeJavaGbFeatureRepository implements IGBFeaturesRepository {
                 reader.close();
                 String responseBody = responseBuilder.toString();
                 String sseSupportHeader = connection.getHeaderField(HttpHeaders.X_SSE_SUPPORT.getHeader());
-                if (sseSupportHeader == null) {
-                    throw new FeatureFetchException(FeatureFetchException.FeatureFetchErrorCode.UNKNOWN);
-                }
-                this.sseAllowed.set(ENABLED.equals(sseSupportHeader));
-                this.onSuccess(responseBody, false);
+                this.sseAllowed.set(Objects.equals(sseSupportHeader, ENABLED));
+                this.onSuccess(responseBody, false, source, startedAtNanos);
+                return;
             }
+
+            FeatureFetchException refreshFailure = new FeatureFetchException(
+                    FeatureFetchException.FeatureFetchErrorCode.HTTP_RESPONSE_ERROR,
+                    "Failed to fetch data from server"
+            );
+
+            if (isCacheDisabled.get()) {
+                this.featureRefreshNotifier.notifyFailure(
+                        refreshFailure,
+                        source,
+                        false,
+                        false,
+                        FeatureRefreshNotifier.elapsedMillis(startedAtNanos)
+                );
+                throw refreshFailure;
+            }
+
+            String cachedData;
+            try {
+                cachedData = getCachedFeatures();
+            } catch (FeatureFetchException e) {
+                this.featureRefreshNotifier.notifyFailure(
+                        e,
+                        source,
+                        false,
+                        false,
+                        FeatureRefreshNotifier.elapsedMillis(startedAtNanos)
+                );
+                throw e;
+            }
+            if (cachedData.isEmpty()) {
+                FeatureFetchException cacheFailure = new FeatureFetchException(
+                        FeatureFetchException.FeatureFetchErrorCode.NO_RESPONSE_ERROR,
+                        "Failed to fetch data from cache"
+                );
+                this.featureRefreshNotifier.notifyFailure(
+                        cacheFailure,
+                        source,
+                        false,
+                        false,
+                        FeatureRefreshNotifier.elapsedMillis(startedAtNanos)
+                );
+                throw cacheFailure;
+            }
+
+            boolean featuresChanged = onResponseJson(cachedData, true);
+            this.featureRefreshNotifier.notifyFailure(
+                    refreshFailure,
+                    source,
+                    featuresChanged,
+                    true,
+                    FeatureRefreshNotifier.elapsedMillis(startedAtNanos)
+            );
         } catch (IOException e) {
             log.error(e.getMessage(), e);
+            boolean featuresChanged = false;
+            boolean loadedFromCache = false;
+            FeatureFetchException cacheFailure = null;
             if (!isCacheDisabled.get()) {
-                String cachedData = getCachedFeatures();
-                onResponseJson(cachedData, true);
-            } else {
-                this.onRefreshFailed(e);
-
+                try {
+                    String cachedData = getCachedFeatures();
+                    featuresChanged = onResponseJson(cachedData, true);
+                    loadedFromCache = true;
+                } catch (FeatureFetchException exception) {
+                    cacheFailure = exception;
+                }
+            }
+            long durationMillis = FeatureRefreshNotifier.elapsedMillis(startedAtNanos);
+            this.onRefreshFailed(e);
+            this.featureRefreshNotifier.notifyFailure(
+                    e,
+                    source,
+                    featuresChanged,
+                    loadedFromCache,
+                    durationMillis
+            );
+            if (cacheFailure != null) {
+                throw cacheFailure;
+            }
+            if (!loadedFromCache) {
                 throw new FeatureFetchException(FeatureFetchException.FeatureFetchErrorCode.UNKNOWN,
                         e.getMessage());
             }
@@ -393,24 +512,36 @@ public class NativeJavaGbFeatureRepository implements IGBFeaturesRepository {
     }
 
 
-    private void onSuccess(String response, boolean isFromCache) throws FeatureFetchException {
+    private void onSuccess(
+            String response,
+            boolean isFromCache,
+            FeatureRefreshSource source,
+            long startedAtNanos
+    ) throws FeatureFetchException {
         String responseJsonString;
         if (response != null) {
             responseJsonString = response;
-        }else {
+        } else {
             log.error("FeatureFetchException: FeatureFetchErrorCode.NO_RESPONSE_ERROR");
             log.info("Fetching data from cache...");
             responseJsonString = getCachedFeatures();
             isFromCache = true;
         }
-        onResponseJson(responseJsonString, isFromCache);
+        boolean featuresChanged = onResponseJson(responseJsonString, isFromCache);
+        this.onRefreshSuccess(this.featuresJson.get());
+        this.featureRefreshNotifier.notifySuccess(
+                source,
+                featuresChanged,
+                isFromCache,
+                FeatureRefreshNotifier.elapsedMillis(startedAtNanos)
+        );
     }
 
-    private void onResponseJson(String responseJsonString, boolean isFromCache) throws FeatureFetchException {
+    private boolean onResponseJson(String responseJsonString, boolean isFromCache) throws FeatureFetchException {
         try {
             lock.lock();
             if (responseJsonString == null || responseJsonString.trim().isEmpty()) {
-                return;
+                return false;
             }
 
             if (!isFromCache && !isCacheDisabled.get() && cacheManager.get() != null) {
@@ -468,10 +599,13 @@ public class NativeJavaGbFeatureRepository implements IGBFeaturesRepository {
                     }
                 }
 
+                boolean featuresChanged = !Objects.equals(this.featuresJson.get(), refreshedFeatures)
+                        || !Objects.equals(this.savedGroupsJson.get(), refreshedSavedGroups);
                 this.featuresJson.set(refreshedFeatures);
                 this.savedGroupsJson.set(refreshedSavedGroups);
 
-                this.onRefreshSuccess(this.featuresJson.get());
+                this.refreshExpiresAt();
+                return featuresChanged;
             } catch (DecryptionUtils.DecryptionException e) {
                 log.error("DecryptionException exception occur, when try to parse: {}. {}",
                         responseJsonString, e.getMessage(), e);
@@ -486,20 +620,59 @@ public class NativeJavaGbFeatureRepository implements IGBFeaturesRepository {
         }
     }
 
+    private void refreshFromJson(String responseJsonString, FeatureRefreshSource source) throws FeatureFetchException {
+        long startedAtNanos = System.nanoTime();
+        try {
+            boolean featuresChanged = onResponseJson(responseJsonString, false);
+            this.onRefreshSuccess(this.featuresJson.get());
+            this.featureRefreshNotifier.notifySuccess(source, featuresChanged, false, FeatureRefreshNotifier.elapsedMillis(startedAtNanos));
+        } catch (FeatureFetchException e) {
+            this.featureRefreshNotifier.notifyFailure(e, source, false, false, FeatureRefreshNotifier.elapsedMillis(startedAtNanos));
+            throw e;
+        }
+    }
+
+    /**
+     * Dispatches legacy feature refresh callbacks.
+     *
+     * @deprecated Use {@link FeatureRefreshNotifier}.
+     */
+    @Deprecated
     public void onRefreshSuccess(String featuresJson) {
         for (FeatureRefreshCallback callback : this.refreshCallbacks) {
             if (callback != null) {
-                callback.onRefresh(featuresJson);
+                try {
+                    callback.onRefresh(featuresJson);
+                } catch (Exception e) {
+                    log.warn("Feature refresh callback failed", e);
+                }
             }
         }
     }
 
+    /**
+     * Dispatches legacy feature refresh error callbacks.
+     *
+     * @deprecated Use {@link FeatureRefreshNotifier}.
+     */
+    @Deprecated
     public void onRefreshFailed(Throwable throwable) {
         for (FeatureRefreshCallback callback : this.refreshCallbacks) {
             if (callback != null) {
-                callback.onError(throwable);
+                try {
+                    callback.onError(throwable);
+                } catch (Exception e) {
+                    log.warn("Feature refresh error callback failed", e);
+                }
             }
         }
+    }
+
+    private int getActiveFeatureCount() {
+        return Optional.ofNullable(this.featuresJson.get())
+                .map(TransformationUtil::transformFeatures)
+                .map(Map::size)
+                .orElse(0);
     }
 
     private Boolean isCacheExpired() {
@@ -532,7 +705,7 @@ public class NativeJavaGbFeatureRepository implements IGBFeaturesRepository {
                         } else if (line.isEmpty()) {
                             String data = dataBuffer.toString();
                             if (!data.isEmpty()) {
-                                onResponseJson(data, false);
+                                refreshFromJson(data, FeatureRefreshSource.SSE);
                             }
                             dataBuffer.setLength(0);
                         }
@@ -555,8 +728,16 @@ public class NativeJavaGbFeatureRepository implements IGBFeaturesRepository {
         new Thread(sseTask).start();
     }
 
-    private void fetchForRemoteEval(RequestBodyForRemoteEval requestBodyForRemoteEval) throws FeatureFetchException {
+    public void fetchForRemoteEval(RequestBodyForRemoteEval requestBodyForRemoteEval) throws FeatureFetchException {
+        fetchForRemoteEval(requestBodyForRemoteEval, FeatureRefreshSource.REMOTE_EVALUATION);
+    }
+
+    private void fetchForRemoteEval(
+            RequestBodyForRemoteEval requestBodyForRemoteEval,
+            FeatureRefreshSource source
+    ) throws FeatureFetchException {
         HttpURLConnection urlConnection = null;
+        long startedAtNanos = System.nanoTime();
         try {
             String body = GrowthBookJsonUtils.getInstance().gson.toJson(requestBodyForRemoteEval);
 
@@ -582,15 +763,17 @@ public class NativeJavaGbFeatureRepository implements IGBFeaturesRepository {
                 }
                 bufferedReader.close();
                 String jsonResponse = builder.toString();
-                onSuccess(jsonResponse, false);
+                onSuccess(jsonResponse, false, source, startedAtNanos);
             } else {
-                onRefreshFailed(new Throwable(
+                Throwable error = new Throwable(
                         "Response is not success. Response code: " + urlConnection.getResponseCode() + ". Message: " + urlConnection.getResponseMessage()
-                ));
+                );
+                onRefreshFailed(error);
+                featureRefreshNotifier.notifyFailure(error, source, false, false, FeatureRefreshNotifier.elapsedMillis(startedAtNanos));
             }
         } catch (IOException e) {
-            onRefreshFailed(e);
             log.error("Exception occur with message: {}", e.getMessage(), e);
+            featureRefreshNotifier.notifyFailure(e, source, false, false, FeatureRefreshNotifier.elapsedMillis(startedAtNanos));
             throw new FeatureFetchException(FeatureFetchException.FeatureFetchErrorCode.NO_RESPONSE_ERROR, e.getMessage());
         } finally {
             if (urlConnection != null) {

--- a/lib/src/main/java/growthbook/sdk/java/repository/internal/FeatureRefreshNotifier.java
+++ b/lib/src/main/java/growthbook/sdk/java/repository/internal/FeatureRefreshNotifier.java
@@ -1,0 +1,138 @@
+package growthbook.sdk.java.repository.internal;
+
+import growthbook.sdk.java.listener.FeatureRefreshListener;
+import growthbook.sdk.java.listener.internal.FeatureRefreshListenerDispatcher;
+import growthbook.sdk.java.model.FeatureRefreshEvent;
+import growthbook.sdk.java.model.FeatureRefreshSource;
+import growthbook.sdk.java.repository.FeatureRefreshStrategy;
+
+import javax.annotation.Nullable;
+import java.util.concurrent.TimeUnit;
+import java.util.function.IntSupplier;
+import java.util.function.Supplier;
+
+/**
+ * Internal dispatcher for repository-level feature refresh events.
+ * Builds metadata-only refresh events and isolates listener failures from repository refresh flow.
+ */
+public final class FeatureRefreshNotifier {
+
+    private final IntSupplier activeFeatureCountSupplier;
+    private final Supplier<FeatureRefreshStrategy> refreshStrategySupplier;
+    private final FeatureRefreshListenerDispatcher dispatcher = new FeatureRefreshListenerDispatcher();
+
+    /**
+     * Creates a notifier backed by repository-specific metadata suppliers.
+     *
+     * @param activeFeatureCountSupplier supplies the current active feature count
+     * @param refreshStrategySupplier supplies the repository refresh strategy
+     */
+    public FeatureRefreshNotifier(
+            IntSupplier activeFeatureCountSupplier,
+            Supplier<FeatureRefreshStrategy> refreshStrategySupplier
+    ) {
+        this.activeFeatureCountSupplier = activeFeatureCountSupplier;
+        this.refreshStrategySupplier = refreshStrategySupplier;
+    }
+
+    /**
+     * Registers a listener if it is non-null and not already registered.
+     *
+     * @param listener listener to register
+     */
+    public void add(FeatureRefreshListener listener) {
+        dispatcher.add(listener);
+    }
+
+    /**
+     * Removes a registered listener.
+     *
+     * @param listener listener to remove
+     */
+    public void remove(FeatureRefreshListener listener) {
+        dispatcher.remove(listener);
+    }
+
+    /**
+     * Removes all registered listeners. Intended for repository shutdown.
+     */
+    public void clear() {
+        dispatcher.clear();
+    }
+
+    /**
+     * Publishes a successful refresh event.
+     *
+     * @param source refresh source
+     * @param featuresChanged whether feature data changed
+     * @param loadedFromCache whether the successful data came from cache
+     * @param durationMillis refresh duration in milliseconds
+     */
+    public void notifySuccess(
+            FeatureRefreshSource source,
+            boolean featuresChanged,
+            boolean loadedFromCache,
+            long durationMillis
+    ) {
+        if (dispatcher.hasNoListeners()) {
+            return;
+        }
+        notifyListeners(FeatureRefreshEvent.success(
+                featuresChanged,
+                loadedFromCache,
+                activeFeatureCountSupplier.getAsInt(),
+                source,
+                getRefreshStrategy(),
+                durationMillis
+        ));
+    }
+
+    /**
+     * Publishes a failed refresh event.
+     *
+     * @param error refresh failure
+     * @param source refresh source
+     * @param featuresChanged whether cache fallback changed feature data
+     * @param loadedFromCache whether cache fallback data was loaded
+     * @param durationMillis refresh duration in milliseconds
+     */
+    public void notifyFailure(
+            Throwable error,
+            FeatureRefreshSource source,
+            boolean featuresChanged,
+            boolean loadedFromCache,
+            long durationMillis
+    ) {
+        if (dispatcher.hasNoListeners()) {
+            return;
+        }
+        notifyListeners(FeatureRefreshEvent.failure(
+                error,
+                featuresChanged,
+                loadedFromCache,
+                activeFeatureCountSupplier.getAsInt(),
+                source,
+                getRefreshStrategy(),
+                durationMillis
+        ));
+    }
+
+    /**
+     * Calculates elapsed milliseconds from a {@link System#nanoTime()} start value.
+     *
+     * @param startedAtNanos start time from {@link System#nanoTime()}
+     * @return elapsed milliseconds
+     */
+    public static long elapsedMillis(long startedAtNanos) {
+        return TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startedAtNanos);
+    }
+
+    @Nullable
+    private FeatureRefreshStrategy getRefreshStrategy() {
+        return refreshStrategySupplier == null ? null : refreshStrategySupplier.get();
+    }
+
+    private void notifyListeners(FeatureRefreshEvent event) {
+        dispatcher.publish(event);
+    }
+}

--- a/lib/src/main/java/growthbook/sdk/java/util/UserContextUtils.java
+++ b/lib/src/main/java/growthbook/sdk/java/util/UserContextUtils.java
@@ -1,12 +1,14 @@
-package growthbook.sdk.java.multiusermode.internal;
+package growthbook.sdk.java.util;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import growthbook.sdk.java.model.StickyAssignmentsDocument;
 import growthbook.sdk.java.multiusermode.configurations.Options;
 import growthbook.sdk.java.multiusermode.configurations.UserContext;
+import growthbook.sdk.java.multiusermode.internal.GlobalContextManager;
+import growthbook.sdk.java.multiusermode.internal.RemoteEvalCoordinator;
 import growthbook.sdk.java.stickyBucketing.StickyBucketService;
-import growthbook.sdk.java.util.GrowthBookJsonUtils;
+import lombok.experimental.UtilityClass;
 
 import javax.annotation.Nullable;
 import java.util.HashMap;
@@ -24,10 +26,8 @@ import java.util.Map;
  * without their persisted assignments, changing assignment behaviour and diverging from the
  * sticky-bucketing contract shared across GrowthBook SDKs.
  */
-final class UserContextMerger {
-
-    private UserContextMerger() {
-    }
+@UtilityClass
+public final class UserContextUtils {
 
     /**
      * Merges global and per-user attributes and preloads sticky-bucket assignments for the merged
@@ -38,9 +38,7 @@ final class UserContextMerger {
      * @param userContext the per-request user context; {@code null} is treated as an empty context
      * @return a new user context carrying the merged attributes and any preloaded sticky docs
      */
-    static UserContext mergeAttributesAndPreloadSticky(Options options, @Nullable UserContext userContext) {
-        // Null-safe default: callers such as GrowthBookClient.preloadRemoteEval may pass null to warm
-        // the default/global response. Treat that as an empty context (the previous merge helper did).
+    public static UserContext mergeAttributesAndPreloadSticky(Options options, @Nullable UserContext userContext) {
         UserContext safeUserContext = userContext == null ? UserContext.builder().build() : userContext;
         JsonObject mergedAttributes = mergeAttributes(options, safeUserContext);
         UserContext mergedUserContext = safeUserContext.withAttributes(mergedAttributes);

--- a/lib/src/test/java/growthbook/sdk/java/GBFeaturesRepositoryTest.java
+++ b/lib/src/test/java/growthbook/sdk/java/GBFeaturesRepositoryTest.java
@@ -1,13 +1,17 @@
 package growthbook.sdk.java;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
@@ -16,6 +20,9 @@ import static org.mockito.Mockito.when;
 import com.google.gson.JsonObject;
 import growthbook.sdk.java.callback.FeatureRefreshCallback;
 import growthbook.sdk.java.exception.FeatureFetchException;
+import growthbook.sdk.java.listener.FeatureRefreshListener;
+import growthbook.sdk.java.model.FeatureRefreshEvent;
+import growthbook.sdk.java.model.FeatureRefreshSource;
 import growthbook.sdk.java.model.RequestBodyForRemoteEval;
 import growthbook.sdk.java.repository.FeatureRefreshStrategy;
 import growthbook.sdk.java.repository.GBFeaturesRepository;
@@ -245,6 +252,154 @@ class GBFeaturesRepositoryTest {
     }
 
     @Test
+    void testOnFeaturesRefresh_ContinuesAfterCallbackFailure() throws IOException, FeatureFetchException {
+        String responseJson = "{\"features\":{\"test-feature\":{\"defaultValue\":true}}}";
+        FeatureRefreshCallback failingCallback = mock(FeatureRefreshCallback.class);
+        FeatureRefreshCallback successfulCallback = mock(FeatureRefreshCallback.class);
+        doThrow(new RuntimeException("callback failed")).when(failingCallback).onRefresh(anyString());
+
+        GBFeaturesRepository subject = new GBFeaturesRepository(
+                "http://localhost:80",
+                "sdk-abc123",
+                null,
+                null,
+                60,
+                mockHttpClient(responseJson),
+                null,
+                null,
+                null,
+                null
+        );
+
+        subject.onFeaturesRefresh(failingCallback);
+        subject.onFeaturesRefresh(successfulCallback);
+        subject.initialize();
+
+        verify(successfulCallback).onRefresh("{\"test-feature\":{\"defaultValue\":true}}");
+        subject.shutdown();
+    }
+
+    @Test
+    void testFeatureRefreshListener_receivesInitializationMetadata() throws IOException, FeatureFetchException {
+        FeatureRefreshListener listener = mock(FeatureRefreshListener.class);
+        GBFeaturesRepository subject = new GBFeaturesRepository(
+                "http://localhost:80",
+                "sdk-abc123",
+                null,
+                null,
+                60,
+                mockHttpClient("{\"features\":{\"test-feature\":{\"defaultValue\":true}}}"),
+                true,
+                null,
+                null
+        );
+        subject.addFeatureRefreshListener(listener);
+
+        subject.initialize();
+
+        ArgumentCaptor<FeatureRefreshEvent> eventCaptor = ArgumentCaptor.forClass(FeatureRefreshEvent.class);
+        verify(listener).onRefresh(eventCaptor.capture());
+        FeatureRefreshEvent event = eventCaptor.getValue();
+        assertTrue(event.isSuccessful());
+        assertTrue(event.isFeaturesChanged());
+        assertFalse(event.isLoadedFromCache());
+        assertEquals(1, event.getActiveFeatureCount());
+        assertEquals(FeatureRefreshSource.INITIALIZATION, event.getSource());
+        assertTrue(event.getDurationMillis() >= 0);
+        subject.shutdown();
+    }
+
+    @Test
+    void testFeatureRefreshListener_receivesManualNotModifiedMetadata() throws IOException, FeatureFetchException {
+        OkHttpClient mockOkHttpClient = mock(OkHttpClient.class);
+        Call mockCall = mock(Call.class);
+        Response response = mock(Response.class);
+        when(mockOkHttpClient.newCall(any(Request.class))).thenReturn(mockCall);
+        when(mockCall.execute()).thenReturn(response);
+        when(response.code()).thenReturn(304);
+
+        FeatureRefreshListener listener = mock(FeatureRefreshListener.class);
+        GBFeaturesRepository subject = new GBFeaturesRepository(
+                "http://localhost:80",
+                "sdk-abc123",
+                null,
+                null,
+                60,
+                mockOkHttpClient,
+                true,
+                null,
+                null
+        );
+        subject.addFeatureRefreshListener(listener);
+
+        subject.fetchFeatures();
+
+        ArgumentCaptor<FeatureRefreshEvent> eventCaptor = ArgumentCaptor.forClass(FeatureRefreshEvent.class);
+        verify(listener).onRefresh(eventCaptor.capture());
+        FeatureRefreshEvent event = eventCaptor.getValue();
+        assertTrue(event.isSuccessful());
+        assertFalse(event.isFeaturesChanged());
+        assertEquals(FeatureRefreshSource.MANUAL, event.getSource());
+    }
+
+    @Test
+    void testFeatureRefreshListener_continuesAfterListenerFailure() throws IOException, FeatureFetchException {
+        FeatureRefreshListener failingListener = mock(FeatureRefreshListener.class);
+        FeatureRefreshListener successfulListener = mock(FeatureRefreshListener.class);
+        doThrow(new RuntimeException("listener failed")).when(failingListener).onRefresh(any());
+        GBFeaturesRepository subject = new GBFeaturesRepository(
+                "http://localhost:80",
+                "sdk-abc123",
+                null,
+                null,
+                60,
+                mockHttpClient("{\"features\":{}}"),
+                true,
+                null,
+                null
+        );
+        subject.addFeatureRefreshListener(failingListener);
+        subject.addFeatureRefreshListener(successfulListener);
+
+        subject.fetchFeatures();
+
+        verify(successfulListener).onRefresh(any(FeatureRefreshEvent.class));
+    }
+
+    @Test
+    void shutdownClearsRegisteredListeners() throws IOException, FeatureFetchException {
+        OkHttpClient mockOkHttpClient = mock(OkHttpClient.class);
+        Call mockCall = mock(Call.class);
+        Response response = mock(Response.class);
+        when(mockOkHttpClient.newCall(any(Request.class))).thenReturn(mockCall);
+        when(mockCall.execute()).thenReturn(response);
+        when(response.code()).thenReturn(304);
+
+        FeatureRefreshListener listener = mock(FeatureRefreshListener.class);
+        GBFeaturesRepository subject = new GBFeaturesRepository(
+                "http://localhost:80",
+                "sdk-abc123",
+                null,
+                null,
+                60,
+                mockOkHttpClient,
+                true,
+                null,
+                null
+        );
+        subject.addFeatureRefreshListener(listener);
+
+        subject.fetchFeatures();
+        verify(listener, times(1)).onRefresh(any(FeatureRefreshEvent.class));
+
+        // shutdown must release listeners so a shut-down repository notifies no one
+        subject.shutdown();
+        subject.fetchFeatures();
+
+        verify(listener, times(1)).onRefresh(any(FeatureRefreshEvent.class));
+    }
+
+    @Test
     void testOnFeaturesRefresh_Error() throws IOException {
         OkHttpClient mockOkHttpClient = mock(OkHttpClient.class);
         IOException requestFailed = new IOException("Request failed");
@@ -300,6 +455,8 @@ class GBFeaturesRepositoryTest {
 
         RequestBodyForRemoteEval requestBody = new RequestBodyForRemoteEval();
         String expectedResponse = "{\"features\": {}}";
+        FeatureRefreshListener listener = mock(FeatureRefreshListener.class);
+        repository.addFeatureRefreshListener(listener);
 
 
 
@@ -319,6 +476,9 @@ class GBFeaturesRepositoryTest {
         verify(mockCall).execute();
         verify(mockResponseBody).string();
         assertEquals("{}", repository.getFeaturesJson());
+        ArgumentCaptor<FeatureRefreshEvent> eventCaptor = ArgumentCaptor.forClass(FeatureRefreshEvent.class);
+        verify(listener).onRefresh(eventCaptor.capture());
+        assertEquals(FeatureRefreshSource.REMOTE_EVALUATION, eventCaptor.getValue().getSource());
     }
 
     @Test
@@ -507,10 +667,19 @@ class GBFeaturesRepositoryTest {
         when(mockCacheManager.loadCache(anyString())).thenReturn(cachedData);
 
         subject.setCacheManager(mockCacheManager);
+        FeatureRefreshListener listener = mock(FeatureRefreshListener.class);
+        subject.addFeatureRefreshListener(listener);
         subject.initialize();
         String actualResult = subject.getFeaturesJson();
         assertEquals(expectedResult, actualResult);
         verify(mockCacheManager).loadCache(anyString());
+        ArgumentCaptor<FeatureRefreshEvent> eventCaptor = ArgumentCaptor.forClass(FeatureRefreshEvent.class);
+        verify(listener).onRefresh(eventCaptor.capture());
+        FeatureRefreshEvent event = eventCaptor.getValue();
+        assertFalse(event.isSuccessful());
+        assertTrue(event.isLoadedFromCache());
+        assertTrue(event.isFeaturesChanged());
+        assertEquals(FeatureRefreshSource.INITIALIZATION, event.getSource());
         mockCacheManager.clearCache();
     }
 

--- a/lib/src/test/java/growthbook/sdk/java/GrowthBookInitializationExceptionTest.java
+++ b/lib/src/test/java/growthbook/sdk/java/GrowthBookInitializationExceptionTest.java
@@ -1,0 +1,25 @@
+package growthbook.sdk.java;
+
+import growthbook.sdk.java.exception.FeatureFetchException;
+import growthbook.sdk.java.exception.GrowthBookInitializationException;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+class GrowthBookInitializationExceptionTest {
+
+    @Test
+    void preservesFeatureFetchExceptionDetails() {
+        FeatureFetchException cause = new FeatureFetchException(
+                FeatureFetchException.FeatureFetchErrorCode.NO_RESPONSE_ERROR,
+                "Request failed"
+        );
+
+        GrowthBookInitializationException exception = new GrowthBookInitializationException(cause);
+
+        assertEquals("Failed to initialize features repository", exception.getMessage());
+        assertEquals(FeatureFetchException.FeatureFetchErrorCode.NO_RESPONSE_ERROR, exception.getErrorCode());
+        assertSame(cause, exception.getCause());
+    }
+}

--- a/lib/src/test/java/growthbook/sdk/java/LocalGbFeatureRepositoryTest.java
+++ b/lib/src/test/java/growthbook/sdk/java/LocalGbFeatureRepositoryTest.java
@@ -1,15 +1,28 @@
 package growthbook.sdk.java;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import growthbook.sdk.java.exception.FeatureFetchException;
+import growthbook.sdk.java.listener.FeatureRefreshListener;
+import growthbook.sdk.java.model.FeatureRefreshEvent;
+import growthbook.sdk.java.model.FeatureRefreshSource;
 import growthbook.sdk.java.repository.LocalGbFeatureRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 class LocalGbFeatureRepositoryTest {
     private LocalGbFeatureRepository repository;
@@ -44,5 +57,59 @@ class LocalGbFeatureRepositoryTest {
         String featuresJson = repository.getFeaturesJson();
 
         assertEquals("{}", featuresJson);
+    }
+
+    @Test
+    void testFeatureRefreshListener_receivesInitializationMetadata() throws Exception {
+        Path localFeaturesPath = writeLocalResource(
+                "listener-test-features.json",
+                "{\"local-feature\":{\"defaultValue\":true}}"
+        );
+        try {
+            LocalGbFeatureRepository subject = new LocalGbFeatureRepository("listener-test-features.json");
+            FeatureRefreshListener listener = mock(FeatureRefreshListener.class);
+            subject.addFeatureRefreshListener(listener);
+
+            subject.initialize();
+
+            ArgumentCaptor<FeatureRefreshEvent> eventCaptor = ArgumentCaptor.forClass(FeatureRefreshEvent.class);
+            verify(listener).onRefresh(eventCaptor.capture());
+            FeatureRefreshEvent event = eventCaptor.getValue();
+            assertTrue(event.isSuccessful());
+            assertTrue(event.isFeaturesChanged());
+            assertFalse(event.isLoadedFromCache());
+            assertEquals(1, event.getActiveFeatureCount());
+            assertEquals(FeatureRefreshSource.INITIALIZATION, event.getSource());
+            assertTrue(event.getDurationMillis() >= 0);
+        } finally {
+            Files.deleteIfExists(localFeaturesPath);
+        }
+    }
+
+    @Test
+    void testFeatureRefreshListener_receivesInitializationFailureMetadata() {
+        LocalGbFeatureRepository subject = new LocalGbFeatureRepository("missing-listener-test-features.json");
+        FeatureRefreshListener listener = mock(FeatureRefreshListener.class);
+        subject.addFeatureRefreshListener(listener);
+
+        assertThrows(FeatureFetchException.class, subject::initialize);
+
+        ArgumentCaptor<FeatureRefreshEvent> eventCaptor = ArgumentCaptor.forClass(FeatureRefreshEvent.class);
+        verify(listener).onRefresh(eventCaptor.capture());
+        FeatureRefreshEvent event = eventCaptor.getValue();
+        assertFalse(event.isSuccessful());
+        assertFalse(event.isFeaturesChanged());
+        assertFalse(event.isLoadedFromCache());
+        assertEquals(0, event.getActiveFeatureCount());
+        assertEquals(FeatureRefreshSource.INITIALIZATION, event.getSource());
+        assertNotNull(event.getError());
+    }
+
+    private Path writeLocalResource(String fileName, String content) throws Exception {
+        Path resourcesDirectory = Paths.get("src", "main", "resources");
+        Files.createDirectories(resourcesDirectory);
+        Path filePath = resourcesDirectory.resolve(fileName);
+        Files.write(filePath, content.getBytes(StandardCharsets.UTF_8));
+        return filePath;
     }
 }

--- a/lib/src/test/java/growthbook/sdk/java/NativeJavaGbFeatureRepositoryTest.java
+++ b/lib/src/test/java/growthbook/sdk/java/NativeJavaGbFeatureRepositoryTest.java
@@ -1,45 +1,47 @@
 package growthbook.sdk.java;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 import growthbook.sdk.java.callback.FeatureRefreshCallback;
 import growthbook.sdk.java.exception.FeatureFetchException;
+import growthbook.sdk.java.listener.FeatureRefreshListener;
+import growthbook.sdk.java.model.FeatureRefreshEvent;
+import growthbook.sdk.java.model.FeatureRefreshSource;
+import growthbook.sdk.java.model.HttpHeaders;
 import growthbook.sdk.java.repository.FeatureRefreshStrategy;
 import growthbook.sdk.java.repository.NativeJavaGbFeatureRepository;
+import growthbook.sdk.java.sandbox.GbCacheManager;
+import com.sun.net.httpserver.HttpServer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.ArgumentCaptor;
 import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
 import java.net.HttpURLConnection;
-import java.net.URL;
+import java.nio.charset.StandardCharsets;
 
 class NativeJavaGbFeatureRepositoryTest {
     private static final String API_HOST = "https://cdn.growthbook.io";
     private static final String CLIENT_KEY = "java_NsrWldWd5bxQJZftGsWKl7R2yD2LtAK8C8EUYh9L8";
-
-    @Mock
-    private HttpURLConnection mockConnection;
-
-    @Mock
-    private URL mockUrl;
+    private static final String TEST_CLIENT_KEY = "sdk-test";
 
     private NativeJavaGbFeatureRepository repository;
 
 
     @BeforeEach
     void setUp() {
-        MockitoAnnotations.openMocks(this);
-
         repository = NativeJavaGbFeatureRepository.builder()
                 .apiHost(API_HOST)
                 .clientKey(CLIENT_KEY)
@@ -141,6 +143,19 @@ class NativeJavaGbFeatureRepositoryTest {
     }
 
     @Test
+    public void testOnFeaturesRefresh_ContinuesAfterListenerFailure() {
+        FeatureRefreshCallback failingListener = mock(FeatureRefreshCallback.class);
+        FeatureRefreshCallback successfulListener = mock(FeatureRefreshCallback.class);
+        doThrow(new RuntimeException("listener failed")).when(failingListener).onRefresh("{}");
+
+        repository.onFeaturesRefresh(failingListener);
+        repository.onFeaturesRefresh(successfulListener);
+        repository.onRefreshSuccess("{}");
+
+        verify(successfulListener).onRefresh("{}");
+    }
+
+    @Test
     public void testOnFeatureError_AddsListener() {
         FeatureRefreshCallback listener = mock(FeatureRefreshCallback.class);
         repository.onFeaturesRefresh(listener);
@@ -148,6 +163,20 @@ class NativeJavaGbFeatureRepositoryTest {
         repository.onRefreshFailed(new Exception("Error"));
 
         verify(listener, times(1)).onError(any(Throwable.class));
+    }
+
+    @Test
+    public void testOnFeatureError_ContinuesAfterListenerFailure() {
+        FeatureRefreshCallback failingListener = mock(FeatureRefreshCallback.class);
+        FeatureRefreshCallback successfulListener = mock(FeatureRefreshCallback.class);
+        RuntimeException refreshError = new RuntimeException("refresh failed");
+        doThrow(new RuntimeException("listener failed")).when(failingListener).onError(refreshError);
+
+        repository.onFeaturesRefresh(failingListener);
+        repository.onFeaturesRefresh(successfulListener);
+        repository.onRefreshFailed(refreshError);
+
+        verify(successfulListener).onError(refreshError);
     }
 
     @Test
@@ -162,24 +191,207 @@ class NativeJavaGbFeatureRepositoryTest {
     }
 
     @Test
+    void testFeatureRefreshListener_receivesInitializationMetadata() throws Exception {
+        HttpServer server = startFeatureServer(
+                HttpURLConnection.HTTP_OK,
+                "{\"features\":{\"test-feature\":{\"defaultValue\":true}}}"
+        );
+        try {
+            NativeJavaGbFeatureRepository subject = NativeJavaGbFeatureRepository.builder()
+                    .apiHost(apiHost(server))
+                    .clientKey(TEST_CLIENT_KEY)
+                    .isCacheDisabled(true)
+                    .build();
+            FeatureRefreshListener listener = mock(FeatureRefreshListener.class);
+            subject.addFeatureRefreshListener(listener);
+
+            subject.initialize();
+
+            ArgumentCaptor<FeatureRefreshEvent> eventCaptor = ArgumentCaptor.forClass(FeatureRefreshEvent.class);
+            verify(listener).onRefresh(eventCaptor.capture());
+            FeatureRefreshEvent event = eventCaptor.getValue();
+            assertTrue(event.isSuccessful());
+            assertTrue(event.isFeaturesChanged());
+            assertFalse(event.isLoadedFromCache());
+            assertEquals(1, event.getActiveFeatureCount());
+            assertEquals(FeatureRefreshSource.INITIALIZATION, event.getSource());
+            assertTrue(event.getDurationMillis() >= 0);
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    void testFeatureRefreshListener_receivesManualNotModifiedMetadata() throws Exception {
+        HttpServer server = startFeatureServer(HttpURLConnection.HTTP_NOT_MODIFIED, "");
+        try {
+            NativeJavaGbFeatureRepository subject = NativeJavaGbFeatureRepository.builder()
+                    .apiHost(apiHost(server))
+                    .clientKey(TEST_CLIENT_KEY)
+                    .isCacheDisabled(true)
+                    .build();
+            FeatureRefreshListener listener = mock(FeatureRefreshListener.class);
+            subject.addFeatureRefreshListener(listener);
+
+            subject.fetchFeatures();
+
+            ArgumentCaptor<FeatureRefreshEvent> eventCaptor = ArgumentCaptor.forClass(FeatureRefreshEvent.class);
+            verify(listener).onRefresh(eventCaptor.capture());
+            FeatureRefreshEvent event = eventCaptor.getValue();
+            assertTrue(event.isSuccessful());
+            assertFalse(event.isFeaturesChanged());
+            assertFalse(event.isLoadedFromCache());
+            assertEquals(0, event.getActiveFeatureCount());
+            assertEquals(FeatureRefreshSource.MANUAL, event.getSource());
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    void testFeatureRefreshListener_continuesAfterListenerFailure() throws Exception {
+        HttpServer server = startFeatureServer(HttpURLConnection.HTTP_OK, "{\"features\":{}}");
+        try {
+            NativeJavaGbFeatureRepository subject = NativeJavaGbFeatureRepository.builder()
+                    .apiHost(apiHost(server))
+                    .clientKey(TEST_CLIENT_KEY)
+                    .isCacheDisabled(true)
+                    .build();
+            FeatureRefreshListener failingListener = mock(FeatureRefreshListener.class);
+            FeatureRefreshListener successfulListener = mock(FeatureRefreshListener.class);
+            doThrow(new RuntimeException("listener failed")).when(failingListener).onRefresh(any(FeatureRefreshEvent.class));
+
+            subject.addFeatureRefreshListener(failingListener);
+            subject.addFeatureRefreshListener(successfulListener);
+            subject.fetchFeatures();
+
+            verify(successfulListener).onRefresh(any(FeatureRefreshEvent.class));
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    void testRemoveFeatureRefreshListener_stopsNotifications() throws Exception {
+        HttpServer server = startFeatureServer(HttpURLConnection.HTTP_OK, "{\"features\":{}}");
+        try {
+            NativeJavaGbFeatureRepository subject = NativeJavaGbFeatureRepository.builder()
+                    .apiHost(apiHost(server))
+                    .clientKey(TEST_CLIENT_KEY)
+                    .isCacheDisabled(true)
+                    .build();
+            FeatureRefreshListener listener = mock(FeatureRefreshListener.class);
+
+            subject.addFeatureRefreshListener(listener);
+            subject.removeFeatureRefreshListener(listener);
+            subject.fetchFeatures();
+
+            verify(listener, never()).onRefresh(any(FeatureRefreshEvent.class));
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    void testFeatureRefreshListener_receivesCacheFallbackMetadata() throws Exception {
+        HttpServer server = startFeatureServer(HttpURLConnection.HTTP_INTERNAL_ERROR, "{\"error\":\"temporary failure\"}");
+        try {
+            NativeJavaGbFeatureRepository subject = NativeJavaGbFeatureRepository.builder()
+                    .apiHost(apiHost(server))
+                    .clientKey(TEST_CLIENT_KEY)
+                    .cacheManager(new StaticCacheManager("{\"features\":{\"cached-feature\":{\"defaultValue\":true}}}"))
+                    .build();
+            FeatureRefreshListener listener = mock(FeatureRefreshListener.class);
+            subject.addFeatureRefreshListener(listener);
+
+            subject.fetchFeatures();
+
+            ArgumentCaptor<FeatureRefreshEvent> eventCaptor = ArgumentCaptor.forClass(FeatureRefreshEvent.class);
+            verify(listener).onRefresh(eventCaptor.capture());
+            FeatureRefreshEvent event = eventCaptor.getValue();
+            assertFalse(event.isSuccessful());
+            assertTrue(event.isFeaturesChanged());
+            assertTrue(event.isLoadedFromCache());
+            assertEquals(1, event.getActiveFeatureCount());
+            assertEquals(FeatureRefreshSource.MANUAL, event.getSource());
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    @Test
     void fetchFeaturesFails() throws Exception {
-        when(mockConnection.getResponseCode()).thenReturn(HttpURLConnection.HTTP_BAD_REQUEST);
-        when(mockConnection.getErrorStream()).thenReturn(this.getClass().getResourceAsStream("/mock_error_response.json"));
+        HttpServer server = startFeatureServer(HttpURLConnection.HTTP_BAD_REQUEST, "{\"error\":\"bad request\"}");
+        try {
+            NativeJavaGbFeatureRepository subject = NativeJavaGbFeatureRepository.builder()
+                    .apiHost(apiHost(server))
+                    .clientKey(TEST_CLIENT_KEY)
+                    .isCacheDisabled(true)
+                    .build();
 
-        assertThrows(FeatureFetchException.class, () -> repository.fetchFeatures());
-
+            assertThrows(FeatureFetchException.class, subject::fetchFeatures);
+        } finally {
+            server.stop(0);
+        }
     }
 
     @Test
     void initializeFails() throws Exception {
-        when(mockUrl.openConnection()).thenReturn(mockConnection);
-        when(mockConnection.getInputStream()).thenThrow(new IOException("Test exception"));
+        HttpServer server = startFeatureServer(HttpURLConnection.HTTP_INTERNAL_ERROR, "{\"error\":\"temporary failure\"}");
+        try {
+            NativeJavaGbFeatureRepository subject = NativeJavaGbFeatureRepository.builder()
+                    .apiHost(apiHost(server))
+                    .clientKey(TEST_CLIENT_KEY)
+                    .isCacheDisabled(true)
+                    .build();
 
-        repository = NativeJavaGbFeatureRepository.builder()
-                .apiHost(API_HOST)
-                .clientKey(CLIENT_KEY)
-                .build();
+            assertThrows(FeatureFetchException.class, subject::initialize);
+        } finally {
+            server.stop(0);
+        }
+    }
 
-        assertThrows(FeatureFetchException.class, () -> repository.initialize());
+    private static HttpServer startFeatureServer(int statusCode, String body) throws IOException {
+        HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/api/features/" + TEST_CLIENT_KEY, exchange -> {
+            byte[] responseBytes = body == null ? new byte[0] : body.getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().add(HttpHeaders.X_SSE_SUPPORT.getHeader(), "enabled");
+            if (statusCode == HttpURLConnection.HTTP_NOT_MODIFIED) {
+                exchange.sendResponseHeaders(statusCode, -1);
+            } else {
+                exchange.sendResponseHeaders(statusCode, responseBytes.length);
+                try (OutputStream responseBody = exchange.getResponseBody()) {
+                    responseBody.write(responseBytes);
+                }
+            }
+            exchange.close();
+        });
+        server.start();
+        return server;
+    }
+
+    private static String apiHost(HttpServer server) {
+        return "http://127.0.0.1:" + server.getAddress().getPort();
+    }
+
+    private static class StaticCacheManager implements GbCacheManager {
+        private final String cachedData;
+
+        private StaticCacheManager(String cachedData) {
+            this.cachedData = cachedData;
+        }
+
+        @Override
+        public void saveContent(String key, String data) {
+        }
+
+        @Override
+        public String loadCache(String key) {
+            return cachedData;
+        }
+
+        @Override
+        public void clearCache() {
+        }
     }
 }

--- a/lib/src/test/java/growthbook/sdk/java/NativeJavaGbFeatureRepositoryTest.java
+++ b/lib/src/test/java/growthbook/sdk/java/NativeJavaGbFeatureRepositoryTest.java
@@ -1,5 +1,10 @@
 package growthbook.sdk.java;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.matching;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -22,7 +27,10 @@ import growthbook.sdk.java.model.HttpHeaders;
 import growthbook.sdk.java.repository.FeatureRefreshStrategy;
 import growthbook.sdk.java.repository.NativeJavaGbFeatureRepository;
 import growthbook.sdk.java.sandbox.GbCacheManager;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import com.sun.net.httpserver.HttpServer;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -38,6 +46,7 @@ class NativeJavaGbFeatureRepositoryTest {
     private static final String TEST_CLIENT_KEY = "sdk-test";
 
     private NativeJavaGbFeatureRepository repository;
+    private WireMockServer wireMock;
 
 
     @BeforeEach
@@ -49,6 +58,16 @@ class NativeJavaGbFeatureRepositoryTest {
                 .refreshStrategy(FeatureRefreshStrategy.STALE_WHILE_REVALIDATE)
                 .swrTtlSeconds(60)
                 .build();
+
+        wireMock = new WireMockServer(WireMockConfiguration.options().dynamicPort());
+        wireMock.start();
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (wireMock != null) {
+            wireMock.stop();
+        }
     }
 
     @Test

--- a/lib/src/test/java/growthbook/sdk/java/multiusermode/GrowthBookClientTest.java
+++ b/lib/src/test/java/growthbook/sdk/java/multiusermode/GrowthBookClientTest.java
@@ -1,22 +1,37 @@
 package growthbook.sdk.java.multiusermode;
 
 import com.google.gson.JsonObject;
+import com.sun.net.httpserver.HttpServer;
 import growthbook.sdk.java.callback.FeatureRefreshCallback;
+import growthbook.sdk.java.listener.FeatureRefreshListener;
+import growthbook.sdk.java.listener.FeatureRefreshSubscription;
 import growthbook.sdk.java.exception.FeatureFetchException;
+import growthbook.sdk.java.model.Feature;
+import growthbook.sdk.java.model.FeatureRefreshEvent;
+import growthbook.sdk.java.model.FeatureRefreshSource;
 import growthbook.sdk.java.model.FeatureResult;
+import growthbook.sdk.java.model.HttpHeaders;
 import growthbook.sdk.java.multiusermode.configurations.Options;
 import growthbook.sdk.java.multiusermode.configurations.UserContext;
 import growthbook.sdk.java.repository.FeatureRefreshStrategy;
 import growthbook.sdk.java.repository.GBFeaturesRepository;
 import growthbook.sdk.java.testhelpers.TestCasesJsonHelper;
 import growthbook.sdk.java.util.GrowthBookJsonUtils;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 
-import java.lang.reflect.Field;
-import java.util.List;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -30,14 +45,6 @@ class GrowthBookClientTest {
     // Mock instances that might be needed across tests
     private GBFeaturesRepository mockRepository;
     private GBFeaturesRepository.GBFeaturesRepositoryBuilder mockBuilder;
-
-    @AfterEach
-    void tearDown() throws Exception {
-        // Reset static repository after each test
-        Field field = GrowthBookClient.class.getDeclaredField("repository");
-        field.setAccessible(true);
-        field.set(null, null);
-    }
 
     @Test
     void test_initialization_withValidConfiguration() throws FeatureFetchException {
@@ -55,25 +62,273 @@ class GrowthBookClientTest {
             assertTrue(client.initialize());
 
             verify(mockRepository).initialize();
-            verify(mockRepository, times(2)).onFeaturesRefresh(any());
+            verify(mockRepository).onFeaturesRefresh(mockCallback);
+            verify(mockRepository).addFeatureRefreshListener(any());
+        }
+    }
 
-            // Capture the callbacks for inspection
-            ArgumentCaptor<FeatureRefreshCallback> callbackCaptor =
-                    ArgumentCaptor.forClass(FeatureRefreshCallback.class);
-            verify(mockRepository, times(2)).onFeaturesRefresh(callbackCaptor.capture());
+    @Test
+    void test_featureRefreshListener_receivesSuccessEvent() throws FeatureFetchException {
+        mockRepository = createMockRepository();
+        mockBuilder = createMockBuilder(mockRepository);
+        FeatureRefreshListener listener = mock(FeatureRefreshListener.class);
 
-            // Get all captured callbacks
-            List<FeatureRefreshCallback> capturedCallbacks = callbackCaptor.getAllValues();
-            assertEquals(2, capturedCallbacks.size());
+        try (MockedStatic<GBFeaturesRepository> mockedStatic = mockStatic(GBFeaturesRepository.class)) {
+            mockedStatic.when(GBFeaturesRepository::builder).thenReturn(mockBuilder);
 
-            // One of them should be our mockCallback
-            assertTrue(capturedCallbacks.contains(mockCallback),
-                    "User callback should be registered");
+            GrowthBookClient client = new GrowthBookClient(createDefaultOptions(null));
+            client.addFeatureRefreshListener(listener);
 
-            // One of them should be the internal callback (instance of anonymous FeatureRefreshCallback)
-            assertTrue(capturedCallbacks.stream()
-                            .anyMatch(callback -> callback != mockCallback && callback != null),
-                    "Internal callback should be registered");
+            assertTrue(client.initialize());
+
+            ArgumentCaptor<FeatureRefreshListener> repositoryListenerCaptor =
+                    ArgumentCaptor.forClass(FeatureRefreshListener.class);
+            verify(mockRepository).addFeatureRefreshListener(repositoryListenerCaptor.capture());
+
+            FeatureRefreshEvent repositoryEvent = FeatureRefreshEvent.success(
+                    true,
+                    false,
+                    1,
+                    FeatureRefreshSource.INITIALIZATION,
+                    FeatureRefreshStrategy.STALE_WHILE_REVALIDATE,
+                    12
+            );
+            repositoryListenerCaptor.getValue().onRefresh(repositoryEvent);
+
+            ArgumentCaptor<FeatureRefreshEvent> eventCaptor =
+                    ArgumentCaptor.forClass(FeatureRefreshEvent.class);
+            verify(listener).onRefresh(eventCaptor.capture());
+
+            FeatureRefreshEvent event = eventCaptor.getValue();
+            assertTrue(event.isSuccessful());
+            assertTrue(event.isFeaturesChanged());
+            assertFalse(event.isLoadedFromCache());
+            assertNull(event.getError());
+            assertEquals(1, event.getActiveFeatureCount());
+            assertEquals(FeatureRefreshSource.INITIALIZATION, event.getSource());
+            assertEquals(FeatureRefreshStrategy.STALE_WHILE_REVALIDATE, event.getRefreshStrategy());
+            assertEquals(12, event.getDurationMillis());
+            assertNotNull(event.getTimestamp());
+        }
+    }
+
+    @Test
+    void test_featureRefreshListener_receivesFailureEvent() throws FeatureFetchException {
+        mockRepository = createMockRepository();
+        mockBuilder = createMockBuilder(mockRepository);
+        FeatureRefreshListener listener = mock(FeatureRefreshListener.class);
+        RuntimeException error = new RuntimeException("refresh failed");
+
+        try (MockedStatic<GBFeaturesRepository> mockedStatic = mockStatic(GBFeaturesRepository.class)) {
+            mockedStatic.when(GBFeaturesRepository::builder).thenReturn(mockBuilder);
+
+            GrowthBookClient client = new GrowthBookClient(createDefaultOptions(null));
+            client.addFeatureRefreshListener(listener);
+
+            assertTrue(client.initialize());
+
+            ArgumentCaptor<FeatureRefreshListener> repositoryListenerCaptor =
+                    ArgumentCaptor.forClass(FeatureRefreshListener.class);
+            verify(mockRepository).addFeatureRefreshListener(repositoryListenerCaptor.capture());
+
+            FeatureRefreshEvent repositoryEvent = FeatureRefreshEvent.failure(
+                    error,
+                    false,
+                    true,
+                    1,
+                    FeatureRefreshSource.SSE,
+                    FeatureRefreshStrategy.STALE_WHILE_REVALIDATE,
+                    8
+            );
+            repositoryListenerCaptor.getValue().onRefresh(repositoryEvent);
+
+            ArgumentCaptor<FeatureRefreshEvent> eventCaptor =
+                    ArgumentCaptor.forClass(FeatureRefreshEvent.class);
+            verify(listener).onRefresh(eventCaptor.capture());
+
+            FeatureRefreshEvent event = eventCaptor.getValue();
+            assertFalse(event.isSuccessful());
+            assertFalse(event.isFeaturesChanged());
+            assertTrue(event.isLoadedFromCache());
+            assertSame(error, event.getError());
+            assertEquals(1, event.getActiveFeatureCount());
+            assertEquals(FeatureRefreshSource.SSE, event.getSource());
+            assertEquals(FeatureRefreshStrategy.STALE_WHILE_REVALIDATE, event.getRefreshStrategy());
+            assertEquals(8, event.getDurationMillis());
+            assertNotNull(event.getTimestamp());
+        }
+    }
+
+    @Test
+    void test_featureRefreshListener_receivesEventWhenGlobalContextRefreshFails() throws FeatureFetchException {
+        mockRepository = createMockRepository();
+        mockBuilder = createMockBuilder(mockRepository);
+        FeatureRefreshListener listener = mock(FeatureRefreshListener.class);
+
+        try (MockedStatic<GBFeaturesRepository> mockedStatic = mockStatic(GBFeaturesRepository.class)) {
+            mockedStatic.when(GBFeaturesRepository::builder).thenReturn(mockBuilder);
+
+            GrowthBookClient client = new GrowthBookClient(createDefaultOptions(null));
+            client.addFeatureRefreshListener(listener);
+
+            assertTrue(client.initialize());
+
+            ArgumentCaptor<FeatureRefreshListener> repositoryListenerCaptor =
+                    ArgumentCaptor.forClass(FeatureRefreshListener.class);
+            verify(mockRepository).addFeatureRefreshListener(repositoryListenerCaptor.capture());
+
+            FeatureRefreshEvent repositoryEvent = successEvent();
+            when(mockRepository.getParsedFeatures()).thenThrow(new IllegalStateException("feature state unavailable"));
+            repositoryListenerCaptor.getValue().onRefresh(repositoryEvent);
+
+            verify(listener).onRefresh(repositoryEvent);
+        }
+    }
+
+    @Test
+    void test_featureRefreshListener_skipsGlobalContextRefreshWhenFeaturesUnchanged() throws FeatureFetchException {
+        mockRepository = createMockRepository();
+        mockBuilder = createMockBuilder(mockRepository);
+        FeatureRefreshListener listener = mock(FeatureRefreshListener.class);
+
+        try (MockedStatic<GBFeaturesRepository> mockedStatic = mockStatic(GBFeaturesRepository.class)) {
+            mockedStatic.when(GBFeaturesRepository::builder).thenReturn(mockBuilder);
+
+            GrowthBookClient client = new GrowthBookClient(createDefaultOptions(null));
+            client.addFeatureRefreshListener(listener);
+
+            assertTrue(client.initialize());
+
+            ArgumentCaptor<FeatureRefreshListener> repositoryListenerCaptor =
+                    ArgumentCaptor.forClass(FeatureRefreshListener.class);
+            verify(mockRepository).addFeatureRefreshListener(repositoryListenerCaptor.capture());
+
+            // Ignore feature reads performed during initialization; assert only on the unchanged event below.
+            clearInvocations(mockRepository);
+
+            FeatureRefreshEvent unchangedEvent = FeatureRefreshEvent.success(
+                    false,
+                    false,
+                    1,
+                    FeatureRefreshSource.POLLING,
+                    FeatureRefreshStrategy.STALE_WHILE_REVALIDATE,
+                    1
+            );
+            repositoryListenerCaptor.getValue().onRefresh(unchangedEvent);
+
+            // Listener is always notified, but the global context is not rebuilt when nothing changed.
+            verify(listener).onRefresh(unchangedEvent);
+            verify(mockRepository, never()).getParsedFeatures();
+        }
+    }
+
+    @Test
+    void test_removeFeatureRefreshListener_stopsNotifications() {
+        mockRepository = createMockRepository();
+        mockBuilder = createMockBuilder(mockRepository);
+        FeatureRefreshListener listener = mock(FeatureRefreshListener.class);
+
+        try (MockedStatic<GBFeaturesRepository> mockedStatic = mockStatic(GBFeaturesRepository.class)) {
+            mockedStatic.when(GBFeaturesRepository::builder).thenReturn(mockBuilder);
+
+            GrowthBookClient client = new GrowthBookClient(createDefaultOptions(null));
+            client.addFeatureRefreshListener(listener);
+            client.removeFeatureRefreshListener(listener);
+
+            assertTrue(client.initialize());
+
+            ArgumentCaptor<FeatureRefreshListener> repositoryListenerCaptor =
+                    ArgumentCaptor.forClass(FeatureRefreshListener.class);
+            verify(mockRepository).addFeatureRefreshListener(repositoryListenerCaptor.capture());
+            repositoryListenerCaptor.getValue().onRefresh(successEvent());
+
+            verify(listener, never()).onRefresh(any());
+        }
+    }
+
+    @Test
+    void test_featureRefreshSubscription_stopsNotificationsWhenClosed() {
+        mockRepository = createMockRepository();
+        mockBuilder = createMockBuilder(mockRepository);
+        FeatureRefreshListener listener = mock(FeatureRefreshListener.class);
+
+        try (MockedStatic<GBFeaturesRepository> mockedStatic = mockStatic(GBFeaturesRepository.class)) {
+            mockedStatic.when(GBFeaturesRepository::builder).thenReturn(mockBuilder);
+
+            GrowthBookClient client = new GrowthBookClient(createDefaultOptions(null));
+            FeatureRefreshSubscription subscription = client.subscribeFeatureRefreshListener(listener);
+            subscription.close();
+            subscription.close();
+            assertTrue(client.initialize());
+
+            ArgumentCaptor<FeatureRefreshListener> repositoryListenerCaptor =
+                    ArgumentCaptor.forClass(FeatureRefreshListener.class);
+            verify(mockRepository).addFeatureRefreshListener(repositoryListenerCaptor.capture());
+            repositoryListenerCaptor.getValue().onRefresh(successEvent());
+
+            verify(listener, never()).onRefresh(any());
+        }
+    }
+
+    @Test
+    void test_featureRefreshListener_usesConfiguredExecutor() {
+        mockRepository = createMockRepository();
+        mockBuilder = createMockBuilder(mockRepository);
+        FeatureRefreshListener listener = mock(FeatureRefreshListener.class);
+        Executor executor = mock(Executor.class);
+
+        try (MockedStatic<GBFeaturesRepository> mockedStatic = mockStatic(GBFeaturesRepository.class)) {
+            mockedStatic.when(GBFeaturesRepository::builder).thenReturn(mockBuilder);
+
+            Options options = Options.builder()
+                    .apiHost("https://custom.growthbook.io")
+                    .clientKey("custom_key")
+                    .decryptionKey("test_key")
+                    .refreshStrategy(FeatureRefreshStrategy.STALE_WHILE_REVALIDATE)
+                    .featureRefreshListenerExecutor(executor)
+                    .build();
+            GrowthBookClient client = new GrowthBookClient(options);
+            client.addFeatureRefreshListener(listener);
+            assertTrue(client.initialize());
+
+            ArgumentCaptor<FeatureRefreshListener> repositoryListenerCaptor =
+                    ArgumentCaptor.forClass(FeatureRefreshListener.class);
+            verify(mockRepository).addFeatureRefreshListener(repositoryListenerCaptor.capture());
+            FeatureRefreshEvent event = successEvent();
+            repositoryListenerCaptor.getValue().onRefresh(event);
+
+            ArgumentCaptor<Runnable> runnableCaptor = ArgumentCaptor.forClass(Runnable.class);
+            verify(executor).execute(runnableCaptor.capture());
+            verify(listener, never()).onRefresh(any());
+
+            runnableCaptor.getValue().run();
+            verify(listener).onRefresh(event);
+        }
+    }
+
+    @Test
+    void test_shutdown_doesNotStopCallerSuppliedExecutor() throws FeatureFetchException {
+        mockRepository = createMockRepository();
+        mockBuilder = createMockBuilder(mockRepository);
+        ExecutorService suppliedExecutor = mock(ExecutorService.class);
+
+        try (MockedStatic<GBFeaturesRepository> mockedStatic = mockStatic(GBFeaturesRepository.class)) {
+            mockedStatic.when(GBFeaturesRepository::builder).thenReturn(mockBuilder);
+
+            Options options = Options.builder()
+                    .apiHost("https://custom.growthbook.io")
+                    .clientKey("custom_key")
+                    .decryptionKey("test_key")
+                    .refreshStrategy(FeatureRefreshStrategy.STALE_WHILE_REVALIDATE)
+                    .featureRefreshListenerExecutor(suppliedExecutor)
+                    .build();
+            GrowthBookClient client = new GrowthBookClient(options);
+            assertTrue(client.initialize());
+
+            client.shutdown();
+
+            verify(mockRepository).shutdown();
+            verify(suppliedExecutor, never()).shutdown();
         }
     }
 
@@ -108,43 +363,158 @@ class GrowthBookClientTest {
         }
     }
 
-  @Test
-  void test_shutdown_withANonInitializedClient() {
-    mockRepository = createMockRepository();
-    mockBuilder = createMockBuilder(mockRepository);
-    FeatureRefreshCallback mockCallback = mock(FeatureRefreshCallback.class);
+    @Test
+    void test_initializeCanRetryAfterRepositoryInitializationFails() throws FeatureFetchException {
+        GBFeaturesRepository failedRepository = mock(GBFeaturesRepository.class);
+        when(failedRepository.getInitialized()).thenReturn(false);
+        doThrow(new FeatureFetchException(FeatureFetchException.FeatureFetchErrorCode.NO_RESPONSE_ERROR))
+                .when(failedRepository).initialize();
 
-    try (MockedStatic<GBFeaturesRepository> mockedStatic = mockStatic(GBFeaturesRepository.class)) {
-      mockedStatic.when(GBFeaturesRepository::builder).thenReturn(mockBuilder);
+        GBFeaturesRepository successfulRepository = createMockRepository();
+        GBFeaturesRepository.GBFeaturesRepositoryBuilder failedBuilder = createMockBuilder(failedRepository);
+        GBFeaturesRepository.GBFeaturesRepositoryBuilder successfulBuilder = createMockBuilder(successfulRepository);
 
-      Options options = createDefaultOptions(mockCallback);
+        try (MockedStatic<GBFeaturesRepository> mockedStatic = mockStatic(GBFeaturesRepository.class)) {
+            mockedStatic.when(GBFeaturesRepository::builder).thenReturn(failedBuilder, successfulBuilder);
 
-      GrowthBookClient client = new GrowthBookClient(options);
+            GrowthBookClient client = new GrowthBookClient(createDefaultOptions(mock(FeatureRefreshCallback.class)));
 
-      client.shutdown();
+            assertFalse(client.initialize());
+            assertTrue(client.initialize());
 
-      verify(mockRepository, never()).shutdown();
+            verify(failedRepository).initialize();
+            verify(failedRepository).shutdown();
+            verify(successfulRepository).initialize();
+        }
     }
-  }
-  @Test
-  void test_shutdown_withAnInitializedClient() {
-    mockRepository = createMockRepository();
-    mockBuilder = createMockBuilder(mockRepository);
-    FeatureRefreshCallback mockCallback = mock(FeatureRefreshCallback.class);
 
-    try (MockedStatic<GBFeaturesRepository> mockedStatic = mockStatic(GBFeaturesRepository.class)) {
-      mockedStatic.when(GBFeaturesRepository::builder).thenReturn(mockBuilder);
+    @Test
+    void test_refreshFeature_beforeInitializeDoesNotThrow() {
+        GrowthBookClient client = new GrowthBookClient(createDefaultOptions(null));
 
-      Options options = createDefaultOptions(mockCallback);
-
-      GrowthBookClient client = new GrowthBookClient(options);
-      client.initialize();
-
-      client.shutdown();
-
-      verify(mockRepository).shutdown();
+        assertDoesNotThrow(client::refreshFeature);
     }
-  }
+
+    @Test
+    void test_refreshForRemoteEval_beforeInitializeDoesNotThrow() {
+        GrowthBookClient client = new GrowthBookClient(createDefaultOptions(null));
+
+        assertDoesNotThrow(() -> client.refreshForRemoteEval(null));
+    }
+
+    @Test
+    void test_clientsUseIndependentRepositories() throws FeatureFetchException {
+        GBFeaturesRepository firstRepository = createMockRepository();
+        GBFeaturesRepository secondRepository = createMockRepository();
+        GBFeaturesRepository.GBFeaturesRepositoryBuilder firstBuilder = createMockBuilder(firstRepository);
+        GBFeaturesRepository.GBFeaturesRepositoryBuilder secondBuilder = createMockBuilder(secondRepository);
+
+        try (MockedStatic<GBFeaturesRepository> mockedStatic = mockStatic(GBFeaturesRepository.class)) {
+            mockedStatic.when(GBFeaturesRepository::builder).thenReturn(firstBuilder, secondBuilder);
+
+            GrowthBookClient firstClient = new GrowthBookClient(createDefaultOptions(null));
+            GrowthBookClient secondClient = new GrowthBookClient(createDefaultOptions(null));
+
+            assertTrue(firstClient.initialize());
+            assertTrue(secondClient.initialize());
+
+            verify(firstRepository).initialize();
+            verify(secondRepository).initialize();
+
+            firstClient.shutdown();
+            verify(firstRepository).shutdown();
+            verify(secondRepository, never()).shutdown();
+        }
+    }
+
+    @Test
+    void test_shutdownDuringInitializationClosesRepositoryAfterInitializationExits() throws FeatureFetchException {
+        mockRepository = createMockRepository();
+        mockBuilder = createMockBuilder(mockRepository);
+        GrowthBookClient[] clientHolder = new GrowthBookClient[1];
+
+        doAnswer(invocation -> {
+            clientHolder[0].shutdown();
+            return null;
+        }).when(mockRepository).initialize();
+
+        try (MockedStatic<GBFeaturesRepository> mockedStatic = mockStatic(GBFeaturesRepository.class)) {
+            mockedStatic.when(GBFeaturesRepository::builder).thenReturn(mockBuilder);
+
+            GrowthBookClient client = new GrowthBookClient(createDefaultOptions(null));
+            clientHolder[0] = client;
+
+            assertFalse(client.initialize());
+
+            verify(mockRepository).initialize();
+            verify(mockRepository).shutdown();
+        }
+    }
+
+    @Test
+    void test_shutdownBeforeRepositoryInitializationSkipsRepositoryInitialization() throws FeatureFetchException {
+        mockRepository = createMockRepository();
+        mockBuilder = createMockBuilder(mockRepository);
+        GrowthBookClient[] clientHolder = new GrowthBookClient[1];
+
+        when(mockBuilder.build()).thenAnswer(invocation -> {
+            clientHolder[0].shutdown();
+            return mockRepository;
+        });
+
+        try (MockedStatic<GBFeaturesRepository> mockedStatic = mockStatic(GBFeaturesRepository.class)) {
+            mockedStatic.when(GBFeaturesRepository::builder).thenReturn(mockBuilder);
+
+            GrowthBookClient client = new GrowthBookClient(createDefaultOptions(null));
+            clientHolder[0] = client;
+
+            assertFalse(client.initialize());
+
+            verify(mockRepository, never()).onFeaturesRefresh(any());
+            verify(mockRepository, never()).addFeatureRefreshListener(any());
+            verify(mockRepository, never()).initialize();
+            verify(mockRepository).shutdown();
+        }
+    }
+
+    @Test
+    void test_shutdown_withANonInitializedClient() {
+        mockRepository = createMockRepository();
+        mockBuilder = createMockBuilder(mockRepository);
+        FeatureRefreshCallback mockCallback = mock(FeatureRefreshCallback.class);
+
+        try (MockedStatic<GBFeaturesRepository> mockedStatic = mockStatic(GBFeaturesRepository.class)) {
+            mockedStatic.when(GBFeaturesRepository::builder).thenReturn(mockBuilder);
+
+            Options options = createDefaultOptions(mockCallback);
+
+            GrowthBookClient client = new GrowthBookClient(options);
+
+            client.shutdown();
+
+            verify(mockRepository, never()).shutdown();
+        }
+    }
+
+    @Test
+    void test_shutdown_withAnInitializedClient() {
+        mockRepository = createMockRepository();
+        mockBuilder = createMockBuilder(mockRepository);
+        FeatureRefreshCallback mockCallback = mock(FeatureRefreshCallback.class);
+
+        try (MockedStatic<GBFeaturesRepository> mockedStatic = mockStatic(GBFeaturesRepository.class)) {
+            mockedStatic.when(GBFeaturesRepository::builder).thenReturn(mockBuilder);
+
+            Options options = createDefaultOptions(mockCallback);
+
+            GrowthBookClient client = new GrowthBookClient(options);
+            client.initialize();
+
+            client.shutdown();
+
+            verify(mockRepository).shutdown();
+        }
+    }
 
     //@Test
     void test_evalFeature_withUserContext() {
@@ -172,11 +542,83 @@ class GrowthBookClientTest {
         }
     }
 
+    @Test
+    void test_endToEnd_realRepositoryRefreshNotifiesListenerAndUpdatesContext() throws Exception {
+        HttpServer server = startFeatureServer(
+                HttpURLConnection.HTTP_OK,
+                "{\"features\":{\"test-feature\":{\"defaultValue\":true}}}"
+        );
+        GrowthBookClient client = null;
+        try {
+            Options options = Options.builder()
+                    .apiHost(apiHost(server))
+                    .clientKey(TEST_CLIENT_KEY)
+                    .isCacheDisabled(true)
+                    .build();
+            client = new GrowthBookClient(options);
+
+            CountDownLatch notified = new CountDownLatch(1);
+            AtomicReference<FeatureRefreshEvent> received = new AtomicReference<>();
+            client.addFeatureRefreshListener(event -> {
+                received.set(event);
+                notified.countDown();
+            });
+
+            assertTrue(client.initialize());
+
+            // Listener is dispatched off the refresh thread, so wait for the owned executor to deliver it.
+            assertTrue(notified.await(5, TimeUnit.SECONDS), "listener was not notified after refresh");
+            FeatureRefreshEvent event = received.get();
+            assertTrue(event.isSuccessful());
+            assertEquals(FeatureRefreshSource.INITIALIZATION, event.getSource());
+            assertTrue(event.isFeaturesChanged());
+
+            // Proves the whole chain wired through: repository -> notifier -> bridge -> global context.
+            UserContext userContext = UserContext.builder().attributesJson("{\"id\":\"1\"}").build();
+            assertTrue(client.isOn("test-feature", userContext));
+        } finally {
+            if (client != null) {
+                client.shutdown();
+            }
+            server.stop(0);
+        }
+    }
+
+    private static final String TEST_CLIENT_KEY = "sdk-test";
+
+    private static HttpServer startFeatureServer(int statusCode, String body) throws IOException {
+        HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/api/features/" + TEST_CLIENT_KEY, exchange -> {
+            byte[] responseBytes = body == null ? new byte[0] : body.getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().add(HttpHeaders.X_SSE_SUPPORT.getHeader(), "enabled");
+            if (statusCode == HttpURLConnection.HTTP_NOT_MODIFIED) {
+                exchange.sendResponseHeaders(statusCode, -1);
+            } else {
+                exchange.sendResponseHeaders(statusCode, responseBytes.length);
+                try (OutputStream responseBody = exchange.getResponseBody()) {
+                    responseBody.write(responseBytes);
+                }
+            }
+            exchange.close();
+        });
+        server.start();
+        return server;
+    }
+
+    private static String apiHost(HttpServer server) {
+        return "http://127.0.0.1:" + server.getAddress().getPort();
+    }
+
     private GBFeaturesRepository createMockRepository() {
         GBFeaturesRepository repository = mock(GBFeaturesRepository.class);
+        HashMap<String, Feature<?>> features = new HashMap<>();
+        features.put("test-feature", new Feature<>());
         when(repository.getInitialized()).thenReturn(true);
         when(repository.getFeaturesJson()).thenReturn("{}");
         when(repository.getSavedGroupsJson()).thenReturn("{}");
+        when(repository.getParsedFeatures()).thenReturn(features);
+        when(repository.getParsedSavedGroups()).thenReturn(new JsonObject());
+        when(repository.getRefreshStrategy()).thenReturn(FeatureRefreshStrategy.STALE_WHILE_REVALIDATE);
         return repository;
     }
 
@@ -204,6 +646,20 @@ class GrowthBookClientTest {
                 .decryptionKey("test_key")
                 .refreshStrategy(FeatureRefreshStrategy.STALE_WHILE_REVALIDATE)
                 .featureRefreshCallback(callback)
+                // Same-thread dispatch keeps listener-routing assertions deterministic; the real
+                // off-thread default executor is exercised by the end-to-end integration test.
+                .featureRefreshListenerExecutor(Runnable::run)
                 .build();
+    }
+
+    private FeatureRefreshEvent successEvent() {
+        return FeatureRefreshEvent.success(
+                true,
+                false,
+                1,
+                FeatureRefreshSource.MANUAL,
+                FeatureRefreshStrategy.STALE_WHILE_REVALIDATE,
+                1
+        );
     }
 }

--- a/lib/src/test/java/growthbook/sdk/java/multiusermode/GrowthBookClientTest.java
+++ b/lib/src/test/java/growthbook/sdk/java/multiusermode/GrowthBookClientTest.java
@@ -41,10 +41,10 @@ import static org.mockito.Mockito.*;
 
 
 class GrowthBookClientTest {
-    private final GrowthBookJsonUtils jsonUtils = GrowthBookJsonUtils.getInstance();
-    private final TestCasesJsonHelper helper = TestCasesJsonHelper.getInstance();
 
-    // Mock instances that might be needed across tests
+    private final TestCasesJsonHelper helper = TestCasesJsonHelper.getInstance();
+    private final GrowthBookJsonUtils jsonUtils = GrowthBookJsonUtils.getInstance();
+
     private GBFeaturesRepository mockRepository;
     private GBFeaturesRepository.GBFeaturesRepositoryBuilder mockBuilder;
 
@@ -70,7 +70,7 @@ class GrowthBookClientTest {
     }
 
     @Test
-    void test_featureRefreshListener_receivesSuccessEvent() throws FeatureFetchException {
+    void test_featureRefreshListener_receivesSuccessEvent() {
         mockRepository = createMockRepository();
         mockBuilder = createMockBuilder(mockRepository);
         FeatureRefreshListener listener = mock(FeatureRefreshListener.class);
@@ -115,7 +115,7 @@ class GrowthBookClientTest {
     }
 
     @Test
-    void test_featureRefreshListener_receivesFailureEvent() throws FeatureFetchException {
+    void test_featureRefreshListener_receivesFailureEvent() {
         mockRepository = createMockRepository();
         mockBuilder = createMockBuilder(mockRepository);
         FeatureRefreshListener listener = mock(FeatureRefreshListener.class);
@@ -162,7 +162,7 @@ class GrowthBookClientTest {
     }
 
     @Test
-    void test_featureRefreshListener_receivesEventWhenGlobalContextRefreshFails() throws FeatureFetchException {
+    void test_featureRefreshListener_receivesEventWhenGlobalContextRefreshFails() {
         mockRepository = createMockRepository();
         mockBuilder = createMockBuilder(mockRepository);
         FeatureRefreshListener listener = mock(FeatureRefreshListener.class);
@@ -188,7 +188,7 @@ class GrowthBookClientTest {
     }
 
     @Test
-    void test_featureRefreshListener_skipsGlobalContextRefreshWhenFeaturesUnchanged() throws FeatureFetchException {
+    void test_featureRefreshListener_skipsGlobalContextRefreshWhenFeaturesUnchanged() {
         mockRepository = createMockRepository();
         mockBuilder = createMockBuilder(mockRepository);
         FeatureRefreshListener listener = mock(FeatureRefreshListener.class);
@@ -309,7 +309,7 @@ class GrowthBookClientTest {
     }
 
     @Test
-    void test_shutdown_doesNotStopCallerSuppliedExecutor() throws FeatureFetchException {
+    void test_shutdown_doesNotStopCallerSuppliedExecutor() {
         mockRepository = createMockRepository();
         mockBuilder = createMockBuilder(mockRepository);
         ExecutorService suppliedExecutor = mock(ExecutorService.class);
@@ -710,4 +710,8 @@ class GrowthBookClientTest {
                 1
         );
     }
+
+  public TestCasesJsonHelper getHelper() {
+    return helper;
+  }
 }

--- a/lib/src/test/java/growthbook/sdk/java/multiusermode/GrowthBookClientTest.java
+++ b/lib/src/test/java/growthbook/sdk/java/multiusermode/GrowthBookClientTest.java
@@ -15,6 +15,7 @@ import growthbook.sdk.java.multiusermode.configurations.Options;
 import growthbook.sdk.java.multiusermode.configurations.UserContext;
 import growthbook.sdk.java.repository.FeatureRefreshStrategy;
 import growthbook.sdk.java.repository.GBFeaturesRepository;
+import growthbook.sdk.java.stickyBucketing.StickyBucketService;
 import growthbook.sdk.java.testhelpers.TestCasesJsonHelper;
 import growthbook.sdk.java.util.GrowthBookJsonUtils;
 import org.junit.jupiter.api.Test;
@@ -27,6 +28,7 @@ import java.net.HttpURLConnection;
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
@@ -581,6 +583,50 @@ class GrowthBookClientTest {
                 client.shutdown();
             }
             server.stop(0);
+        }
+    }
+
+    @Test
+    void evalFeature_withStickyBucketService_preloadsAssignmentsForMergedAttributes() {
+        // Regression: local evaluation through GrowthBookClient must still preload sticky-bucket
+        // assignments before evaluating, as the pre-refactor toUserContextWithMergedAttributes path
+        // did. Without it, multi-user clients configured with a StickyBucketService would evaluate
+        // experiments without their persisted assignments, diverging from the cross-SDK contract.
+        mockRepository = createMockRepository();
+        mockBuilder = createMockBuilder(mockRepository);
+
+        StickyBucketService stickyBucketService = mock(StickyBucketService.class);
+        when(stickyBucketService.getAllAssignments(any())).thenReturn(new HashMap<>());
+
+        JsonObject globalAttributes = new JsonObject();
+        globalAttributes.addProperty("country", "US");
+
+        try (MockedStatic<GBFeaturesRepository> mockedStatic = mockStatic(GBFeaturesRepository.class)) {
+            mockedStatic.when(GBFeaturesRepository::builder).thenReturn(mockBuilder);
+
+            Options options = Options.builder()
+                    .apiHost("https://custom.growthbook.io")
+                    .clientKey("custom_key")
+                    .decryptionKey("test_key")
+                    .refreshStrategy(FeatureRefreshStrategy.STALE_WHILE_REVALIDATE)
+                    .featureRefreshListenerExecutor(Runnable::run)
+                    .stickyBucketService(stickyBucketService)
+                    .globalAttributes(globalAttributes)
+                    .build();
+
+            GrowthBookClient client = new GrowthBookClient(options);
+            assertTrue(client.initialize());
+
+            UserContext userContext = UserContext.builder().attributesJson("{\"id\":\"1\"}").build();
+            client.evalFeature("test-feature", Boolean.class, userContext);
+
+            // The sticky assignments are loaded once for the merged (global + per-user) attributes.
+            @SuppressWarnings("unchecked")
+            ArgumentCaptor<Map<String, String>> attributesCaptor = ArgumentCaptor.forClass(Map.class);
+            verify(stickyBucketService).getAllAssignments(attributesCaptor.capture());
+            Map<String, String> capturedAttributes = attributesCaptor.getValue();
+            assertEquals("US", capturedAttributes.get("country"));
+            assertEquals("1", capturedAttributes.get("id"));
         }
     }
 

--- a/lib/src/test/java/growthbook/sdk/java/multiusermode/internal/FeatureRefreshListenerRegistryTest.java
+++ b/lib/src/test/java/growthbook/sdk/java/multiusermode/internal/FeatureRefreshListenerRegistryTest.java
@@ -1,0 +1,62 @@
+package growthbook.sdk.java.multiusermode.internal;
+
+import growthbook.sdk.java.listener.FeatureRefreshListener;
+import growthbook.sdk.java.model.FeatureRefreshEvent;
+import growthbook.sdk.java.model.FeatureRefreshSource;
+import growthbook.sdk.java.repository.FeatureRefreshStrategy;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.RejectedExecutionException;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+class FeatureRefreshListenerRegistryTest {
+
+    private static FeatureRefreshEvent sampleEvent() {
+        return FeatureRefreshEvent.success(
+                true,
+                false,
+                1,
+                FeatureRefreshSource.MANUAL,
+                FeatureRefreshStrategy.STALE_WHILE_REVALIDATE,
+                1
+        );
+    }
+
+    @Test
+    void publishFallsBackToSynchronousDispatchWhenExecutorRejects() {
+        FeatureRefreshListener listener = mock(FeatureRefreshListener.class);
+        FeatureRefreshEvent event = sampleEvent();
+        Executor rejectingExecutor = command -> {
+            throw new RejectedExecutionException("queue full");
+        };
+        FeatureRefreshListenerRegistry registry = new FeatureRefreshListenerRegistry(rejectingExecutor);
+
+        registry.add(listener);
+
+        assertDoesNotThrow(() -> registry.publish(event));
+        verify(listener).onRefresh(event);
+    }
+
+    @Test
+    void publishIsolatesListenerErrorsAndStillNotifiesRemainingListeners() {
+        FeatureRefreshListener throwingListener = mock(FeatureRefreshListener.class);
+        FeatureRefreshListener healthyListener = mock(FeatureRefreshListener.class);
+        doThrow(new AssertionError("listener blew up")).when(throwingListener).onRefresh(any());
+        FeatureRefreshEvent event = sampleEvent();
+        // null executor -> synchronous dispatch on the calling thread
+        FeatureRefreshListenerRegistry registry = new FeatureRefreshListenerRegistry((Executor) null);
+
+        registry.add(throwingListener);
+        registry.add(healthyListener);
+
+        assertDoesNotThrow(() -> registry.publish(event));
+        verify(throwingListener).onRefresh(event);
+        verify(healthyListener).onRefresh(event);
+    }
+}

--- a/lib/src/test/java/growthbook/sdk/java/multiusermode/internal/ManagedListenerExecutorTest.java
+++ b/lib/src/test/java/growthbook/sdk/java/multiusermode/internal/ManagedListenerExecutorTest.java
@@ -1,0 +1,57 @@
+package growthbook.sdk.java.multiusermode.internal;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+class ManagedListenerExecutorTest {
+
+    @Test
+    void resolveUsesSuppliedExecutorAndDoesNotOwnItsLifecycle() {
+        ExecutorService supplied = mock(ExecutorService.class);
+
+        ManagedListenerExecutor managed = ManagedListenerExecutor.resolve(supplied);
+
+        assertSame(supplied, managed.executor());
+        managed.shutdown();
+        verify(supplied, never()).shutdown();
+    }
+
+    @Test
+    void resolveCreatesOwnedDaemonExecutorWhenNoneSupplied() throws InterruptedException {
+        ManagedListenerExecutor managed = ManagedListenerExecutor.resolve(null);
+        try {
+            CountDownLatch ran = new CountDownLatch(1);
+            AtomicBoolean daemon = new AtomicBoolean(false);
+            managed.executor().execute(() -> {
+                daemon.set(Thread.currentThread().isDaemon());
+                ran.countDown();
+            });
+
+            assertTrue(ran.await(5, TimeUnit.SECONDS), "owned executor did not run the task");
+            assertTrue(daemon.get(), "owned executor thread should be a daemon");
+        } finally {
+            managed.shutdown();
+        }
+    }
+
+    @Test
+    void shutdownStopsTheOwnedExecutor() {
+        ManagedListenerExecutor managed = ManagedListenerExecutor.resolve(null);
+
+        managed.shutdown();
+
+        assertThrows(RejectedExecutionException.class, () -> managed.executor().execute(() -> { }));
+    }
+}

--- a/lib/src/test/java/growthbook/sdk/java/remoteeval/RemoteEvalSupportTest.java
+++ b/lib/src/test/java/growthbook/sdk/java/remoteeval/RemoteEvalSupportTest.java
@@ -184,6 +184,20 @@ class RemoteEvalSupportTest {
     }
 
     @Test
+    @DisplayName("preloadRemoteEval(null) warms the default response without throwing")
+    void growthBookClient_preloadRemoteEvalWithNullContextWarmsDefaultResponse() throws Exception {
+        // Regression: preloadRemoteEval(null) must warm the default/global response rather than
+        // throwing NPE. Callers previously relied on null being treated as an empty user context.
+        try (RemoteEvalTestServer server = new RemoteEvalTestServer(featureResponse(true))) {
+            GrowthBookClient client = new GrowthBookClient(remoteEvalOptions(server));
+            assertTrue(client.initialize());
+
+            assertTrue(client.preloadRemoteEval(null));
+            assertEquals(1, server.callCount());
+        }
+    }
+
+    @Test
     @DisplayName("refreshFeature clears the remote eval cache")
     void growthBookClient_refreshFeatureClearsRemoteEvalCache() throws Exception {
         try (RemoteEvalTestServer server = new RemoteEvalTestServer(featureResponse(true))) {


### PR DESCRIPTION
## Feature: Feature Refresh Listeners

### Summary

This update adds feature refresh listener support to the Java SDK.

Consumers can now subscribe to feature refresh events and react when feature definitions are refreshed successfully or when a refresh attempt fails. The event payload is metadata-only and does not expose feature definitions directly.

This allows SDK users to observe refresh lifecycle events, trigger custom logging or monitoring, and integrate refresh status with their own application workflows.

---

### What Changed

#### Feature Refresh Listener API

Added client-level APIs for managing feature refresh listeners:

1. `addFeatureRefreshListener(...)`
2. `removeFeatureRefreshListener(...)`
3. `subscribeFeatureRefreshListener(...)`

The `subscribeFeatureRefreshListener(...)` API returns a `FeatureRefreshSubscription`, which provides an idempotent cleanup mechanism for unsubscribing listeners.

---

#### Feature Refresh Event Metadata

Added `FeatureRefreshEvent` to provide metadata about feature refresh results.

Listeners can now receive events when:

1. Feature refresh completes successfully.
2. Feature refresh fails.
3. Refresh metadata needs to be inspected by the consumer.

The event is intentionally metadata-only, so listener consumers can react to refresh status without directly depending on feature payload internals.

---

#### Listener Dispatch Support

Feature refresh listener dispatch is now supported across the refresh flow, including:

1. `GrowthBookClient`
2. `GBFeaturesRepository`
3. `NativeJavaGbFeatureRepository`
4. `LocalGbFeatureRepository`

This ensures refresh events are propagated consistently across client-level and repository-level refresh operations.

---

#### Listener Failure Isolation

Listener execution is isolated from the SDK refresh flow.

If a listener throws an exception:

1. The exception does not break the feature refresh process.
2. Other listeners can still be executed.
3. SDK feature fetching and cache behavior remain unaffected.

This prevents consumer-side listener failures from impacting core SDK behavior.

---

#### Optional Listener Executor

Added optional executor support through:

```java
Options.featureRefreshListenerExecutor(...)
````

This allows consumers to control how listener callbacks are dispatched, including custom threading or asynchronous execution strategies.

---

#### Repository Initialization Refactor

Refactored `GrowthBookClient` repository initialization into an internal provider.

This keeps repository creation and lifecycle handling more centralized, while preserving the public SDK behavior.

---
