### PR TITLE
feat: add remote evaluation support

### DIFF
--- a/lib/src/main/java/growthbook/sdk/java/GrowthBook.java
+++ b/lib/src/main/java/growthbook/sdk/java/GrowthBook.java
@@ -189,6 +189,7 @@ public class GrowthBook implements IGrowthBook {
                 this.context.getClientKey(),
                 this.context.getAttributes(),
                 this.context.getForcedVariationsMap(),
+                this.forcedFeatureValues,
                 url,
                 this.context.getCacheKeyAttributes()
         );

--- a/lib/src/main/java/growthbook/sdk/java/GrowthBook.java
+++ b/lib/src/main/java/growthbook/sdk/java/GrowthBook.java
@@ -6,16 +6,25 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import javax.annotation.Nullable;
+import java.time.Duration;
 import com.google.gson.JsonObject;
 import growthbook.sdk.java.callback.ExperimentRunCallback;
 import growthbook.sdk.java.evaluators.ConditionEvaluator;
 import growthbook.sdk.java.evaluators.ExperimentEvaluator;
 import growthbook.sdk.java.evaluators.FeatureEvaluator;
+import growthbook.sdk.java.exception.FeatureFetchException;
 import growthbook.sdk.java.model.AssignedExperiment;
 import growthbook.sdk.java.model.Experiment;
 import growthbook.sdk.java.model.ExperimentResult;
 import growthbook.sdk.java.model.FeatureResult;
 import growthbook.sdk.java.model.GBContext;
+import growthbook.sdk.java.model.RequestBodyForRemoteEval;
+import growthbook.sdk.java.remoteeval.RemoteEvalCache;
+import growthbook.sdk.java.remoteeval.RemoteEvalCacheKey;
+import growthbook.sdk.java.remoteeval.RemoteEvalOptionsValidator;
+import growthbook.sdk.java.remoteeval.RemoteEvalRequestBuilder;
+import growthbook.sdk.java.remoteeval.RemoteEvalResponse;
+import growthbook.sdk.java.remoteeval.RemoteEvalService;
 import growthbook.sdk.java.util.GrowthBookJsonUtils;
 import growthbook.sdk.java.util.GrowthBookUtils;
 import lombok.Getter;
@@ -52,8 +61,10 @@ public class GrowthBook implements IGrowthBook {
 
     public EvaluationContext evaluationContext = null;
     private final Map<String, AssignedExperiment> assigned;
+    private RemoteEvalService remoteEvalService;
+    private RemoteEvalCache remoteEvalCache;
 
-    @Getter @Setter private Map<String, Object> forcedFeatureValues;
+    @Getter private Map<String, Object> forcedFeatureValues;
     /**
      * Initialize the GrowthBook SDK with a provided {@link GBContext}
      *
@@ -113,12 +124,37 @@ public class GrowthBook implements IGrowthBook {
     }
 
     private void initializeEvalContext() {
-        // build options
+        if (this.context.isRemoteEvalEnabled()) {
+            refreshRemoteEvalContext();
+            return;
+        }
+
+        this.evaluationContext = buildEvaluationContext(this.context.getFeatures(), this.context.getSavedGroups());
+    }
+
+    private void refreshRemoteEvalContext() {
+        RemoteEvalOptionsValidator.validate(this.context);
+        try {
+            RemoteEvalResponse response = getRemoteEvalResponse();
+            this.context.setFeatures(response.getFeatures());
+            this.context.setSavedGroups(response.getSavedGroups());
+        } catch (FeatureFetchException e) {
+            log.warn("Remote evaluation request failed. Falling back to current local feature context.", e);
+        }
+        this.evaluationContext = buildEvaluationContext(this.context.getFeatures(), this.context.getSavedGroups());
+    }
+
+    private EvaluationContext buildEvaluationContext(Map<String, growthbook.sdk.java.model.Feature<?>> features, JsonObject savedGroups) {
         Options options = Options.builder()
                 .enabled(this.context.getEnabled())
                 .isQaMode(this.context.getIsQaMode())
                 .allowUrlOverrides(this.context.getAllowUrlOverride())
                 .url(this.context.getUrl())
+                .apiHost(this.context.getApiHost())
+                .clientKey(this.context.getClientKey())
+                .remoteEval(this.context.getRemoteEval())
+                .cacheKeyAttributes(this.context.getCacheKeyAttributes())
+                .remoteEvalCacheSize(this.context.getRemoteEvalCacheSize())
                 .stickyBucketIdentifierAttributes(this.context.getStickyBucketIdentifierAttributes())
                 .stickyBucketService(this.context.getStickyBucketService())
                 .trackingCallBackWithUser(new TrackingCallbackAdapter(this.context.getTrackingCallback()))
@@ -126,14 +162,15 @@ public class GrowthBook implements IGrowthBook {
                 .globalForcedFeatureValues(this.forcedFeatureValues)
                 .build();
 
-        // build global
         GlobalContext globalContext = GlobalContext.builder()
-                .features(this.context.getFeatures())
-                .savedGroups(this.context.getSavedGroups())
+                .features(features)
+                .savedGroups(savedGroups)
                 .forcedFeatureValues(this.forcedFeatureValues)
+                .forcedVariations(this.context.getForcedVariationsMap())
+                .enabled(this.context.getEnabled())
+                .qaMode(this.context.getIsQaMode())
                 .build();
 
-        // build user context
         UserContext userContext = new UserContext.UserContextBuilder()
                 .attributes(this.context.getAttributes())
                 .stickyBucketAssignmentDocs(this.context.getStickyBucketAssignmentDocs())
@@ -141,8 +178,54 @@ public class GrowthBook implements IGrowthBook {
                 .forcedFeatureValues(this.forcedFeatureValues)
                 .build();
 
-        this.evaluationContext = new EvaluationContext(globalContext, userContext,
+        return new EvaluationContext(globalContext, userContext,
                 new EvaluationContext.StackContext(), options);
+    }
+
+    private RemoteEvalResponse getRemoteEvalResponse() throws FeatureFetchException {
+        String url = RemoteEvalRequestBuilder.normalizeUrl(this.context.getUrl());
+        String cacheKey = RemoteEvalCacheKey.fromContext(
+                this.context.getApiHost(),
+                this.context.getClientKey(),
+                this.context.getAttributes(),
+                this.context.getForcedVariationsMap(),
+                url,
+                this.context.getCacheKeyAttributes()
+        );
+
+        RequestBodyForRemoteEval requestBody = RemoteEvalRequestBuilder.build(
+                this.context.getAttributes(),
+                this.forcedFeatureValues,
+                this.context.getForcedVariationsMap(),
+                url
+        );
+        return getRemoteEvalCache().get(cacheKey, requestBody);
+    }
+
+    private synchronized RemoteEvalService getRemoteEvalService() {
+        if (this.remoteEvalService == null) {
+            this.remoteEvalService = new RemoteEvalService(this.context.getApiHost(), this.context.getClientKey());
+        }
+        return this.remoteEvalService;
+    }
+
+    private synchronized RemoteEvalCache getRemoteEvalCache() {
+        if (this.remoteEvalCache == null) {
+            Integer cacheTtlSeconds = this.context.getRemoteEvalCacheTtlSeconds();
+            this.remoteEvalCache = new RemoteEvalCache(
+                    getRemoteEvalService(),
+                    RemoteEvalRequestBuilder.normalizeCacheSize(this.context.getRemoteEvalCacheSize()),
+                    null,
+                    cacheTtlSeconds == null ? null : Duration.ofSeconds(cacheTtlSeconds)
+            );
+        }
+        return this.remoteEvalCache;
+    }
+
+    private void clearRemoteEvalCache() {
+        if (this.remoteEvalCache != null) {
+            this.remoteEvalCache.invalidateAll();
+        }
     }
 
     private EvaluationContext getEvaluationContext() {
@@ -183,6 +266,22 @@ public class GrowthBook implements IGrowthBook {
     @Override
     public void setAttributes(String attributesJsonString) {
         this.context.setAttributesJson(attributesJsonString);
+        initializeEvalContext();
+    }
+
+    public void setUrl(String url) {
+        this.context.setUrl(url);
+        initializeEvalContext();
+    }
+
+    public void setForcedVariations(Map<String, Integer> forcedVariations) {
+        this.context.setForcedVariationsMap(forcedVariations);
+        initializeEvalContext();
+    }
+
+    public void setForcedFeatureValues(Map<String, Object> forcedFeatureValues) {
+        this.forcedFeatureValues = forcedFeatureValues;
+        clearRemoteEvalCache();
         initializeEvalContext();
     }
 
@@ -499,6 +598,12 @@ public class GrowthBook implements IGrowthBook {
     @Override
     public void destroy() {
         this.callbacks = new ArrayList<>();
+        if (this.remoteEvalCache != null) {
+            this.remoteEvalCache.shutdown();
+        }
+        if (this.remoteEvalService != null) {
+            this.remoteEvalService.close();
+        }
     }
 
     /**

--- a/lib/src/main/java/growthbook/sdk/java/evaluators/ConditionEvaluator.java
+++ b/lib/src/main/java/growthbook/sdk/java/evaluators/ConditionEvaluator.java
@@ -317,7 +317,7 @@ public class ConditionEvaluator implements IConditionEvaluator {
                 return evalRegex(actual, expected, attributeDataType, true, true);
 
             case NE:
-                if (DataType.NULL.equals(attributeDataType)) return false;
+                if (DataType.NULL.equals(attributeDataType)) return !expected.isJsonNull();
                 return !Objects.equals(actual, expected);
 
             case EQ:
@@ -666,7 +666,7 @@ public class ConditionEvaluator implements IConditionEvaluator {
                                               DataType attributeDataType,
                                               boolean caseInsensitive,
                                               boolean negate) {
-        if (actual == null || DataType.NULL.equals(attributeDataType)) return false;
+        if (actual == null || DataType.NULL.equals(attributeDataType)) return negate;
 
         int flags = caseInsensitive ? Pattern.CASE_INSENSITIVE : 0;
 
@@ -676,7 +676,7 @@ public class ConditionEvaluator implements IConditionEvaluator {
             boolean matches = matcher.find();
             return negate != matches;
         } catch (Exception e) {
-            return false;
+            return negate;
         }
     }
 

--- a/lib/src/main/java/growthbook/sdk/java/evaluators/ExperimentEvaluator.java
+++ b/lib/src/main/java/growthbook/sdk/java/evaluators/ExperimentEvaluator.java
@@ -15,6 +15,7 @@ import growthbook.sdk.java.model.FeatureResult;
 import growthbook.sdk.java.model.FeatureResultSource;
 import growthbook.sdk.java.model.Filter;
 import growthbook.sdk.java.model.StickyBucketVariation;
+import growthbook.sdk.java.model.TrackData;
 import growthbook.sdk.java.model.VariationMeta;
 import growthbook.sdk.java.multiusermode.configurations.EvaluationContext;
 import growthbook.sdk.java.multiusermode.usage.TrackingCallbackWithUser;
@@ -391,12 +392,7 @@ public class ExperimentEvaluator implements IExperimentEvaluator {
 
     //  Track experiments to trigger callbacks.
     private <ValueType> boolean isExperimentTracked(Experiment<ValueType> experiment, ExperimentResult<ValueType> result) {
-        String experimentKey = experiment.getKey();
-
-        String key = (
-                result.getHashAttribute() != null ? result.getHashAttribute() : "")
-                + (result.getHashValue() != null ? result.getHashValue() : "")
-                + (experimentKey + result.getVariationId());
+        String key = trackingKey(experiment, result);
 
         // Add the experiment to the tracker if it doesn't exist.
         if (!experimentTracker.isExperimentTracked(key)) {
@@ -404,6 +400,59 @@ public class ExperimentEvaluator implements IExperimentEvaluator {
         }
 
         return false;
+    }
+
+    /**
+     * Fires tracking callbacks for experiments that were evaluated remotely (a feature rule's
+     * {@code tracks}). De-duplicates per {@code (hashAttribute, hashValue, experimentKey, variationId)}
+     * using the same {@link ExperimentTracker} as local evaluation, so reusing a cached remote-eval
+     * response does not re-fire exposure events.
+     */
+    public <ValueType> void fireRemoteEvaluationTracks(
+            @Nullable List<TrackData<ValueType>> tracks,
+            EvaluationContext context
+    ) {
+        if (tracks == null) {
+            return;
+        }
+        TrackingCallbackWithUser trackingCallBackWithUser = context.getOptions().getTrackingCallBackWithUser();
+        if (trackingCallBackWithUser == null) {
+            return;
+        }
+
+        for (TrackData<ValueType> track : tracks) {
+            if (track == null
+                    || track.getExperiment() == null
+                    || track.getResult() == null
+                    || track.getExperiment().getKey() == null
+                    || track.getExperiment().getVariations() == null) {
+                log.debug("Skipping malformed remote evaluation tracking payload.");
+                continue;
+            }
+            if (alreadyTracked(track.getExperiment(), track.getResult())) {
+                continue;
+            }
+            try {
+                trackingCallBackWithUser.onTrack(track.getExperiment(), track.getResult(), context.getUser());
+            } catch (RuntimeException e) {
+                log.warn("Tracking callback failed for remote evaluation payload.", e);
+            }
+        }
+    }
+
+    private <ValueType> boolean alreadyTracked(Experiment<ValueType> experiment, ExperimentResult<ValueType> result) {
+        String key = trackingKey(experiment, result);
+        if (experimentTracker.isExperimentTracked(key)) {
+            return true;
+        }
+        experimentTracker.trackExperiment(key);
+        return false;
+    }
+
+    private <ValueType> String trackingKey(Experiment<ValueType> experiment, ExperimentResult<ValueType> result) {
+        return (result.getHashAttribute() != null ? result.getHashAttribute() : "")
+                + (result.getHashValue() != null ? result.getHashValue() : "")
+                + experiment.getKey() + result.getVariationId();
     }
 
     private <ValueType> boolean isStickyBucketingEnabledForExperiment(EvaluationContext context,

--- a/lib/src/main/java/growthbook/sdk/java/evaluators/FeatureEvaluator.java
+++ b/lib/src/main/java/growthbook/sdk/java/evaluators/FeatureEvaluator.java
@@ -11,10 +11,8 @@ import growthbook.sdk.java.model.FeatureResult;
 import growthbook.sdk.java.model.FeatureResultSource;
 import growthbook.sdk.java.model.FeatureRule;
 import growthbook.sdk.java.model.Filter;
-import growthbook.sdk.java.model.TrackData;
 import growthbook.sdk.java.multiusermode.configurations.EvaluationContext;
 import growthbook.sdk.java.multiusermode.usage.FeatureUsageCallbackWithUser;
-import growthbook.sdk.java.multiusermode.usage.TrackingCallbackWithUser;
 import lombok.extern.slf4j.Slf4j;
 import javax.annotation.Nullable;
 import java.net.MalformedURLException;
@@ -281,20 +279,9 @@ public class FeatureEvaluator implements IFeatureEvaluator {
                         continue;
                     }
 
-                    // Call the tracking callback with all the track data
-                    List<TrackData<ValueType>> trackData = rule.getTracks();
-                    TrackingCallbackWithUser trackingCallBackWithUser = context.getOptions().getTrackingCallBackWithUser();
-
-                    // If this was a remotely evaluated experiment, fire the tracking callbacks
-                    if (trackData != null && trackingCallBackWithUser != null) {
-                        trackData.forEach(t ->
-                                trackingCallBackWithUser.onTrack(
-                                        t.getExperiment(),
-                                        t.getResult().getExperimentResult(),
-                                        context.getUser()
-                                )
-                        );
-                    }
+                    // Fire tracking callbacks for remotely evaluated experiments, de-duplicated per
+                    // assignment so repeated cached evaluations don't re-fire exposures.
+                    experimentEvaluator.fireRemoteEvaluationTracks(rule.getTracks(), context);
 
                     ValueType value = (ValueType) GrowthBookJsonUtils.unwrap(rule.getForce().getValue());
 

--- a/lib/src/main/java/growthbook/sdk/java/model/GBContext.java
+++ b/lib/src/main/java/growthbook/sdk/java/model/GBContext.java
@@ -5,6 +5,7 @@ import growthbook.sdk.java.util.ExperimentHelper;
 import growthbook.sdk.java.callback.FeatureUsageCallback;
 import growthbook.sdk.java.callback.TrackingCallback;
 import growthbook.sdk.java.multiusermode.util.TransformationUtil;
+import growthbook.sdk.java.remoteeval.RemoteEvalRequestBuilder;
 import growthbook.sdk.java.stickyBucketing.StickyBucketService;
 import lombok.Builder;
 import lombok.Data;
@@ -43,6 +44,13 @@ public class GBContext {
      * @param stickyBucketService              Service that provide functionality of Sticky Bucketing.
      * @param stickyBucketAssignmentDocs       Map of Sticky Bucket documents.
      * @param stickyBucketIdentifierAttributes List of user's attributes keys.
+     * @param savedGroups                      Saved Groups data.
+     * @param apiHost                          GrowthBook API host for remote evaluation.
+     * @param clientKey                        GrowthBook SDK client key for remote evaluation.
+     * @param remoteEval                       Whether to use remote evaluation.
+     * @param cacheKeyAttributes               Attribute names used to build the remote eval cache key.
+     * @param remoteEvalCacheSize              Maximum number of remote eval responses kept in memory.
+     * @param remoteEvalCacheTtlSeconds        Hard expiry (seconds) for cached remote eval responses; null disables time-based expiry.
      */
     @Builder
     public GBContext(
@@ -61,7 +69,13 @@ public class GBContext {
             @Nullable StickyBucketService stickyBucketService,
             @Nullable Map<String, StickyAssignmentsDocument> stickyBucketAssignmentDocs,
             @Nullable List<String> stickyBucketIdentifierAttributes,
-            @Nullable JsonObject savedGroups
+            @Nullable JsonObject savedGroups,
+            @Nullable String apiHost,
+            @Nullable String clientKey,
+            @Nullable Boolean remoteEval,
+            @Nullable List<String> cacheKeyAttributes,
+            @Nullable Integer remoteEvalCacheSize,
+            @Nullable Integer remoteEvalCacheTtlSeconds
     ) {
         this.encryptionKey = encryptionKey;
         this.attributesJson = attributesJson == null ? "{}" : attributesJson;
@@ -85,6 +99,56 @@ public class GBContext {
         this.stickyBucketAssignmentDocs = stickyBucketAssignmentDocs;
         this.stickyBucketIdentifierAttributes = stickyBucketIdentifierAttributes;
         this.savedGroups = savedGroups == null ? new JsonObject() : savedGroups;
+        this.apiHost = apiHost;
+        this.clientKey = clientKey;
+        this.remoteEval = remoteEval != null && remoteEval;
+        this.cacheKeyAttributes = cacheKeyAttributes;
+        this.remoteEvalCacheSize = RemoteEvalRequestBuilder.normalizeCacheSize(remoteEvalCacheSize);
+        this.remoteEvalCacheTtlSeconds = remoteEvalCacheTtlSeconds;
+    }
+
+    public GBContext(
+            @Nullable String attributesJson,
+            @Nullable JsonObject attributes,
+            @Nullable String featuresJson,
+            @Nullable Map<String, Feature<?>> features,
+            @Nullable String encryptionKey,
+            @Nullable Boolean enabled,
+            Boolean isQaMode,
+            @Nullable String url,
+            Boolean allowUrlOverrides,
+            @Nullable Map<String, Integer> forcedVariationsMap,
+            @Nullable TrackingCallback trackingCallback,
+            @Nullable FeatureUsageCallback featureUsageCallback,
+            @Nullable StickyBucketService stickyBucketService,
+            @Nullable Map<String, StickyAssignmentsDocument> stickyBucketAssignmentDocs,
+            @Nullable List<String> stickyBucketIdentifierAttributes,
+            @Nullable JsonObject savedGroups
+    ) {
+        this(
+                attributesJson,
+                attributes,
+                featuresJson,
+                features,
+                encryptionKey,
+                enabled,
+                isQaMode,
+                url,
+                allowUrlOverrides,
+                forcedVariationsMap,
+                trackingCallback,
+                featureUsageCallback,
+                stickyBucketService,
+                stickyBucketAssignmentDocs,
+                stickyBucketIdentifierAttributes,
+                savedGroups,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null
+        );
     }
 
     /**
@@ -233,6 +297,29 @@ public class GBContext {
      */
     @Nullable
     private String stickyBucketIdentifierAttributesSignature;
+
+    @Nullable
+    private String apiHost;
+
+    @Nullable
+    private String clientKey;
+
+    private Boolean remoteEval;
+
+    @Nullable
+    private List<String> cacheKeyAttributes;
+
+    private Integer remoteEvalCacheSize;
+
+    /**
+     * Hard expiry (seconds) for cached remote-eval responses; {@code null} disables time-based expiry.
+     */
+    @Nullable
+    private Integer remoteEvalCacheTtlSeconds;
+
+    public boolean isRemoteEvalEnabled() {
+        return Boolean.TRUE.equals(this.remoteEval);
+    }
 
     /**
      * The builder class to help create a context. You can use {@link #builder()} or the {@link GBContext} constructor

--- a/lib/src/main/java/growthbook/sdk/java/model/RequestBodyForRemoteEval.java
+++ b/lib/src/main/java/growthbook/sdk/java/model/RequestBodyForRemoteEval.java
@@ -1,24 +1,50 @@
 package growthbook.sdk.java.model;
 
 import com.google.gson.JsonObject;
-import lombok.AllArgsConstructor;
 import lombok.Data;
-import lombok.NoArgsConstructor;
 
 import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 @Data
-@NoArgsConstructor
-@AllArgsConstructor
 public class RequestBodyForRemoteEval {
-    @Nullable
     private JsonObject attributes;
-    @Nullable
     private List<List<Object>> forcedFeatures;
-    @Nullable
     private Map<String, Integer> forcedVariations;
-    @Nullable
     private String url;
+
+    public RequestBodyForRemoteEval() {
+        this(null, null, null, null);
+    }
+
+    public RequestBodyForRemoteEval(
+            @Nullable JsonObject attributes,
+            @Nullable List<List<Object>> forcedFeatures,
+            @Nullable Map<String, Integer> forcedVariations,
+            @Nullable String url
+    ) {
+        setAttributes(attributes);
+        setForcedFeatures(forcedFeatures);
+        setForcedVariations(forcedVariations);
+        setUrl(url);
+    }
+
+    public void setAttributes(@Nullable JsonObject attributes) {
+        this.attributes = attributes == null ? new JsonObject() : attributes;
+    }
+
+    public void setForcedFeatures(@Nullable List<List<Object>> forcedFeatures) {
+        this.forcedFeatures = forcedFeatures == null ? new ArrayList<>() : forcedFeatures;
+    }
+
+    public void setForcedVariations(@Nullable Map<String, Integer> forcedVariations) {
+        this.forcedVariations = forcedVariations == null ? new HashMap<>() : forcedVariations;
+    }
+
+    public void setUrl(@Nullable String url) {
+        this.url = url == null ? "" : url;
+    }
 }

--- a/lib/src/main/java/growthbook/sdk/java/model/TrackData.java
+++ b/lib/src/main/java/growthbook/sdk/java/model/TrackData.java
@@ -11,5 +11,5 @@ import lombok.Getter;
 @Getter
 public class TrackData<ValueType> {
     Experiment<ValueType> experiment;
-    FeatureResult<ValueType> result;
+    ExperimentResult<ValueType> result;
 }

--- a/lib/src/main/java/growthbook/sdk/java/multiusermode/GrowthBookClient.java
+++ b/lib/src/main/java/growthbook/sdk/java/multiusermode/GrowthBookClient.java
@@ -41,6 +41,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 @Slf4j
@@ -55,8 +56,9 @@ public class GrowthBookClient {
     private final ExperimentEvaluator experimentEvaluatorEvaluator;
     private final AtomicReference<GlobalContext> globalContext = new AtomicReference<>();
     private final AtomicReference<GBFeaturesRepository> repository = new AtomicReference<>();
-    private RemoteEvalService remoteEvalService;
-    private RemoteEvalCache remoteEvalCache;
+    private volatile RemoteEvalService remoteEvalService;
+    private volatile RemoteEvalCache remoteEvalCache;
+    private final AtomicBoolean remoteEvalReady = new AtomicBoolean(false);
 
     public GrowthBookClient() {
         this(Options.builder().build());
@@ -310,12 +312,21 @@ public class GrowthBookClient {
     }
 
     private boolean ensureRemoteEvalReady() {
-        RemoteEvalOptionsValidator.validate(this.options);
-        getRemoteEvalService();
-        getRemoteEvalCache();
-        initializeRemoteEvalSseInvalidationIfNeeded();
-        this.globalContext.compareAndSet(null, buildGlobalContext(Collections.emptyMap(), new JsonObject()));
-        return true;
+        if (this.remoteEvalReady.get()) {
+            return true;
+        }
+        synchronized (this) {
+            if (this.remoteEvalReady.get()) {
+                return true;
+            }
+            RemoteEvalOptionsValidator.validate(this.options);
+            getRemoteEvalService();
+            getRemoteEvalCache();
+            initializeRemoteEvalSseInvalidationIfNeeded();
+            this.globalContext.compareAndSet(null, buildGlobalContext(Collections.emptyMap(), new JsonObject()));
+            this.remoteEvalReady.set(true);
+            return true;
+        }
     }
 
     private void initializeRemoteEvalSseInvalidationIfNeeded() {
@@ -518,8 +529,9 @@ public class GrowthBookClient {
     }
 
     private void clearRemoteEvalCache() {
-        if (this.remoteEvalCache != null) {
-            this.remoteEvalCache.invalidateAll();
+        RemoteEvalCache cache = this.remoteEvalCache;
+        if (cache != null) {
+            cache.invalidateAll();
         }
     }
 

--- a/lib/src/main/java/growthbook/sdk/java/multiusermode/GrowthBookClient.java
+++ b/lib/src/main/java/growthbook/sdk/java/multiusermode/GrowthBookClient.java
@@ -384,6 +384,7 @@ public class GrowthBookClient {
                 this.options.getClientKey(),
                 userContext.getAttributes(),
                 forcedVariations,
+                forcedFeatures,
                 url,
                 this.options.getCacheKeyAttributes()
         );

--- a/lib/src/main/java/growthbook/sdk/java/multiusermode/GrowthBookClient.java
+++ b/lib/src/main/java/growthbook/sdk/java/multiusermode/GrowthBookClient.java
@@ -16,28 +16,40 @@ import growthbook.sdk.java.multiusermode.configurations.EvaluationContext;
 import growthbook.sdk.java.multiusermode.configurations.GlobalContext;
 import growthbook.sdk.java.multiusermode.configurations.Options;
 import growthbook.sdk.java.multiusermode.configurations.UserContext;
+import growthbook.sdk.java.repository.FeatureRefreshStrategy;
 import growthbook.sdk.java.repository.GBFeaturesRepository;
+import growthbook.sdk.java.remoteeval.RemoteEvalCache;
+import growthbook.sdk.java.remoteeval.RemoteEvalCacheKey;
+import growthbook.sdk.java.remoteeval.RemoteEvalOptionsValidator;
+import growthbook.sdk.java.remoteeval.RemoteEvalRequestBuilder;
+import growthbook.sdk.java.remoteeval.RemoteEvalResponse;
+import growthbook.sdk.java.remoteeval.RemoteEvalService;
 import growthbook.sdk.java.sandbox.CacheManagerFactory;
 import growthbook.sdk.java.sandbox.CacheMode;
 import growthbook.sdk.java.sandbox.GbCacheManager;
 import growthbook.sdk.java.util.GrowthBookJsonUtils;
 import lombok.extern.slf4j.Slf4j;
 
+import javax.annotation.Nullable;
+import java.time.Duration;
 import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 @Slf4j
 public class GrowthBookClient {
 
+    private static final int DEFAULT_SWR_TTL_SECONDS = 60;
+
     private final Options options;
     private final FeatureEvaluator featureEvaluator;
     private final ExperimentEvaluator experimentEvaluatorEvaluator;
-    private static GBFeaturesRepository repository;
+    private GBFeaturesRepository repository;
+    private RemoteEvalService remoteEvalService;
+    private RemoteEvalCache remoteEvalCache;
     private List<ExperimentRunCallback> callbacks;
     private final Map<String, AssignedExperiment> assigned;
     private GlobalContext globalContext;
@@ -53,76 +65,47 @@ public class GrowthBookClient {
         this.callbacks = new ArrayList<>();
         this.featureEvaluator = new FeatureEvaluator();
         this.experimentEvaluatorEvaluator = new ExperimentEvaluator();
-        this.callbacks = new ArrayList<>();
     }
 
     public boolean initialize() {
-        boolean isReady = false;
         try {
-
-            if (repository == null) {
-                GbCacheManager cm = this.options.getCacheManager() != null
-                        ? this.options.getCacheManager()
-                        : CacheManagerFactory.create(this.options.getCacheMode(), this.options.getCacheDirectory()
-                        );
-
-                repository = GBFeaturesRepository.builder()
-                        .apiHost(this.options.getApiHost())
-                        .clientKey(this.options.getClientKey())
-                        .decryptionKey(this.options.getDecryptionKey())
-                        .refreshStrategy(this.options.getRefreshStrategy())
-                        .swrTtlSeconds(this.options.getSwrTtlSeconds())
-                        .isCacheDisabled(this.options.getIsCacheDisabled() || this.options.getCacheMode() == CacheMode.NONE)
-                        .cacheManager(cm)
-                        // if we don't want to pre-fetch for remote eval we can delete this line
-                        .requestBodyForRemoteEval(configurePayloadForRemoteEval(this.options))
-                        .build();
-
-                // Add featureRefreshCallback
-                repository.onFeaturesRefresh(this.options.getFeatureRefreshCallback());
-
-                // Add a callback to refresh the global context
-                repository.onFeaturesRefresh(this.refreshGlobalContext());
-
-                try {
-                    repository.initialize();
-                } catch (FeatureFetchException e) {
-                    log.error("Failed to initialize features repository", e);
-                    throw new RuntimeException(e);
-                }
-
-                // instantiate a global context that holds features & savedGroups.
-                this.globalContext = GlobalContext.builder()
-                        .features(repository.getParsedFeatures())
-                        .savedGroups(repository.getParsedSavedGroups())
-                        .enabled(this.options.getEnabled())
-                        .qaMode(this.options.getIsQaMode())
-                        .forcedFeatureValues(this.options.getGlobalForcedFeatureValues())
-                        .forcedVariations(this.options.getGlobalForcedVariationsMap())
-                        .build();
-
-                isReady = repository.getInitialized();
-                log.info("GrowthBookClient initialized repository and registered feature refresh callbacks.");
+            if (this.options.isRemoteEvalEnabled()) {
+                return ensureRemoteEvalReady();
             }
+
+            return initializeRepository();
         } catch (Exception e) {
             log.error("Failed to initialize growthbook instance", e);
+            return false;
         }
-        return isReady;
     }
 
     public void setGlobalAttributes(String attributes) {
         this.options.setGlobalAttributes(attributes);
+        clearRemoteEvalCache();
     }
 
     public void setGlobalForceFeatures(Map<String, Object> forceFeatures) {
         this.options.setGlobalForcedFeatureValues(forceFeatures);
+        clearRemoteEvalCache();
     }
 
     public void setGlobalForceVariations(Map<String, Integer> forceVariations) {
         this.options.setGlobalForcedVariationsMap(forceVariations);
+        clearRemoteEvalCache();
     }
 
     public void refreshFeature() {
+        if (this.options.isRemoteEvalEnabled()) {
+            clearRemoteEvalCache();
+            return;
+        }
+
+        if (repository == null) {
+            log.warn("Cannot refresh features before GrowthBookClient is initialized.");
+            return;
+        }
+
         try {
             repository.fetchFeatures();
         } catch (FeatureFetchException e) {
@@ -132,9 +115,34 @@ public class GrowthBookClient {
 
     public void refreshForRemoteEval(RequestBodyForRemoteEval requestBodyForRemoteEval) {
         try {
+            if (this.options.isRemoteEvalEnabled()) {
+                RemoteEvalResponse response = getRemoteEvalService().fetch(requestBodyForRemoteEval);
+                this.globalContext = buildGlobalContext(response.getFeatures(), response.getSavedGroups());
+                clearRemoteEvalCache();
+                return;
+            }
+
+            if (repository == null) {
+                log.warn("Cannot refresh remote evaluation features before GrowthBookClient is initialized.");
+                return;
+            }
             repository.fetchForRemoteEval(requestBodyForRemoteEval);
         } catch (FeatureFetchException e) {
             log.error("Refreshing for remote eval wasn't successful. Message is: {}", e.getMessage(), e);
+        }
+    }
+
+    public boolean preloadRemoteEval(UserContext userContext) {
+        if (!this.options.isRemoteEvalEnabled()) {
+            return false;
+        }
+
+        try {
+            getRemoteEvalResponse(toUserContextWithMergedAttributes(userContext));
+            return true;
+        } catch (FeatureFetchException e) {
+            log.warn("Unable to preload remote evaluation response", e);
+            return false;
         }
     }
 
@@ -186,11 +194,92 @@ public class GrowthBookClient {
     }
 
     public void shutdown() {
-      if (repository != null) {
-        repository.shutdown();
-        repository = null;
-        log.info("Repository shut down");
-      }
+        if (repository != null) {
+            repository.shutdown();
+            repository = null;
+            log.info("Repository shut down");
+        }
+        if (this.remoteEvalCache != null) {
+            this.remoteEvalCache.shutdown();
+        }
+        if (this.remoteEvalService != null) {
+            this.remoteEvalService.close();
+        }
+    }
+
+    private boolean initializeRepository() throws FeatureFetchException {
+        if (this.repository != null) {
+            return this.repository.getInitialized();
+        }
+
+        GbCacheManager cacheManager = this.options.getCacheManager() != null
+                ? this.options.getCacheManager()
+                : CacheManagerFactory.create(this.options.getCacheMode(), this.options.getCacheDirectory());
+
+        this.repository = GBFeaturesRepository.builder()
+                .apiHost(this.options.getApiHost())
+                .clientKey(this.options.getClientKey())
+                .decryptionKey(this.options.getDecryptionKey())
+                .refreshStrategy(this.options.getRefreshStrategy())
+                .swrTtlSeconds(this.options.getSwrTtlSeconds())
+                .isCacheDisabled(this.options.getIsCacheDisabled() || this.options.getCacheMode() == CacheMode.NONE)
+                .cacheManager(cacheManager)
+                .requestBodyForRemoteEval(configurePayloadForRemoteEval(this.options))
+                .build();
+
+        this.repository.onFeaturesRefresh(this.options.getFeatureRefreshCallback());
+        this.repository.onFeaturesRefresh(this.refreshGlobalContext());
+        try {
+            this.repository.initialize();
+        } catch (FeatureFetchException e) {
+            this.repository = null;
+            throw e;
+        }
+        this.globalContext = buildGlobalContext(this.repository.getParsedFeatures(), this.repository.getParsedSavedGroups());
+        log.info("GrowthBookClient initialized repository and registered feature refresh callbacks.");
+
+        return this.repository.getInitialized();
+    }
+
+    private boolean ensureRemoteEvalReady() {
+        RemoteEvalOptionsValidator.validate(this.options);
+        getRemoteEvalService();
+        getRemoteEvalCache();
+        initializeRemoteEvalSseInvalidationIfNeeded();
+        if (this.globalContext == null) {
+            this.globalContext = buildGlobalContext(Collections.emptyMap(), new JsonObject());
+        }
+        return true;
+    }
+
+    private void initializeRemoteEvalSseInvalidationIfNeeded() {
+        if (this.options.getRefreshStrategy() != FeatureRefreshStrategy.SERVER_SENT_EVENTS || this.repository != null) {
+            return;
+        }
+
+        this.repository = GBFeaturesRepository.builder()
+                .apiHost(this.options.getApiHost())
+                .clientKey(this.options.getClientKey())
+                .refreshStrategy(FeatureRefreshStrategy.SERVER_SENT_EVENTS)
+                .isCacheDisabled(true)
+                .build();
+        this.repository.onFeaturesRefresh(new FeatureRefreshCallback() {
+            @Override
+            public void onRefresh(String featuresJson) {
+                clearRemoteEvalCache();
+            }
+
+            @Override
+            public void onError(Throwable throwable) {
+                log.warn("Unable to receive remote evaluation invalidation event", throwable);
+            }
+        });
+
+        try {
+            this.repository.initialize();
+        } catch (FeatureFetchException e) {
+            log.warn("Remote evaluation SSE invalidation could not be initialized", e);
+        }
     }
 
     private <ValueType> void fireSubscriptions(Experiment<ValueType> experiment, ExperimentResult<ValueType> result) {
@@ -221,15 +310,18 @@ public class GrowthBookClient {
         return new FeatureRefreshCallback() {
             @Override
             public void onRefresh(String featuresJson) {
-                // refer the global context with latest features & saved groups
+                GBFeaturesRepository currentRepository = repository;
+                if (currentRepository == null) {
+                    log.debug("Skipping global context refresh because repository is not initialized.");
+                    return;
+                }
                 if (globalContext != null) {
-                    globalContext.setFeatures(repository.getParsedFeatures());
-                    globalContext.setSavedGroups(repository.getParsedSavedGroups());
+                    globalContext.setFeatures(currentRepository.getParsedFeatures());
+                    globalContext.setSavedGroups(currentRepository.getParsedSavedGroups());
                 } else {
-                    // TBD:M This should never happen! Just to be cautious about race conditions at the time of initialization
                     globalContext = GlobalContext.builder()
-                            .features(repository.getParsedFeatures())
-                            .savedGroups(repository.getParsedSavedGroups())
+                            .features(currentRepository.getParsedFeatures())
+                            .savedGroups(currentRepository.getParsedSavedGroups())
                             .enabled(options.getEnabled())
                             .qaMode(options.getIsQaMode())
                             .forcedFeatureValues(options.getGlobalForcedFeatureValues())
@@ -246,29 +338,140 @@ public class GrowthBookClient {
     }
 
     private EvaluationContext getEvalContext(UserContext userContext) {
-        // Merge attributes using JsonObject to avoid parse/serialize churn
+        UserContext updatedUserContext = toUserContextWithMergedAttributes(userContext);
+        if (this.options.isRemoteEvalEnabled()) {
+            return getRemoteEvalContext(updatedUserContext);
+        }
+        return new EvaluationContext(getLocalGlobalContext(), updatedUserContext, new EvaluationContext.StackContext(), this.options);
+    }
+
+    private EvaluationContext getRemoteEvalContext(UserContext userContext) {
+        try {
+            RemoteEvalResponse response = getRemoteEvalResponse(userContext);
+            GlobalContext remoteGlobalContext = buildGlobalContext(response.getFeatures(), response.getSavedGroups());
+            return new EvaluationContext(remoteGlobalContext, userContext, new EvaluationContext.StackContext(), this.options);
+        } catch (FeatureFetchException e) {
+            log.warn("Remote evaluation request failed. Falling back to local feature context.", e);
+            return new EvaluationContext(getLocalGlobalContext(), userContext, new EvaluationContext.StackContext(), this.options);
+        }
+    }
+
+    private UserContext toUserContextWithMergedAttributes(UserContext userContext) {
+        UserContext currentUserContext = userContext == null ? UserContext.builder().build() : userContext;
         JsonObject merged = new JsonObject();
         if (this.options.getGlobalAttributes() != null) {
             merged = GrowthBookJsonUtils.getInstance().gson.fromJson(this.options.getGlobalAttributes(), JsonObject.class);
             if (merged == null) merged = new JsonObject();
         }
-        JsonObject userAttrs = userContext.getAttributes();
+        JsonObject userAttrs = currentUserContext.getAttributes();
         if (userAttrs != null) {
             for (Map.Entry<String, JsonElement> e : userAttrs.entrySet()) {
                 merged.add(e.getKey(), e.getValue());
             }
         }
-        UserContext updatedUserContext = userContext.withAttributes(merged);
-        return new EvaluationContext(this.globalContext, updatedUserContext, new EvaluationContext.StackContext(), this.options);
+        return currentUserContext.withAttributes(merged);
+    }
+
+    private RemoteEvalResponse getRemoteEvalResponse(UserContext userContext) throws FeatureFetchException {
+        ensureRemoteEvalReady();
+
+        Map<String, Integer> forcedVariations = mergeForcedVariations(userContext);
+        Map<String, Object> forcedFeatures = mergeForcedFeatures(userContext);
+        String url = userContext.getUrl() == null ? this.options.getUrl() : userContext.getUrl();
+        url = RemoteEvalRequestBuilder.normalizeUrl(url);
+        String cacheKey = RemoteEvalCacheKey.fromContext(
+                this.options.getApiHost(),
+                this.options.getClientKey(),
+                userContext.getAttributes(),
+                forcedVariations,
+                url,
+                this.options.getCacheKeyAttributes()
+        );
+
+        RequestBodyForRemoteEval requestBody = RemoteEvalRequestBuilder.build(
+                userContext.getAttributes(),
+                forcedFeatures,
+                forcedVariations,
+                url
+        );
+        return getRemoteEvalCache().get(cacheKey, requestBody);
+    }
+
+    private synchronized RemoteEvalService getRemoteEvalService() {
+        if (this.remoteEvalService == null) {
+            this.remoteEvalService = new RemoteEvalService(this.options.getApiHost(), this.options.getClientKey());
+        }
+        return this.remoteEvalService;
+    }
+
+    private synchronized RemoteEvalCache getRemoteEvalCache() {
+        if (this.remoteEvalCache == null) {
+            this.remoteEvalCache = new RemoteEvalCache(
+                    getRemoteEvalService(),
+                    RemoteEvalRequestBuilder.normalizeCacheSize(this.options.getRemoteEvalCacheSize()),
+                    secondsToDuration(this.options.getSwrTtlSeconds() == null ? DEFAULT_SWR_TTL_SECONDS : this.options.getSwrTtlSeconds()),
+                    secondsToDuration(this.options.getRemoteEvalCacheTtlSeconds())
+            );
+        }
+        return this.remoteEvalCache;
+    }
+
+    private static Duration secondsToDuration(@Nullable Integer seconds) {
+        return seconds == null ? null : Duration.ofSeconds(seconds);
+    }
+
+    private void clearRemoteEvalCache() {
+        if (this.remoteEvalCache != null) {
+            this.remoteEvalCache.invalidateAll();
+        }
+    }
+
+    private GlobalContext getLocalGlobalContext() {
+        if (this.globalContext == null) {
+            this.globalContext = buildGlobalContext(Collections.emptyMap(), new JsonObject());
+        }
+        return this.globalContext;
+    }
+
+    private GlobalContext buildGlobalContext(Map<String, growthbook.sdk.java.model.Feature<?>> features, JsonObject savedGroups) {
+        return GlobalContext.builder()
+                .features(features == null ? Collections.emptyMap() : features)
+                .savedGroups(savedGroups == null ? new JsonObject() : savedGroups)
+                .enabled(this.options.getEnabled())
+                .qaMode(this.options.getIsQaMode())
+                .forcedFeatureValues(this.options.getGlobalForcedFeatureValues())
+                .forcedVariations(this.options.getGlobalForcedVariationsMap())
+                .build();
+    }
+
+    private Map<String, Integer> mergeForcedVariations(UserContext userContext) {
+        Map<String, Integer> forcedVariations = new HashMap<>();
+        if (this.options.getGlobalForcedVariationsMap() != null) {
+            forcedVariations.putAll(this.options.getGlobalForcedVariationsMap());
+        }
+        if (userContext.getForcedVariationsMap() != null) {
+            forcedVariations.putAll(userContext.getForcedVariationsMap());
+        }
+        return forcedVariations;
+    }
+
+    private Map<String, Object> mergeForcedFeatures(UserContext userContext) {
+        Map<String, Object> forcedFeatures = new HashMap<>();
+        if (this.options.getGlobalForcedFeatureValues() != null) {
+            forcedFeatures.putAll(this.options.getGlobalForcedFeatureValues());
+        }
+        if (userContext.getForcedFeatureValues() != null) {
+            forcedFeatures.putAll(userContext.getForcedFeatureValues());
+        }
+        return forcedFeatures;
     }
 
     private RequestBodyForRemoteEval configurePayloadForRemoteEval(Options options) {
-        List<List<Object>> forceFeaturesForPayload = new ArrayList<>();
-        if (options.getGlobalForcedFeatureValues() != null) {
-            forceFeaturesForPayload = options.getGlobalForcedFeatureValues().entrySet().stream()
-                    .map(entry -> Arrays.asList(entry.getKey(), entry.getValue()))
-                    .collect(Collectors.toList());
-        }
-        return new RequestBodyForRemoteEval(options.getGlobalAttributes(), forceFeaturesForPayload, options.getGlobalForcedVariationsMap(), options.getUrl());
+        return RemoteEvalRequestBuilder.build(
+                options.getGlobalAttributes(),
+                options.getGlobalForcedFeatureValues(),
+                options.getGlobalForcedVariationsMap(),
+                options.getUrl()
+        );
     }
 }

--- a/lib/src/main/java/growthbook/sdk/java/multiusermode/configurations/Options.java
+++ b/lib/src/main/java/growthbook/sdk/java/multiusermode/configurations/Options.java
@@ -8,6 +8,7 @@ import growthbook.sdk.java.model.FeatureResult;
 import growthbook.sdk.java.multiusermode.usage.FeatureUsageCallbackWithUser;
 import growthbook.sdk.java.multiusermode.usage.TrackingCallbackWithUser;
 import growthbook.sdk.java.multiusermode.util.TransformationUtil;
+import growthbook.sdk.java.remoteeval.RemoteEvalRequestBuilder;
 import growthbook.sdk.java.repository.FeatureRefreshStrategy;
 import growthbook.sdk.java.sandbox.GbCacheManager;
 import growthbook.sdk.java.sandbox.CacheMode;
@@ -47,7 +48,11 @@ public class Options {
                    @Nullable Map<String, Integer> globalForcedVariationsMap,
                    @Nullable GbCacheManager cacheManager,
                    @Nullable CacheMode cacheMode,
-                   @Nullable String cacheDirectory
+                   @Nullable String cacheDirectory,
+                   @Nullable Boolean remoteEval,
+                   @Nullable List<String> cacheKeyAttributes,
+                   @Nullable Integer remoteEvalCacheSize,
+                   @Nullable Integer remoteEvalCacheTtlSeconds
 
     ) {
         this.enabled = enabled == null || enabled;
@@ -71,6 +76,62 @@ public class Options {
         this.cacheManager = cacheManager;
         this.cacheMode = cacheMode == null ? CacheMode.AUTO : cacheMode;
         this.cacheDirectory = cacheDirectory;
+        this.remoteEval = remoteEval != null && remoteEval;
+        this.cacheKeyAttributes = cacheKeyAttributes;
+        this.remoteEvalCacheSize = RemoteEvalRequestBuilder.normalizeCacheSize(remoteEvalCacheSize);
+        this.remoteEvalCacheTtlSeconds = remoteEvalCacheTtlSeconds;
+    }
+
+    public Options(@Nullable Boolean enabled,
+                   Boolean isQaMode,
+                   @Nullable Boolean isCacheDisabled,
+                   Boolean allowUrlOverrides,
+                   @Nullable String url,
+                   @Nullable String apiHost,
+                   @Nullable String clientKey,
+                   @Nullable String decryptionKey,
+                   @Nullable List<String> stickyBucketIdentifierAttributes,
+                   @Nullable StickyBucketService stickyBucketService,
+                   @Nullable TrackingCallbackWithUser trackingCallBackWithUser,
+                   @Nullable FeatureUsageCallbackWithUser featureUsageCallbackWithUser,
+                   @Nullable FeatureRefreshStrategy refreshStrategy,
+                   @Nullable Integer swrTtlSeconds,
+                   @Nullable FeatureRefreshCallback featureRefreshCallback,
+                   @Nullable JsonObject globalAttributes,
+                   @Nullable Map<String, Object> globalForcedFeatureValues,
+                   @Nullable Map<String, Integer> globalForcedVariationsMap,
+                   @Nullable GbCacheManager cacheManager,
+                   @Nullable CacheMode cacheMode,
+                   @Nullable String cacheDirectory
+
+    ) {
+        this(
+                enabled,
+                isQaMode,
+                isCacheDisabled,
+                allowUrlOverrides,
+                url,
+                apiHost,
+                clientKey,
+                decryptionKey,
+                stickyBucketIdentifierAttributes,
+                stickyBucketService,
+                trackingCallBackWithUser,
+                featureUsageCallbackWithUser,
+                refreshStrategy,
+                swrTtlSeconds,
+                featureRefreshCallback,
+                globalAttributes,
+                globalForcedFeatureValues,
+                globalForcedVariationsMap,
+                cacheManager,
+                cacheMode,
+                cacheDirectory,
+                null,
+                null,
+                null,
+                null
+        );
     }
 
     /**
@@ -197,6 +258,19 @@ public class Options {
     @Nullable
     private String cacheDirectory;
 
+    private Boolean remoteEval;
+
+    @Nullable
+    private List<String> cacheKeyAttributes;
+
+    private Integer remoteEvalCacheSize;
+
+    /**
+     * Hard expiry (seconds) for cached remote-eval responses; {@code null} disables time-based expiry.
+     */
+    @Nullable
+    private Integer remoteEvalCacheTtlSeconds;
+
     public CacheMode getCacheMode() { return cacheMode == null ? CacheMode.AUTO : cacheMode; }
     @Nullable
     public String getCacheDirectory() { return cacheDirectory; }
@@ -213,5 +287,9 @@ public class Options {
     public void setGlobalAttributes(@Nullable String attributesJson) {
         this.attributesJson = attributesJson;
         this.globalAttributes = TransformationUtil.transformAttributes(attributesJson);
+    }
+
+    public boolean isRemoteEvalEnabled() {
+        return Boolean.TRUE.equals(this.remoteEval);
     }
 }

--- a/lib/src/main/java/growthbook/sdk/java/remoteeval/RemoteEvalCache.java
+++ b/lib/src/main/java/growthbook/sdk/java/remoteeval/RemoteEvalCache.java
@@ -1,0 +1,176 @@
+package growthbook.sdk.java.remoteeval;
+
+import com.google.common.base.Ticker;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListenableFutureTask;
+import com.google.common.util.concurrent.UncheckedExecutionException;
+import growthbook.sdk.java.exception.FeatureFetchException;
+import growthbook.sdk.java.model.RequestBodyForRemoteEval;
+import lombok.extern.slf4j.Slf4j;
+
+import javax.annotation.Nullable;
+import java.time.Duration;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * In-memory cache for remote-eval responses.
+ *
+ * <p>Backed by a Guava {@link LoadingCache}: served fresh within {@code staleTtl}, served stale
+ * with a background refetch up to {@code cacheTtl}, refetched after that. Guava coalesces
+ * concurrent reads for the same key into a single fetch.
+ */
+@Slf4j
+public final class RemoteEvalCache {
+
+    private final LoadingCache<Key, RemoteEvalResponse> cache;
+
+    @Nullable
+    private final ExecutorService refreshExecutor;
+
+    private final AtomicBoolean closed = new AtomicBoolean(false);
+
+    public RemoteEvalCache(
+            RemoteEvalService service,
+            int maximumSize,
+            @Nullable Duration staleTtl,
+            @Nullable Duration cacheTtl
+    ) {
+        this(service, maximumSize, staleTtl, cacheTtl, null);
+    }
+
+    /**
+     * @param service    performs the actual remote-eval POST.
+     * @param maximumSize LRU bound on cached responses (values {@code <= 0} disable retention).
+     * @param staleTtl   when positive, enables stale-while-revalidate: entries older than this
+     *                   are served stale while refreshed in the background. {@code null} disables SWR.
+     * @param cacheTtl   when positive, the hard expiry after which an entry is dropped and refetched.
+     *                   {@code null} means no time-based expiry (entries live until evicted or invalidated).
+     * @param ticker     time source; {@code null} uses the system ticker. Injectable for tests.
+     */
+    public RemoteEvalCache(
+            RemoteEvalService service,
+            int maximumSize,
+            @Nullable Duration staleTtl,
+            @Nullable Duration cacheTtl,
+            @Nullable Ticker ticker
+    ) {
+        boolean staleWhileRevalidate = isPositive(staleTtl);
+        this.refreshExecutor = staleWhileRevalidate ? newRefreshExecutor() : null;
+
+        CacheBuilder<Object, Object> builder = CacheBuilder.newBuilder()
+                .maximumSize(Math.max(0, maximumSize));
+        if (ticker != null) {
+            builder.ticker(ticker);
+        }
+        if (isPositive(cacheTtl)) {
+            builder.expireAfterWrite(cacheTtl);
+        }
+        if (staleWhileRevalidate) {
+            builder.refreshAfterWrite(staleTtl);
+        }
+
+        this.cache = builder.build(new CacheLoader<Key, RemoteEvalResponse>() {
+            @Override
+            public RemoteEvalResponse load(Key key) throws FeatureFetchException {
+                return service.fetch(key.payload);
+            }
+
+            @Override
+            public ListenableFuture<RemoteEvalResponse> reload(Key key, RemoteEvalResponse oldValue) {
+                if (closed.get()) {
+                    return Futures.immediateFuture(oldValue);
+                }
+                ListenableFutureTask<RemoteEvalResponse> task =
+                        ListenableFutureTask.create(() -> service.fetch(key.payload));
+                refreshExecutor.execute(task);
+                return task;
+            }
+        });
+    }
+
+    public RemoteEvalResponse get(String cacheKey, RequestBodyForRemoteEval payload) throws FeatureFetchException {
+        if (closed.get()) {
+            throw new FeatureFetchException(
+                    FeatureFetchException.FeatureFetchErrorCode.UNKNOWN,
+                    "Remote evaluation cache is closed"
+            );
+        }
+        try {
+            return cache.get(new Key(cacheKey, payload));
+        } catch (ExecutionException | UncheckedExecutionException e) {
+            throw toFeatureFetchException(e);
+        }
+    }
+
+    public void invalidateAll() {
+        cache.invalidateAll();
+    }
+
+    public void shutdown() {
+        closed.set(true);
+        cache.invalidateAll();
+        if (refreshExecutor != null) {
+            refreshExecutor.shutdownNow();
+        }
+    }
+
+    private static boolean isPositive(@Nullable Duration duration) {
+        return duration != null && !duration.isZero() && !duration.isNegative();
+    }
+
+    private static FeatureFetchException toFeatureFetchException(Exception e) {
+        Throwable cause = e.getCause() == null ? e : e.getCause();
+        if (cause instanceof FeatureFetchException) {
+            return (FeatureFetchException) cause;
+        }
+        return new FeatureFetchException(
+                FeatureFetchException.FeatureFetchErrorCode.UNKNOWN,
+                cause.getMessage()
+        );
+    }
+
+    private static ExecutorService newRefreshExecutor() {
+        return Executors.newCachedThreadPool(runnable -> {
+            Thread thread = new Thread(runnable, "growthbook-remote-eval-refresh");
+            thread.setDaemon(true);
+            return thread;
+        });
+    }
+
+    /**
+     * Identity is the cache key only; the payload rides along for the loader but is deliberately
+     * excluded from equals/hashCode (same cache key means same user).
+     */
+    private static final class Key {
+        private final String cacheKey;
+        private final RequestBodyForRemoteEval payload;
+
+        Key(String cacheKey, RequestBodyForRemoteEval payload) {
+            this.cacheKey = cacheKey;
+            this.payload = payload;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof Key)) {
+                return false;
+            }
+            return cacheKey.equals(((Key) o).cacheKey);
+        }
+
+        @Override
+        public int hashCode() {
+            return cacheKey.hashCode();
+        }
+    }
+}

--- a/lib/src/main/java/growthbook/sdk/java/remoteeval/RemoteEvalCacheKey.java
+++ b/lib/src/main/java/growthbook/sdk/java/remoteeval/RemoteEvalCacheKey.java
@@ -20,6 +20,7 @@ public final class RemoteEvalCacheKey {
     private static final String PAYLOAD_SEPARATOR = "||";
     private static final String ATTRIBUTES_KEY = "ca";
     private static final String FORCED_VARIATIONS_KEY = "fv";
+    private static final String FORCED_FEATURES_KEY = "ff";
     private static final String URL_KEY = "url";
 
     private RemoteEvalCacheKey() {
@@ -30,12 +31,14 @@ public final class RemoteEvalCacheKey {
             String clientKey,
             JsonObject attributes,
             @Nullable Map<String, Integer> forcedVariations,
+            @Nullable Map<String, Object> forcedFeatures,
             @Nullable String url,
             @Nullable List<String> cacheKeyAttributes
     ) {
         JsonObject keyPayload = new JsonObject();
         keyPayload.add(ATTRIBUTES_KEY, selectCacheAttributes(attributes, cacheKeyAttributes));
         keyPayload.add(FORCED_VARIATIONS_KEY, toSortedJsonObject(forcedVariations));
+        keyPayload.add(FORCED_FEATURES_KEY, toSortedForcedFeatures(forcedFeatures));
         keyPayload.add(URL_KEY, GrowthBookJsonUtils.getInstance().gson.toJsonTree(RemoteEvalRequestBuilder.normalizeUrl(url)));
         return normalize(apiHost) + CLIENT_SEPARATOR + normalize(clientKey)
                 + PAYLOAD_SEPARATOR + GrowthBookJsonUtils.getInstance().gson.toJson(keyPayload);
@@ -46,10 +49,11 @@ public final class RemoteEvalCacheKey {
             String clientKey,
             JsonObject attributes,
             @Nullable Map<String, Integer> forcedVariations,
+            @Nullable Map<String, Object> forcedFeatures,
             @Nullable String url,
             @Nullable List<String> cacheKeyAttributes
     ) {
-        return fromContext(apiHost, clientKey, attributes, forcedVariations, url, cacheKeyAttributes);
+        return fromContext(apiHost, clientKey, attributes, forcedVariations, forcedFeatures, url, cacheKeyAttributes);
     }
 
     private static JsonObject selectCacheAttributes(JsonObject attributes, @Nullable List<String> cacheKeyAttributes) {
@@ -83,6 +87,20 @@ public final class RemoteEvalCacheKey {
         TreeMap<String, Integer> sortedValues = new TreeMap<>(values);
         for (Map.Entry<String, Integer> entry : sortedValues.entrySet()) {
             jsonObject.addProperty(entry.getKey(), entry.getValue());
+        }
+        return jsonObject;
+    }
+
+    private static JsonObject toSortedForcedFeatures(@Nullable Map<String, Object> forcedFeatures) {
+        JsonObject jsonObject = new JsonObject();
+        if (forcedFeatures == null || forcedFeatures.isEmpty()) {
+            return jsonObject;
+        }
+
+        TreeSet<String> keys = new TreeSet<>(forcedFeatures.keySet());
+        for (String key : keys) {
+            JsonElement value = GrowthBookJsonUtils.getInstance().gson.toJsonTree(forcedFeatures.get(key));
+            jsonObject.add(key, canonicalize(value));
         }
         return jsonObject;
     }

--- a/lib/src/main/java/growthbook/sdk/java/remoteeval/RemoteEvalCacheKey.java
+++ b/lib/src/main/java/growthbook/sdk/java/remoteeval/RemoteEvalCacheKey.java
@@ -1,0 +1,114 @@
+package growthbook.sdk.java.remoteeval;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonNull;
+import com.google.gson.JsonObject;
+import growthbook.sdk.java.util.GrowthBookJsonUtils;
+
+import javax.annotation.Nullable;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.TreeSet;
+
+/**
+ * Builds deterministic cache keys for remote evaluation payloads.
+ */
+public final class RemoteEvalCacheKey {
+    private static final String CLIENT_SEPARATOR = "::";
+    private static final String PAYLOAD_SEPARATOR = "||";
+    private static final String ATTRIBUTES_KEY = "ca";
+    private static final String FORCED_VARIATIONS_KEY = "fv";
+    private static final String URL_KEY = "url";
+
+    private RemoteEvalCacheKey() {
+    }
+
+    public static String fromContext(
+            String apiHost,
+            String clientKey,
+            JsonObject attributes,
+            @Nullable Map<String, Integer> forcedVariations,
+            @Nullable String url,
+            @Nullable List<String> cacheKeyAttributes
+    ) {
+        JsonObject keyPayload = new JsonObject();
+        keyPayload.add(ATTRIBUTES_KEY, selectCacheAttributes(attributes, cacheKeyAttributes));
+        keyPayload.add(FORCED_VARIATIONS_KEY, toSortedJsonObject(forcedVariations));
+        keyPayload.add(URL_KEY, GrowthBookJsonUtils.getInstance().gson.toJsonTree(RemoteEvalRequestBuilder.normalizeUrl(url)));
+        return normalize(apiHost) + CLIENT_SEPARATOR + normalize(clientKey)
+                + PAYLOAD_SEPARATOR + GrowthBookJsonUtils.getInstance().gson.toJson(keyPayload);
+    }
+
+    public static String from(
+            String apiHost,
+            String clientKey,
+            JsonObject attributes,
+            @Nullable Map<String, Integer> forcedVariations,
+            @Nullable String url,
+            @Nullable List<String> cacheKeyAttributes
+    ) {
+        return fromContext(apiHost, clientKey, attributes, forcedVariations, url, cacheKeyAttributes);
+    }
+
+    private static JsonObject selectCacheAttributes(JsonObject attributes, @Nullable List<String> cacheKeyAttributes) {
+        JsonObject selected = new JsonObject();
+        if (attributes == null) {
+            return selected;
+        }
+
+        TreeSet<String> keys = new TreeSet<>();
+        if (cacheKeyAttributes == null) {
+            keys.addAll(attributes.keySet());
+        } else {
+            keys.addAll(cacheKeyAttributes);
+        }
+
+        for (String key : keys) {
+            JsonElement value = attributes.get(key);
+            if (value != null) {
+                selected.add(key, canonicalize(value));
+            }
+        }
+        return selected;
+    }
+
+    private static JsonObject toSortedJsonObject(@Nullable Map<String, Integer> values) {
+        JsonObject jsonObject = new JsonObject();
+        if (values == null || values.isEmpty()) {
+            return jsonObject;
+        }
+
+        TreeMap<String, Integer> sortedValues = new TreeMap<>(values);
+        for (Map.Entry<String, Integer> entry : sortedValues.entrySet()) {
+            jsonObject.addProperty(entry.getKey(), entry.getValue());
+        }
+        return jsonObject;
+    }
+
+    private static JsonElement canonicalize(JsonElement element) {
+        if (element == null || element.isJsonNull() || element.isJsonPrimitive()) {
+            return element == null ? JsonNull.INSTANCE : element.deepCopy();
+        }
+
+        if (element.isJsonArray()) {
+            JsonArray array = new JsonArray();
+            for (JsonElement item : element.getAsJsonArray()) {
+                array.add(canonicalize(item));
+            }
+            return array;
+        }
+
+        JsonObject object = new JsonObject();
+        TreeSet<String> keys = new TreeSet<>(element.getAsJsonObject().keySet());
+        for (String key : keys) {
+            object.add(key, canonicalize(element.getAsJsonObject().get(key)));
+        }
+        return object;
+    }
+
+    private static String normalize(@Nullable String value) {
+        return value == null ? "" : value;
+    }
+}

--- a/lib/src/main/java/growthbook/sdk/java/remoteeval/RemoteEvalEndpoints.java
+++ b/lib/src/main/java/growthbook/sdk/java/remoteeval/RemoteEvalEndpoints.java
@@ -1,0 +1,21 @@
+package growthbook.sdk.java.remoteeval;
+
+import javax.annotation.Nullable;
+
+/**
+ * Endpoint helpers for the GrowthBook remote-eval API.
+ */
+public final class RemoteEvalEndpoints {
+    public static final String EVAL_PATH_PREFIX = "/api/eval/";
+
+    private RemoteEvalEndpoints() {
+    }
+
+    public static String evalEndpoint(@Nullable String apiHost, @Nullable String clientKey) {
+        return normalize(apiHost) + EVAL_PATH_PREFIX + normalize(clientKey);
+    }
+
+    private static String normalize(@Nullable String value) {
+        return value == null ? "" : value;
+    }
+}

--- a/lib/src/main/java/growthbook/sdk/java/remoteeval/RemoteEvalOptionsValidator.java
+++ b/lib/src/main/java/growthbook/sdk/java/remoteeval/RemoteEvalOptionsValidator.java
@@ -1,0 +1,96 @@
+package growthbook.sdk.java.remoteeval;
+
+import growthbook.sdk.java.model.GBContext;
+import growthbook.sdk.java.multiusermode.configurations.Options;
+import growthbook.sdk.java.repository.FeatureRefreshStrategy;
+
+import javax.annotation.Nullable;
+import java.net.URI;
+import java.util.Locale;
+
+/**
+ * Validates SDK options before enabling remote evaluation.
+ */
+public final class RemoteEvalOptionsValidator {
+    private static final String DEFAULT_SCHEME = "https://";
+    private static final String SCHEME_SEPARATOR = "://";
+    private static final String GROWTHBOOK_CLOUD_DOMAIN = "growthbook.io";
+
+    private RemoteEvalOptionsValidator() {
+    }
+
+    public static void validate(Options options) {
+        if (options == null || !options.isRemoteEvalEnabled()) {
+            return;
+        }
+
+        validateCommon(
+                options.getApiHost(),
+                options.getClientKey(),
+                options.getDecryptionKey(),
+                options.getStickyBucketService() != null,
+                options.getRefreshStrategy()
+        );
+    }
+
+    public static void validate(GBContext context) {
+        if (context == null || !context.isRemoteEvalEnabled()) {
+            return;
+        }
+
+        validateCommon(
+                context.getApiHost(),
+                context.getClientKey(),
+                context.getEncryptionKey(),
+                context.getStickyBucketService() != null,
+                null
+        );
+    }
+
+    private static void validateCommon(
+            @Nullable String apiHost,
+            @Nullable String clientKey,
+            @Nullable String decryptionKey,
+            boolean hasStickyBucketService,
+            @Nullable FeatureRefreshStrategy refreshStrategy
+    ) {
+        if (isBlank(apiHost)) {
+            throw new IllegalArgumentException("apiHost is required when remoteEval is enabled");
+        }
+        if (isBlank(clientKey)) {
+            throw new IllegalArgumentException("clientKey is required when remoteEval is enabled");
+        }
+        if (!isBlank(decryptionKey)) {
+            throw new IllegalArgumentException("decryptionKey is not supported when remoteEval is enabled");
+        }
+        if (hasStickyBucketService) {
+            throw new IllegalArgumentException("stickyBucketService is not supported when remoteEval is enabled");
+        }
+        if (refreshStrategy == FeatureRefreshStrategy.STALE_WHILE_REVALIDATE) {
+            throw new IllegalArgumentException("stale-while-revalidate is not supported when remoteEval is enabled");
+        }
+        if (isGrowthBookCloudHost(apiHost)) {
+            throw new IllegalArgumentException("remoteEval requires a self-hosted GrowthBook proxy or edge API host");
+        }
+    }
+
+    private static boolean isGrowthBookCloudHost(String apiHost) {
+        try {
+            String raw = apiHost == null ? "" : apiHost.trim();
+            String normalized = raw.contains(SCHEME_SEPARATOR) ? raw : DEFAULT_SCHEME + raw;
+            String host = URI.create(normalized).getHost();
+            if (host == null) {
+                return false;
+            }
+            String lowerHost = host.toLowerCase(Locale.ROOT);
+            return lowerHost.equals(GROWTHBOOK_CLOUD_DOMAIN)
+                    || lowerHost.endsWith("." + GROWTHBOOK_CLOUD_DOMAIN);
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+    private static boolean isBlank(@Nullable String value) {
+        return value == null || value.trim().isEmpty();
+    }
+}

--- a/lib/src/main/java/growthbook/sdk/java/remoteeval/RemoteEvalRequestBuilder.java
+++ b/lib/src/main/java/growthbook/sdk/java/remoteeval/RemoteEvalRequestBuilder.java
@@ -1,0 +1,56 @@
+package growthbook.sdk.java.remoteeval;
+
+import com.google.gson.JsonObject;
+import growthbook.sdk.java.model.RequestBodyForRemoteEval;
+
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Builds the remote-eval request payload in the JS/Python SDK wire format.
+ */
+public final class RemoteEvalRequestBuilder {
+    public static final int DEFAULT_CACHE_SIZE = 1000;
+
+    private RemoteEvalRequestBuilder() {
+    }
+
+    public static RequestBodyForRemoteEval build(
+            @Nullable JsonObject attributes,
+            @Nullable Map<String, Object> forcedFeatures,
+            @Nullable Map<String, Integer> forcedVariations,
+            @Nullable String url
+    ) {
+        return new RequestBodyForRemoteEval(
+                attributes,
+                toForcedFeaturesPayload(forcedFeatures),
+                forcedVariations,
+                normalizeUrl(url)
+        );
+    }
+
+    public static List<List<Object>> toForcedFeaturesPayload(@Nullable Map<String, Object> forcedFeatures) {
+        List<List<Object>> payload = new ArrayList<>();
+        if (forcedFeatures == null || forcedFeatures.isEmpty()) {
+            return payload;
+        }
+
+        for (Map.Entry<String, Object> entry : forcedFeatures.entrySet()) {
+            List<Object> forcedFeature = new ArrayList<>();
+            forcedFeature.add(entry.getKey());
+            forcedFeature.add(entry.getValue());
+            payload.add(forcedFeature);
+        }
+        return payload;
+    }
+
+    public static String normalizeUrl(@Nullable String url) {
+        return url == null ? "" : url;
+    }
+
+    public static int normalizeCacheSize(@Nullable Integer cacheSize) {
+        return cacheSize == null ? DEFAULT_CACHE_SIZE : Math.max(0, cacheSize);
+    }
+}

--- a/lib/src/main/java/growthbook/sdk/java/remoteeval/RemoteEvalResponse.java
+++ b/lib/src/main/java/growthbook/sdk/java/remoteeval/RemoteEvalResponse.java
@@ -1,0 +1,22 @@
+package growthbook.sdk.java.remoteeval;
+
+import com.google.gson.JsonObject;
+import growthbook.sdk.java.model.Feature;
+import lombok.Getter;
+
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * Parsed response returned by the GrowthBook remote evaluation endpoint.
+ */
+@Getter
+public class RemoteEvalResponse {
+    private final Map<String, Feature<?>> features;
+    private final JsonObject savedGroups;
+
+    public RemoteEvalResponse(Map<String, Feature<?>> features, JsonObject savedGroups) {
+        this.features = features == null ? Collections.emptyMap() : features;
+        this.savedGroups = savedGroups == null ? new JsonObject() : savedGroups;
+    }
+}

--- a/lib/src/main/java/growthbook/sdk/java/remoteeval/RemoteEvalResponseParser.java
+++ b/lib/src/main/java/growthbook/sdk/java/remoteeval/RemoteEvalResponseParser.java
@@ -1,0 +1,62 @@
+package growthbook.sdk.java.remoteeval;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonSyntaxException;
+import growthbook.sdk.java.exception.FeatureFetchException;
+import growthbook.sdk.java.model.Feature;
+import growthbook.sdk.java.model.FeatureResponseKey;
+import growthbook.sdk.java.multiusermode.util.TransformationUtil;
+import growthbook.sdk.java.util.GrowthBookJsonUtils;
+
+import java.util.Map;
+
+/**
+ * Parses the proxy response used by remote evaluation.
+ */
+public class RemoteEvalResponseParser {
+
+    public RemoteEvalResponse parse(String responseJson) throws FeatureFetchException {
+        if (responseJson == null || responseJson.trim().isEmpty()) {
+            throw new FeatureFetchException(
+                    FeatureFetchException.FeatureFetchErrorCode.NO_RESPONSE_ERROR,
+                    "Remote evaluation response body is empty"
+            );
+        }
+
+        JsonObject jsonObject = parseJsonObject(responseJson);
+        JsonElement featuresElement = jsonObject.get(FeatureResponseKey.FEATURE_KEY.getKey());
+        if (featuresElement == null || !featuresElement.isJsonObject()) {
+            throw new FeatureFetchException(
+                    FeatureFetchException.FeatureFetchErrorCode.CONFIGURATION_ERROR,
+                    "Remote evaluation response does not include features"
+            );
+        }
+
+        JsonElement savedGroupsElement = jsonObject.get(FeatureResponseKey.SAVED_GROUP_KEY.getKey());
+        Map<String, Feature<?>> features = TransformationUtil.transformFeatures(featuresElement.toString());
+        JsonObject savedGroups = savedGroupsElement == null
+                ? new JsonObject()
+                : TransformationUtil.transformSavedGroups(savedGroupsElement.toString());
+
+        return new RemoteEvalResponse(features, savedGroups);
+    }
+
+    private JsonObject parseJsonObject(String responseJson) throws FeatureFetchException {
+        try {
+            JsonElement element = GrowthBookJsonUtils.getInstance().gson.fromJson(responseJson, JsonElement.class);
+            if (element == null || !element.isJsonObject()) {
+                throw new FeatureFetchException(
+                        FeatureFetchException.FeatureFetchErrorCode.CONFIGURATION_ERROR,
+                        "Remote evaluation response must be a JSON object"
+                );
+            }
+            return element.getAsJsonObject();
+        } catch (JsonSyntaxException e) {
+            throw new FeatureFetchException(
+                    FeatureFetchException.FeatureFetchErrorCode.CONFIGURATION_ERROR,
+                    "Remote evaluation response is invalid JSON"
+            );
+        }
+    }
+}

--- a/lib/src/main/java/growthbook/sdk/java/remoteeval/RemoteEvalService.java
+++ b/lib/src/main/java/growthbook/sdk/java/remoteeval/RemoteEvalService.java
@@ -1,0 +1,91 @@
+package growthbook.sdk.java.remoteeval;
+
+import growthbook.sdk.java.exception.FeatureFetchException;
+import growthbook.sdk.java.model.RequestBodyForRemoteEval;
+import growthbook.sdk.java.util.GrowthBookJsonUtils;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+
+/**
+ * HTTP client for the remote evaluation endpoint.
+ */
+public class RemoteEvalService {
+
+    private static final MediaType JSON = MediaType.parse("application/json");
+
+    private final String endpoint;
+    private final OkHttpClient okHttpClient;
+    private final boolean ownsHttpClient;
+    private final RemoteEvalResponseParser responseParser;
+
+    public RemoteEvalService(String apiHost, String clientKey) {
+        this(apiHost, clientKey, null, new RemoteEvalResponseParser());
+    }
+
+    public RemoteEvalService(
+            String apiHost,
+            String clientKey,
+            @Nullable OkHttpClient okHttpClient,
+            RemoteEvalResponseParser responseParser
+    ) {
+        this.ownsHttpClient = okHttpClient == null;
+        this.okHttpClient = okHttpClient == null ? new OkHttpClient() : okHttpClient;
+        this.endpoint = RemoteEvalEndpoints.evalEndpoint(apiHost, clientKey);
+        this.responseParser = responseParser == null ? new RemoteEvalResponseParser() : responseParser;
+    }
+
+    /**
+     * Releases the HTTP resources owned by this service. A client passed in by the caller is left
+     * untouched; only an internally created {@link OkHttpClient} is shut down.
+     */
+    public void close() {
+        if (ownsHttpClient) {
+            okHttpClient.dispatcher().executorService().shutdown();
+            okHttpClient.connectionPool().evictAll();
+        }
+    }
+
+    public RemoteEvalResponse fetch(RequestBodyForRemoteEval requestBodyForRemoteEval) throws FeatureFetchException {
+        RequestBodyForRemoteEval payload = requestBodyForRemoteEval == null
+                ? new RequestBodyForRemoteEval()
+                : requestBodyForRemoteEval;
+        String jsonBody = GrowthBookJsonUtils.getInstance().gson.toJson(payload);
+        RequestBody requestBody = RequestBody.create(jsonBody, JSON);
+        Request request = new Request.Builder()
+                .url(this.endpoint)
+                .post(requestBody)
+                .build();
+
+        try (Response response = this.okHttpClient.newCall(request).execute()) {
+            ResponseBody responseBody = getSuccessfulResponseBody(response);
+            return responseParser.parse(responseBody.string());
+        } catch (IOException e) {
+            throw new FeatureFetchException(
+                    FeatureFetchException.FeatureFetchErrorCode.NO_RESPONSE_ERROR,
+                    e.getMessage()
+            );
+        }
+    }
+
+    private ResponseBody getSuccessfulResponseBody(Response response) throws FeatureFetchException {
+        ResponseBody responseBody = response.body();
+        if (response.code() == HttpURLConnection.HTTP_OK && responseBody != null) {
+            return responseBody;
+        }
+
+        throw new FeatureFetchException(
+                responseBody == null
+                        ? FeatureFetchException.FeatureFetchErrorCode.NO_RESPONSE_ERROR
+                        : FeatureFetchException.FeatureFetchErrorCode.HTTP_RESPONSE_ERROR,
+                "Remote evaluation request failed with status " + response.code()
+        );
+    }
+}

--- a/lib/src/main/java/growthbook/sdk/java/repository/GBFeaturesRepository.java
+++ b/lib/src/main/java/growthbook/sdk/java/repository/GBFeaturesRepository.java
@@ -10,6 +10,7 @@ import growthbook.sdk.java.model.GBContext;
 import growthbook.sdk.java.model.HttpHeaders;
 import growthbook.sdk.java.model.RequestBodyForRemoteEval;
 import growthbook.sdk.java.multiusermode.util.TransformationUtil;
+import growthbook.sdk.java.remoteeval.RemoteEvalEndpoints;
 import growthbook.sdk.java.sandbox.CacheManagerFactory;
 import growthbook.sdk.java.sandbox.CacheMode;
 import growthbook.sdk.java.sandbox.GbCacheManager;
@@ -314,7 +315,7 @@ public class GBFeaturesRepository implements IGBFeaturesRepository {
         // Build the endpoints from the apiHost and clientKey
         this.featuresEndpoint = apiHost + "/api/features/" + clientKey;
         this.eventsEndpoint = apiHost + "/sub/" + clientKey;
-        this.remoteEvalEndPoint = apiHost + "/api/eval/" + clientKey;
+        this.remoteEvalEndPoint = RemoteEvalEndpoints.evalEndpoint(apiHost, clientKey);
 
         this.encryptionKey = decryptionKey;
         this.decryptionKey = decryptionKey;
@@ -474,6 +475,11 @@ public class GBFeaturesRepository implements IGBFeaturesRepository {
                             @Override
                             public void onFeaturesResponse(String featuresJsonResponse) throws FeatureFetchException {
                                 onResponseJson(featuresJsonResponse, false);
+                            }
+
+                            @Override
+                            public void onFeaturesUpdated() {
+                                onRefreshSuccess(featuresJson);
                             }
                         }
                 ) {
@@ -743,6 +749,8 @@ public class GBFeaturesRepository implements IGBFeaturesRepository {
         void onClose(EventSource eventSource);
 
         void onFeaturesResponse(String featuresJsonResponse) throws FeatureFetchException;
+
+        void onFeaturesUpdated() throws FeatureFetchException;
     }
 
     private static class GBEventSourceListener extends EventSourceListener {
@@ -762,9 +770,11 @@ public class GBFeaturesRepository implements IGBFeaturesRepository {
         public void onEvent(@NotNull EventSource eventSource, @Nullable String id, @Nullable String type, @NotNull String data) {
             super.onEvent(eventSource, id, type, data);
 
-            if (data.trim().isEmpty()) return;
-
             try {
+                if (data.trim().isEmpty()) {
+                    handler.onFeaturesUpdated();
+                    return;
+                }
                 handler.onFeaturesResponse(data);
             } catch (FeatureFetchException e) {
                 log.error(e.getMessage(), e);
@@ -822,7 +832,10 @@ public class GBFeaturesRepository implements IGBFeaturesRepository {
         if (this.remoteEvalEndPoint == null) {
             throw new IllegalArgumentException("remote eval features endpoint cannot be null");
         }
-        String jsonBody = GrowthBookJsonUtils.getInstance().gson.toJson(requestBodyForRemoteEval);
+        RequestBodyForRemoteEval payload = requestBodyForRemoteEval == null
+                ? new RequestBodyForRemoteEval()
+                : requestBodyForRemoteEval;
+        String jsonBody = GrowthBookJsonUtils.getInstance().gson.toJson(payload);
         RequestBody requestBody = RequestBody.create(
                 jsonBody,
                 MediaType.parse("application/json")

--- a/lib/src/main/java/growthbook/sdk/java/repository/NativeJavaGbFeatureRepository.java
+++ b/lib/src/main/java/growthbook/sdk/java/repository/NativeJavaGbFeatureRepository.java
@@ -16,6 +16,7 @@ import growthbook.sdk.java.model.HttpMethods;
 import growthbook.sdk.java.model.RequestBodyForRemoteEval;
 import growthbook.sdk.java.model.SseKey;
 import growthbook.sdk.java.model.GBContext;
+import growthbook.sdk.java.remoteeval.RemoteEvalEndpoints;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -180,7 +181,7 @@ public class NativeJavaGbFeatureRepository implements IGBFeaturesRepository {
         this.refreshStrategy = refreshStrategy == null ? FeatureRefreshStrategy.STALE_WHILE_REVALIDATE : refreshStrategy;
         this.featuresEndpoint = apiHost + "/api/features/" + clientKey;
         this.eventsEndpoint = apiHost + "/sub/" + clientKey;
-        this.remoteEvalEndPoint = apiHost + "/api/eval/" + clientKey;
+        this.remoteEvalEndPoint = RemoteEvalEndpoints.evalEndpoint(apiHost, clientKey);
         this.requestBodyForRemoteEval = requestBodyForRemoteEval;
 
         this.encryptionKey = encryptionKey;
@@ -558,7 +559,10 @@ public class NativeJavaGbFeatureRepository implements IGBFeaturesRepository {
     private void fetchForRemoteEval(RequestBodyForRemoteEval requestBodyForRemoteEval) throws FeatureFetchException {
         HttpURLConnection urlConnection = null;
         try {
-            String body = GrowthBookJsonUtils.getInstance().gson.toJson(requestBodyForRemoteEval);
+            RequestBodyForRemoteEval payload = requestBodyForRemoteEval == null
+                    ? new RequestBodyForRemoteEval()
+                    : requestBodyForRemoteEval;
+            String body = GrowthBookJsonUtils.getInstance().gson.toJson(payload);
 
             URL url = new URL(this.remoteEvalEndPoint);
             urlConnection = (HttpURLConnection) url.openConnection();

--- a/lib/src/test/java/growthbook/sdk/java/ConditionEvaluatorTest.java
+++ b/lib/src/test/java/growthbook/sdk/java/ConditionEvaluatorTest.java
@@ -16,6 +16,7 @@ import java.io.PrintStream;
 import growthbook.sdk.java.util.GrowthBookJsonUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import java.util.ArrayList;
 import java.util.Objects;
@@ -104,6 +105,40 @@ class ConditionEvaluatorTest {
 
         assertTrue(evaluator.isOperatorObject(condition));
         assertFalse(evaluator.isOperatorObject(attributes));
+    }
+
+    @Test
+    void test_notRegexOperatorsPassForMissingAttributes() {
+        ConditionEvaluator evaluator = new ConditionEvaluator();
+
+        JsonObject attributes = GrowthBookJsonUtils.getInstance().gson
+                .fromJson("{}", JsonObject.class);
+        JsonObject notRegexCondition = GrowthBookJsonUtils.getInstance().gson
+                .fromJson("{\"userAgent\":{\"$notRegex\":\"(Mobile|Tablet)\"}}", JsonObject.class);
+        JsonObject notRegexICondition = GrowthBookJsonUtils.getInstance().gson
+                .fromJson("{\"userAgent\":{\"$notRegexi\":\"(mobile|tablet)\"}}", JsonObject.class);
+
+        assertTrue(evaluator.evaluateCondition(attributes, notRegexCondition, null));
+        assertTrue(evaluator.evaluateCondition(attributes, notRegexICondition, null));
+    }
+
+    @Test
+    @DisplayName("$ne treats missing/null attributes as not equal to a value, but equal to null")
+    void test_notEqualOperatorForMissingOrNullAttributes() {
+        ConditionEvaluator evaluator = new ConditionEvaluator();
+
+        JsonObject neCondition = GrowthBookJsonUtils.getInstance().gson
+                .fromJson("{\"level\":{\"$ne\":\"senior\"}}", JsonObject.class);
+
+        assertTrue(evaluator.evaluateCondition(
+                GrowthBookJsonUtils.getInstance().gson.fromJson("{}", JsonObject.class), neCondition, null));
+        assertTrue(evaluator.evaluateCondition(
+                GrowthBookJsonUtils.getInstance().gson.fromJson("{\"level\":null}", JsonObject.class), neCondition, null));
+
+        JsonObject neNullCondition = GrowthBookJsonUtils.getInstance().gson
+                .fromJson("{\"level\":{\"$ne\":null}}", JsonObject.class);
+        assertFalse(evaluator.evaluateCondition(
+                GrowthBookJsonUtils.getInstance().gson.fromJson("{\"level\":null}", JsonObject.class), neNullCondition, null));
     }
 
     @Test

--- a/lib/src/test/java/growthbook/sdk/java/TrackDataTest.java
+++ b/lib/src/test/java/growthbook/sdk/java/TrackDataTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import growthbook.sdk.java.model.Experiment;
 import growthbook.sdk.java.model.ExperimentResult;
-import growthbook.sdk.java.model.FeatureResult;
 import growthbook.sdk.java.model.TrackData;
 import org.junit.jupiter.api.Test;
 
@@ -19,13 +18,10 @@ class TrackDataTest {
                 .inExperiment(true)
                 .key("my_experiment")
                 .build();
-        FeatureResult<Integer> featureResult = FeatureResult.<Integer>builder()
-                .experimentResult(experimentResult)
-                .build();
 
-        TrackData<Integer> subject = new TrackData<>(experiment, featureResult);
+        TrackData<Integer> subject = new TrackData<>(experiment, experimentResult);
 
         assertEquals(experiment, subject.getExperiment());
-        assertEquals(experimentResult, subject.getResult().getExperimentResult());
+        assertEquals(experimentResult, subject.getResult());
     }
 }

--- a/lib/src/test/java/growthbook/sdk/java/multiusermode/GrowthBookClientTest.java
+++ b/lib/src/test/java/growthbook/sdk/java/multiusermode/GrowthBookClientTest.java
@@ -10,12 +10,10 @@ import growthbook.sdk.java.repository.FeatureRefreshStrategy;
 import growthbook.sdk.java.repository.GBFeaturesRepository;
 import growthbook.sdk.java.testhelpers.TestCasesJsonHelper;
 import growthbook.sdk.java.util.GrowthBookJsonUtils;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 
-import java.lang.reflect.Field;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -30,14 +28,6 @@ class GrowthBookClientTest {
     // Mock instances that might be needed across tests
     private GBFeaturesRepository mockRepository;
     private GBFeaturesRepository.GBFeaturesRepositoryBuilder mockBuilder;
-
-    @AfterEach
-    void tearDown() throws Exception {
-        // Reset static repository after each test
-        Field field = GrowthBookClient.class.getDeclaredField("repository");
-        field.setAccessible(true);
-        field.set(null, null);
-    }
 
     @Test
     void test_initialization_withValidConfiguration() throws FeatureFetchException {

--- a/lib/src/test/java/growthbook/sdk/java/remoteeval/RemoteEvalCacheTest.java
+++ b/lib/src/test/java/growthbook/sdk/java/remoteeval/RemoteEvalCacheTest.java
@@ -1,0 +1,247 @@
+package growthbook.sdk.java.remoteeval;
+
+import com.google.common.base.Ticker;
+import com.google.gson.JsonObject;
+import growthbook.sdk.java.exception.FeatureFetchException;
+import growthbook.sdk.java.model.RequestBodyForRemoteEval;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
+
+class RemoteEvalCacheTest {
+
+    private static final String KEY = "host::key||{}";
+
+    @Test
+    @DisplayName("Serves the cached response while still within the stale window")
+    void servesCachedResponseWithinStaleWindow() throws Exception {
+        CountingService service = new CountingService();
+        FakeTicker ticker = new FakeTicker();
+        RemoteEvalCache cache = new RemoteEvalCache(service, 10, Duration.ofSeconds(30), Duration.ofSeconds(300), ticker);
+
+        cache.get(KEY, payload());
+        ticker.advance(Duration.ofSeconds(5));
+        cache.get(KEY, payload());
+
+        assertEquals(1, service.callCount());
+    }
+
+    @Test
+    @DisplayName("Refetches once the hard cache TTL has passed")
+    void hardExpiryRefetchesPastCacheTtl() throws Exception {
+        CountingService service = new CountingService();
+        FakeTicker ticker = new FakeTicker();
+        RemoteEvalCache cache = new RemoteEvalCache(service, 10, null, Duration.ofSeconds(30), ticker);
+
+        cache.get(KEY, payload());
+        ticker.advance(Duration.ofSeconds(31));
+        cache.get(KEY, payload());
+
+        assertEquals(2, service.callCount());
+    }
+
+    @Test
+    @DisplayName("Past the stale TTL, serves the stale value while refreshing in the background")
+    void staleWhileRevalidateServesStaleThenRefreshesInBackground() throws Exception {
+        CountingService service = new CountingService();
+        FakeTicker ticker = new FakeTicker();
+        RemoteEvalCache cache = new RemoteEvalCache(service, 10, Duration.ofSeconds(30), Duration.ofSeconds(300), ticker);
+
+        RemoteEvalResponse first = cache.get(KEY, payload());
+        ticker.advance(Duration.ofSeconds(31));
+
+        CountDownLatch gate = new CountDownLatch(1);
+        service.blockFetchesUntil(gate);
+
+        RemoteEvalResponse stale = cache.get(KEY, payload());
+        assertSame(first, stale);
+        assertEquals(1, service.callCount());
+
+        gate.countDown();
+        awaitCallCount(service, 2);
+
+        RemoteEvalResponse refreshed = awaitRefreshedValue(cache, first);
+        assertSame(service.lastResponse(), refreshed);
+        assertEquals(2, service.callCount());
+
+        cache.shutdown();
+    }
+
+    @Test
+    @DisplayName("A zero maximum size disables retention and refetches on every read")
+    void zeroSizeDisablesRetentionAndRefetchesEveryRead() throws Exception {
+        CountingService service = new CountingService();
+        RemoteEvalCache cache = new RemoteEvalCache(service, 0, null, null, new FakeTicker());
+
+        cache.get(KEY, payload());
+        cache.get(KEY, payload());
+
+        assertEquals(2, service.callCount());
+    }
+
+    @Test
+    @DisplayName("A failed load is not cached, so the next read retries and then caches the success")
+    void failedLoadIsNotCached() throws Exception {
+        CountingService service = new CountingService();
+        service.failNextFetches(1);
+        RemoteEvalCache cache = new RemoteEvalCache(service, 10, null, Duration.ofSeconds(300), new FakeTicker());
+
+        assertThrows(FeatureFetchException.class, () -> cache.get(KEY, payload()));
+        RemoteEvalResponse ok = cache.get(KEY, payload());
+        assertSame(service.lastResponse(), ok);
+        cache.get(KEY, payload());
+        assertEquals(2, service.callCount());
+    }
+
+    @Test
+    @DisplayName("A failed background refresh keeps serving the stale value")
+    void failedBackgroundRefreshKeepsStaleValue() throws Exception {
+        CountingService service = new CountingService();
+        FakeTicker ticker = new FakeTicker();
+        RemoteEvalCache cache = new RemoteEvalCache(service, 10, Duration.ofSeconds(30), Duration.ofSeconds(300), ticker);
+
+        RemoteEvalResponse first = cache.get(KEY, payload());
+        service.failNextFetches(1);
+        ticker.advance(Duration.ofSeconds(31));
+
+        assertSame(first, cache.get(KEY, payload()));
+        awaitCallCount(service, 2);
+        assertSame(first, cache.get(KEY, payload()));
+
+        cache.shutdown();
+    }
+
+    @Test
+    @DisplayName("A closed cache rejects reads")
+    void closedCacheRejectsReads() throws Exception {
+        CountingService service = new CountingService();
+        RemoteEvalCache cache = new RemoteEvalCache(service, 10, Duration.ofSeconds(30), Duration.ofSeconds(300), new FakeTicker());
+
+        cache.get(KEY, payload());
+        cache.shutdown();
+
+        assertThrows(FeatureFetchException.class, () -> cache.get(KEY, payload()));
+    }
+
+    @Test
+    @DisplayName("An in-flight load that completes after shutdown is never served from the cache")
+    void inFlightLoadAfterShutdownIsNotServedFromCache() throws Exception {
+        CountingService service = new CountingService();
+        RemoteEvalCache cache = new RemoteEvalCache(service, 10, Duration.ofSeconds(30), Duration.ofSeconds(300), new FakeTicker());
+
+        CountDownLatch gate = new CountDownLatch(1);
+        service.blockFetchesUntil(gate);
+
+        Thread loader = new Thread(() -> {
+            try {
+                cache.get(KEY, payload());
+            } catch (FeatureFetchException ignored) {
+            }
+        });
+        loader.start();
+        Thread.sleep(50);
+
+        cache.shutdown();
+        gate.countDown();
+        loader.join(2000);
+
+        assertThrows(FeatureFetchException.class, () -> cache.get(KEY, payload()));
+    }
+
+    private static RequestBodyForRemoteEval payload() {
+        return new RequestBodyForRemoteEval(new JsonObject(), Collections.emptyList(), Collections.emptyMap(), "");
+    }
+
+    private static void awaitCallCount(CountingService service, int expected) throws InterruptedException {
+        long deadline = System.currentTimeMillis() + 2000;
+        while (System.currentTimeMillis() < deadline) {
+            if (service.callCount() >= expected) {
+                return;
+            }
+            Thread.sleep(10);
+        }
+        fail("Expected background refresh to reach " + expected + " calls, but saw " + service.callCount());
+    }
+
+    private static RemoteEvalResponse awaitRefreshedValue(RemoteEvalCache cache, RemoteEvalResponse stale) throws Exception {
+        long deadline = System.currentTimeMillis() + 2000;
+        while (System.currentTimeMillis() < deadline) {
+            RemoteEvalResponse current = cache.get(KEY, payload());
+            if (current != stale) {
+                return current;
+            }
+            Thread.sleep(10);
+        }
+        return fail("Expected the cache entry to be replaced by the background refresh");
+    }
+
+    /** Counts fetch attempts and returns a distinct response each time; an optional gate can hold a fetch open. */
+    private static final class CountingService extends RemoteEvalService {
+        private final AtomicInteger calls = new AtomicInteger();
+        private final AtomicInteger failuresRemaining = new AtomicInteger();
+        private volatile RemoteEvalResponse lastResponse;
+        private volatile CountDownLatch gate;
+
+        CountingService() {
+            super("http://localhost", "key");
+        }
+
+        @Override
+        public RemoteEvalResponse fetch(RequestBodyForRemoteEval requestBodyForRemoteEval) throws FeatureFetchException {
+            CountDownLatch currentGate = this.gate;
+            if (currentGate != null) {
+                try {
+                    currentGate.await();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+            calls.incrementAndGet();
+            if (failuresRemaining.getAndUpdate(n -> Math.max(0, n - 1)) > 0) {
+                throw new FeatureFetchException(
+                        FeatureFetchException.FeatureFetchErrorCode.NO_RESPONSE_ERROR, "remote eval failed");
+            }
+            this.lastResponse = new RemoteEvalResponse(Collections.emptyMap(), new JsonObject());
+            return this.lastResponse;
+        }
+
+        void blockFetchesUntil(CountDownLatch gate) {
+            this.gate = gate;
+        }
+
+        void failNextFetches(int count) {
+            this.failuresRemaining.set(count);
+        }
+
+        int callCount() {
+            return calls.get();
+        }
+
+        RemoteEvalResponse lastResponse() {
+            return lastResponse;
+        }
+    }
+
+    private static final class FakeTicker extends Ticker {
+        private final AtomicLong nanos = new AtomicLong();
+
+        @Override
+        public long read() {
+            return nanos.get();
+        }
+
+        void advance(Duration duration) {
+            nanos.addAndGet(duration.toNanos());
+        }
+    }
+}

--- a/lib/src/test/java/growthbook/sdk/java/remoteeval/RemoteEvalCacheTest.java
+++ b/lib/src/test/java/growthbook/sdk/java/remoteeval/RemoteEvalCacheTest.java
@@ -1,0 +1,251 @@
+package growthbook.sdk.java.remoteeval;
+
+import com.google.common.base.Ticker;
+import com.google.gson.JsonObject;
+import growthbook.sdk.java.exception.FeatureFetchException;
+import growthbook.sdk.java.model.RequestBodyForRemoteEval;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
+
+class RemoteEvalCacheTest {
+
+    private static final String KEY = "host::key||{}";
+
+    @Test
+    @DisplayName("Serves the cached response while still within the stale window")
+    void servesCachedResponseWithinStaleWindow() throws Exception {
+        CountingService service = new CountingService();
+        FakeTicker ticker = new FakeTicker();
+        RemoteEvalCache cache = new RemoteEvalCache(service, 10, Duration.ofSeconds(30), Duration.ofSeconds(300), ticker);
+
+        cache.get(KEY, payload());
+        ticker.advance(Duration.ofSeconds(5));
+        cache.get(KEY, payload());
+
+        assertEquals(1, service.callCount());
+    }
+
+    @Test
+    @DisplayName("Refetches once the hard cache TTL has passed")
+    void hardExpiryRefetchesPastCacheTtl() throws Exception {
+        CountingService service = new CountingService();
+        FakeTicker ticker = new FakeTicker();
+        RemoteEvalCache cache = new RemoteEvalCache(service, 10, null, Duration.ofSeconds(30), ticker);
+
+        cache.get(KEY, payload());
+        ticker.advance(Duration.ofSeconds(31));
+        cache.get(KEY, payload());
+
+        assertEquals(2, service.callCount());
+    }
+
+    @Test
+    @DisplayName("Past the stale TTL, serves the stale value while refreshing in the background")
+    void staleWhileRevalidateServesStaleThenRefreshesInBackground() throws Exception {
+        CountingService service = new CountingService();
+        FakeTicker ticker = new FakeTicker();
+        RemoteEvalCache cache = new RemoteEvalCache(service, 10, Duration.ofSeconds(30), Duration.ofSeconds(300), ticker);
+
+        RemoteEvalResponse first = cache.get(KEY, payload());
+        ticker.advance(Duration.ofSeconds(31));
+
+        CountDownLatch gate = new CountDownLatch(1);
+        service.blockFetchesUntil(gate);
+
+        RemoteEvalResponse stale = cache.get(KEY, payload());
+        assertSame(first, stale);
+        assertEquals(1, service.callCount());
+
+        gate.countDown();
+        awaitCallCount(service, 2);
+
+        RemoteEvalResponse refreshed = awaitRefreshedValue(cache, first);
+        assertSame(service.lastResponse(), refreshed);
+        assertEquals(2, service.callCount());
+
+        cache.shutdown();
+    }
+
+    @Test
+    @DisplayName("A zero maximum size disables retention and refetches on every read")
+    void zeroSizeDisablesRetentionAndRefetchesEveryRead() throws Exception {
+        CountingService service = new CountingService();
+        RemoteEvalCache cache = new RemoteEvalCache(service, 0, null, null, new FakeTicker());
+
+        cache.get(KEY, payload());
+        cache.get(KEY, payload());
+
+        assertEquals(2, service.callCount());
+    }
+
+    @Test
+    @DisplayName("A failed load is not cached, so the next read retries and then caches the success")
+    void failedLoadIsNotCached() throws Exception {
+        CountingService service = new CountingService();
+        service.failNextFetches(1);
+        RemoteEvalCache cache = new RemoteEvalCache(service, 10, null, Duration.ofSeconds(300), new FakeTicker());
+
+        assertThrows(FeatureFetchException.class, () -> cache.get(KEY, payload()));
+        RemoteEvalResponse ok = cache.get(KEY, payload());
+        assertSame(service.lastResponse(), ok);
+        cache.get(KEY, payload());
+        assertEquals(2, service.callCount());
+    }
+
+    @Test
+    @DisplayName("A failed background refresh keeps serving the stale value")
+    void failedBackgroundRefreshKeepsStaleValue() throws Exception {
+        CountingService service = new CountingService();
+        FakeTicker ticker = new FakeTicker();
+        RemoteEvalCache cache = new RemoteEvalCache(service, 10, Duration.ofSeconds(30), Duration.ofSeconds(300), ticker);
+
+        RemoteEvalResponse first = cache.get(KEY, payload());
+        service.failNextFetches(1);
+        ticker.advance(Duration.ofSeconds(31));
+
+        assertSame(first, cache.get(KEY, payload()));
+        awaitCallCount(service, 2);
+
+        CountDownLatch retryGate = new CountDownLatch(1);
+        service.blockFetchesUntil(retryGate);
+        assertSame(first, cache.get(KEY, payload()));
+        retryGate.countDown();
+
+        cache.shutdown();
+    }
+
+    @Test
+    @DisplayName("A closed cache rejects reads")
+    void closedCacheRejectsReads() throws Exception {
+        CountingService service = new CountingService();
+        RemoteEvalCache cache = new RemoteEvalCache(service, 10, Duration.ofSeconds(30), Duration.ofSeconds(300), new FakeTicker());
+
+        cache.get(KEY, payload());
+        cache.shutdown();
+
+        assertThrows(FeatureFetchException.class, () -> cache.get(KEY, payload()));
+    }
+
+    @Test
+    @DisplayName("An in-flight load that completes after shutdown is never served from the cache")
+    void inFlightLoadAfterShutdownIsNotServedFromCache() throws Exception {
+        CountingService service = new CountingService();
+        RemoteEvalCache cache = new RemoteEvalCache(service, 10, Duration.ofSeconds(30), Duration.ofSeconds(300), new FakeTicker());
+
+        CountDownLatch gate = new CountDownLatch(1);
+        service.blockFetchesUntil(gate);
+
+        Thread loader = new Thread(() -> {
+            try {
+                cache.get(KEY, payload());
+            } catch (FeatureFetchException ignored) {
+            }
+        });
+        loader.start();
+        Thread.sleep(50);
+
+        cache.shutdown();
+        gate.countDown();
+        loader.join(2000);
+
+        assertThrows(FeatureFetchException.class, () -> cache.get(KEY, payload()));
+    }
+
+    private static RequestBodyForRemoteEval payload() {
+        return new RequestBodyForRemoteEval(new JsonObject(), Collections.emptyList(), Collections.emptyMap(), "");
+    }
+
+    private static void awaitCallCount(CountingService service, int expected) throws InterruptedException {
+        long deadline = System.currentTimeMillis() + 2000;
+        while (System.currentTimeMillis() < deadline) {
+            if (service.callCount() >= expected) {
+                return;
+            }
+            Thread.sleep(10);
+        }
+        fail("Expected background refresh to reach " + expected + " calls, but saw " + service.callCount());
+    }
+
+    private static RemoteEvalResponse awaitRefreshedValue(RemoteEvalCache cache, RemoteEvalResponse stale) throws Exception {
+        long deadline = System.currentTimeMillis() + 2000;
+        while (System.currentTimeMillis() < deadline) {
+            RemoteEvalResponse current = cache.get(KEY, payload());
+            if (current != stale) {
+                return current;
+            }
+            Thread.sleep(10);
+        }
+        return fail("Expected the cache entry to be replaced by the background refresh");
+    }
+
+    /** Counts fetch attempts and returns a distinct response each time; an optional gate can hold a fetch open. */
+    private static final class CountingService extends RemoteEvalService {
+        private final AtomicInteger calls = new AtomicInteger();
+        private final AtomicInteger failuresRemaining = new AtomicInteger();
+        private volatile RemoteEvalResponse lastResponse;
+        private volatile CountDownLatch gate;
+
+        CountingService() {
+            super("http://localhost", "key");
+        }
+
+        @Override
+        public RemoteEvalResponse fetch(RequestBodyForRemoteEval requestBodyForRemoteEval) throws FeatureFetchException {
+            CountDownLatch currentGate = this.gate;
+            if (currentGate != null) {
+                try {
+                    currentGate.await();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+            calls.incrementAndGet();
+            if (failuresRemaining.getAndUpdate(n -> Math.max(0, n - 1)) > 0) {
+                throw new FeatureFetchException(
+                        FeatureFetchException.FeatureFetchErrorCode.NO_RESPONSE_ERROR, "remote eval failed");
+            }
+            this.lastResponse = new RemoteEvalResponse(Collections.emptyMap(), new JsonObject());
+            return this.lastResponse;
+        }
+
+        void blockFetchesUntil(CountDownLatch gate) {
+            this.gate = gate;
+        }
+
+        void failNextFetches(int count) {
+            this.failuresRemaining.set(count);
+        }
+
+        int callCount() {
+            return calls.get();
+        }
+
+        RemoteEvalResponse lastResponse() {
+            return lastResponse;
+        }
+    }
+
+    private static final class FakeTicker extends Ticker {
+        private final AtomicLong nanos = new AtomicLong();
+
+        @Override
+        public long read() {
+            return nanos.get();
+        }
+
+        void advance(Duration duration) {
+            nanos.addAndGet(duration.toNanos());
+        }
+    }
+}

--- a/lib/src/test/java/growthbook/sdk/java/remoteeval/RemoteEvalSseInvalidationTest.java
+++ b/lib/src/test/java/growthbook/sdk/java/remoteeval/RemoteEvalSseInvalidationTest.java
@@ -1,0 +1,170 @@
+package growthbook.sdk.java.remoteeval;
+
+import com.google.gson.JsonObject;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import growthbook.sdk.java.multiusermode.GrowthBookClient;
+import growthbook.sdk.java.multiusermode.configurations.Options;
+import growthbook.sdk.java.multiusermode.configurations.UserContext;
+import growthbook.sdk.java.repository.FeatureRefreshStrategy;
+import growthbook.sdk.java.util.GrowthBookJsonUtils;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RemoteEvalSseInvalidationTest {
+
+    private static final String FEATURES = "{\"features\":{\"remote-feature\":{\"defaultValue\":true}},\"savedGroups\":{}}";
+
+    @Test
+    @DisplayName("An SSE invalidation event clears the remote eval cache so the next evaluation refetches")
+    void sseEventInvalidatesRemoteEvalCacheAndNextEvaluationRefetches() throws Exception {
+        try (SseServer server = new SseServer()) {
+            GrowthBookClient client = new GrowthBookClient(Options.builder()
+                    .apiHost(server.apiHost())
+                    .clientKey("sdk-test")
+                    .remoteEval(true)
+                    .refreshStrategy(FeatureRefreshStrategy.SERVER_SENT_EVENTS)
+                    .build());
+            assertTrue(client.initialize());
+
+            try {
+                UserContext user = UserContext.builder()
+                        .attributes(GrowthBookJsonUtils.getInstance().gson.fromJson("{\"id\":\"user-1\"}", JsonObject.class))
+                        .build();
+
+                assertTrue(server.awaitConnected(2000));
+                assertTrue(client.isOn("remote-feature", user));
+                client.isOn("remote-feature", user);
+                assertEquals(1, server.evalCount());
+
+                server.sendInvalidationEvent();
+                assertTrue(awaitRefetch(server, client, user), "Expected SSE invalidation to force a fresh remote eval");
+            } finally {
+                client.shutdown();
+            }
+        }
+    }
+
+    private static boolean awaitRefetch(SseServer server, GrowthBookClient client, UserContext user) throws InterruptedException {
+        long deadline = System.currentTimeMillis() + 3000;
+        while (System.currentTimeMillis() < deadline) {
+            client.isOn("remote-feature", user);
+            if (server.evalCount() >= 2) {
+                return true;
+            }
+            Thread.sleep(20);
+        }
+        return false;
+    }
+
+    /** Minimal proxy: POST /api/eval, GET /api/features (advertising SSE), GET /sub (event stream). */
+    private static final class SseServer implements AutoCloseable {
+        private final HttpServer server;
+        private final ExecutorService executor;
+        private final AtomicInteger evalCount = new AtomicInteger();
+        private final CountDownLatch connected = new CountDownLatch(1);
+        private final CountDownLatch sseGate = new CountDownLatch(1);
+        private final CountDownLatch stop = new CountDownLatch(1);
+
+        SseServer() throws IOException {
+            this.server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+            this.executor = Executors.newCachedThreadPool();
+            this.server.createContext("/api/eval/sdk-test", this::handleEval);
+            this.server.createContext("/api/features/sdk-test", this::handleFeatures);
+            this.server.createContext("/sub/sdk-test", this::handleSse);
+            this.server.setExecutor(this.executor);
+            this.server.start();
+        }
+
+        String apiHost() {
+            return "http://127.0.0.1:" + this.server.getAddress().getPort();
+        }
+
+        int evalCount() {
+            return this.evalCount.get();
+        }
+
+        boolean awaitConnected(long millis) throws InterruptedException {
+            return connected.await(millis, java.util.concurrent.TimeUnit.MILLISECONDS);
+        }
+
+        void sendInvalidationEvent() {
+            sseGate.countDown();
+        }
+
+        private void handleEval(HttpExchange exchange) throws IOException {
+            evalCount.incrementAndGet();
+            drain(exchange);
+            writeJson(exchange, FEATURES);
+        }
+
+        private void handleFeatures(HttpExchange exchange) throws IOException {
+            drain(exchange);
+            exchange.getResponseHeaders().add("Content-Type", "application/json");
+            exchange.getResponseHeaders().add("X-Sse-Support", "enabled");
+            byte[] body = FEATURES.getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(200, body.length);
+            try (OutputStream os = exchange.getResponseBody()) {
+                os.write(body);
+            }
+        }
+
+        private void handleSse(HttpExchange exchange) throws IOException {
+            drain(exchange);
+            exchange.getResponseHeaders().add("Content-Type", "text/event-stream");
+            exchange.sendResponseHeaders(200, 0);
+            OutputStream os = exchange.getResponseBody();
+            connected.countDown();
+            try {
+                sseGate.await();
+                os.write(("data: " + FEATURES + "\n\n").getBytes(StandardCharsets.UTF_8));
+                os.flush();
+                stop.await();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            } finally {
+                try {
+                    os.close();
+                } catch (IOException ignored) {
+                }
+            }
+        }
+
+        private void writeJson(HttpExchange exchange, String json) throws IOException {
+            byte[] body = json.getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().add("Content-Type", "application/json");
+            exchange.sendResponseHeaders(200, body.length);
+            try (OutputStream os = exchange.getResponseBody()) {
+                os.write(body);
+            }
+        }
+
+        private void drain(HttpExchange exchange) throws IOException {
+            try (java.io.InputStream is = exchange.getRequestBody()) {
+                byte[] buffer = new byte[1024];
+                while (is.read(buffer) != -1) {
+                }
+            }
+        }
+
+        @Override
+        public void close() {
+            stop.countDown();
+            sseGate.countDown();
+            this.server.stop(0);
+            this.executor.shutdownNow();
+        }
+    }
+}

--- a/lib/src/test/java/growthbook/sdk/java/remoteeval/RemoteEvalSupportTest.java
+++ b/lib/src/test/java/growthbook/sdk/java/remoteeval/RemoteEvalSupportTest.java
@@ -1,0 +1,780 @@
+package growthbook.sdk.java.remoteeval;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import growthbook.sdk.java.GrowthBook;
+import growthbook.sdk.java.model.Experiment;
+import growthbook.sdk.java.model.ExperimentResult;
+import growthbook.sdk.java.model.GBContext;
+import growthbook.sdk.java.model.RequestBodyForRemoteEval;
+import growthbook.sdk.java.multiusermode.GrowthBookClient;
+import growthbook.sdk.java.multiusermode.configurations.Options;
+import growthbook.sdk.java.multiusermode.configurations.UserContext;
+import growthbook.sdk.java.multiusermode.usage.TrackingCallbackWithUser;
+import growthbook.sdk.java.repository.FeatureRefreshStrategy;
+import growthbook.sdk.java.stickyBucketing.InMemoryStickyBucketServiceImpl;
+import growthbook.sdk.java.util.GrowthBookJsonUtils;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RemoteEvalSupportTest {
+    private final GrowthBookJsonUtils jsonUtils = GrowthBookJsonUtils.getInstance();
+
+    @Test
+    @DisplayName("Posts the user context to the remote eval endpoint and evaluates the response")
+    void growthBookClient_remoteEvalPostsUserContextAndEvaluatesResponse() throws Exception {
+        try (RemoteEvalTestServer server = new RemoteEvalTestServer(featureResponse(true))) {
+            GrowthBookClient client = new GrowthBookClient(Options.builder()
+                    .apiHost(server.apiHost())
+                    .clientKey("sdk-test")
+                    .remoteEval(true)
+                    .globalForcedVariationsMap(Collections.singletonMap("global-exp", 1))
+                    .build());
+
+            assertTrue(client.initialize());
+
+            UserContext userContext = UserContext.builder()
+                    .attributes(jsonObject("{\"id\":\"user-1\"}"))
+                    .forcedVariationsMap(Collections.singletonMap("user-exp", 2))
+                    .build();
+
+            assertTrue(client.isOn("remote-feature", userContext));
+            assertEquals(1, server.callCount());
+
+            JsonObject requestBody = jsonObject(server.lastBody());
+            assertEquals("user-1", requestBody.getAsJsonObject("attributes").get("id").getAsString());
+            assertEquals(1, requestBody.getAsJsonObject("forcedVariations").get("global-exp").getAsInt());
+            assertEquals(2, requestBody.getAsJsonObject("forcedVariations").get("user-exp").getAsInt());
+            assertEquals(0, requestBody.getAsJsonArray("forcedFeatures").size());
+            assertEquals("", requestBody.get("url").getAsString());
+        }
+    }
+
+    @Test
+    @DisplayName("Reuses the cached response for the same cache key")
+    void growthBookClient_remoteEvalReusesCachedResponseForSameCacheKey() throws Exception {
+        try (RemoteEvalTestServer server = new RemoteEvalTestServer(featureResponse(true))) {
+            GrowthBookClient client = new GrowthBookClient(remoteEvalOptions(server));
+            assertTrue(client.initialize());
+
+            UserContext userContext = UserContext.builder()
+                    .attributes(jsonObject("{\"id\":\"user-1\"}"))
+                    .build();
+
+            assertTrue(client.isOn("remote-feature", userContext));
+            assertTrue(client.isOn("remote-feature", userContext));
+
+            assertEquals(1, server.callCount());
+        }
+    }
+
+    @Test
+    @DisplayName("cacheKeyAttributes narrows the cache key to the listed attributes")
+    void growthBookClient_cacheKeyAttributesCanNarrowRemoteEvalCacheKey() throws Exception {
+        try (RemoteEvalTestServer server = new RemoteEvalTestServer(featureResponse(true))) {
+            GrowthBookClient client = new GrowthBookClient(Options.builder()
+                    .apiHost(server.apiHost())
+                    .clientKey("sdk-test")
+                    .remoteEval(true)
+                    .cacheKeyAttributes(Collections.singletonList("id"))
+                    .build());
+            assertTrue(client.initialize());
+
+            client.isOn("remote-feature", UserContext.builder()
+                    .attributes(jsonObject("{\"id\":\"user-1\",\"plan\":\"free\"}"))
+                    .build());
+            client.isOn("remote-feature", UserContext.builder()
+                    .attributes(jsonObject("{\"id\":\"user-1\",\"plan\":\"enterprise\"}"))
+                    .build());
+
+            assertEquals(1, server.callCount());
+        }
+    }
+
+    @Test
+    @DisplayName("An empty cacheKeyAttributes list excludes all attributes from the cache key")
+    void growthBookClient_emptyCacheKeyAttributesExcludeAllAttributesFromCacheKey() throws Exception {
+        try (RemoteEvalTestServer server = new RemoteEvalTestServer(featureResponse(true))) {
+            GrowthBookClient client = new GrowthBookClient(Options.builder()
+                    .apiHost(server.apiHost())
+                    .clientKey("sdk-test")
+                    .remoteEval(true)
+                    .cacheKeyAttributes(Collections.emptyList())
+                    .build());
+            assertTrue(client.initialize());
+
+            client.isOn("remote-feature", UserContext.builder()
+                    .attributes(jsonObject("{\"id\":\"user-1\"}"))
+                    .build());
+            client.isOn("remote-feature", UserContext.builder()
+                    .attributes(jsonObject("{\"id\":\"user-2\"}"))
+                    .build());
+
+            assertEquals(1, server.callCount());
+        }
+    }
+
+    @Test
+    @DisplayName("Fetches again when the default cache key changes")
+    void growthBookClient_remoteEvalFetchesAgainWhenDefaultCacheKeyChanges() throws Exception {
+        try (RemoteEvalTestServer server = new RemoteEvalTestServer(featureResponse(true))) {
+            GrowthBookClient client = new GrowthBookClient(remoteEvalOptions(server));
+            assertTrue(client.initialize());
+
+            client.isOn("remote-feature", UserContext.builder()
+                    .attributes(jsonObject("{\"id\":\"user-1\"}"))
+                    .build());
+            client.isOn("remote-feature", UserContext.builder()
+                    .attributes(jsonObject("{\"id\":\"user-2\"}"))
+                    .build());
+
+            assertEquals(2, server.callCount());
+        }
+    }
+
+    @Test
+    @DisplayName("Coalesces concurrent identical requests into a single network call")
+    void growthBookClient_remoteEvalCoalescesConcurrentIdenticalRequests() throws Exception {
+        try (RemoteEvalTestServer server = new RemoteEvalTestServer(featureResponse(true), 200)) {
+            GrowthBookClient client = new GrowthBookClient(remoteEvalOptions(server));
+            assertTrue(client.initialize());
+
+            UserContext userContext = UserContext.builder()
+                    .attributes(jsonObject("{\"id\":\"user-1\"}"))
+                    .build();
+
+            ExecutorService executor = Executors.newFixedThreadPool(4);
+            try {
+                Future<Boolean> first = executor.submit(() -> client.preloadRemoteEval(userContext));
+                Future<Boolean> second = executor.submit(() -> client.preloadRemoteEval(userContext));
+                Future<Boolean> third = executor.submit(() -> client.preloadRemoteEval(userContext));
+
+                assertTrue(first.get());
+                assertTrue(second.get());
+                assertTrue(third.get());
+            } finally {
+                executor.shutdownNow();
+            }
+
+            assertEquals(1, server.callCount());
+        }
+    }
+
+    @Test
+    @DisplayName("refreshFeature clears the remote eval cache")
+    void growthBookClient_refreshFeatureClearsRemoteEvalCache() throws Exception {
+        try (RemoteEvalTestServer server = new RemoteEvalTestServer(featureResponse(true))) {
+            GrowthBookClient client = new GrowthBookClient(remoteEvalOptions(server));
+            assertTrue(client.initialize());
+
+            UserContext userContext = UserContext.builder()
+                    .attributes(jsonObject("{\"id\":\"user-1\"}"))
+                    .build();
+
+            client.isOn("remote-feature", userContext);
+            client.refreshFeature();
+            client.isOn("remote-feature", userContext);
+
+            assertEquals(2, server.callCount());
+        }
+    }
+
+    @Test
+    @DisplayName("Forced features are sent in the payload but excluded from the cache key")
+    void growthBookClient_forcedFeaturesAreSentButExcludedFromCacheKey() throws Exception {
+        try (RemoteEvalTestServer server = new RemoteEvalTestServer(featureResponse(true))) {
+            GrowthBookClient client = new GrowthBookClient(remoteEvalOptions(server));
+            assertTrue(client.initialize());
+
+            Map<String, Object> firstForcedFeatures = new HashMap<>();
+            firstForcedFeatures.put("irrelevant-feature", true);
+            Map<String, Object> secondForcedFeatures = new HashMap<>();
+            secondForcedFeatures.put("irrelevant-feature", false);
+
+            JsonObject attributes = jsonObject("{\"id\":\"user-1\"}");
+            client.isOn("remote-feature", UserContext.builder()
+                    .attributes(attributes)
+                    .forcedFeatureValues(firstForcedFeatures)
+                    .build());
+            client.isOn("remote-feature", UserContext.builder()
+                    .attributes(attributes)
+                    .forcedFeatureValues(secondForcedFeatures)
+                    .build());
+
+            assertEquals(1, server.callCount());
+
+            JsonArray forcedFeatures = jsonObject(server.lastBody()).getAsJsonArray("forcedFeatures");
+            assertEquals(1, forcedFeatures.size());
+            assertEquals("irrelevant-feature", forcedFeatures.get(0).getAsJsonArray().get(0).getAsString());
+            assertTrue(forcedFeatures.get(0).getAsJsonArray().get(1).getAsBoolean());
+        }
+    }
+
+    @Test
+    @DisplayName("Rejects GrowthBook Cloud hosts for remote eval")
+    void growthBookClient_remoteEvalRejectsGrowthBookCloudHost() {
+        GrowthBookClient client = new GrowthBookClient(Options.builder()
+                .apiHost("https://cdn.growthbook.io")
+                .clientKey("sdk-test")
+                .remoteEval(true)
+                .build());
+
+        assertFalse(client.initialize());
+
+        assertFalse(new GrowthBookClient(Options.builder()
+                .apiHost("cdn.growthbook.io")
+                .clientKey("sdk-test")
+                .remoteEval(true)
+                .build()).initialize());
+
+        assertFalse(new GrowthBookClient(Options.builder()
+                .apiHost("GROWTHBOOK.IO")
+                .clientKey("sdk-test")
+                .remoteEval(true)
+                .build()).initialize());
+    }
+
+    @Test
+    @DisplayName("Rejects options incompatible with remote eval (missing clientKey, decryptionKey, sticky bucketing, SWR)")
+    void growthBookClient_remoteEvalRejectsUnsupportedOptions() {
+        assertFalse(new GrowthBookClient(Options.builder()
+                .apiHost("http://127.0.0.1:1234")
+                .remoteEval(true)
+                .build()).initialize());
+
+        assertFalse(new GrowthBookClient(Options.builder()
+                .apiHost("http://127.0.0.1:1234")
+                .clientKey("sdk-test")
+                .decryptionKey("secret")
+                .remoteEval(true)
+                .build()).initialize());
+
+        assertFalse(new GrowthBookClient(Options.builder()
+                .apiHost("http://127.0.0.1:1234")
+                .clientKey("sdk-test")
+                .stickyBucketService(new InMemoryStickyBucketServiceImpl(new HashMap<>()))
+                .remoteEval(true)
+                .build()).initialize());
+
+        assertFalse(new GrowthBookClient(Options.builder()
+                .apiHost("http://127.0.0.1:1234")
+                .clientKey("sdk-test")
+                .refreshStrategy(FeatureRefreshStrategy.STALE_WHILE_REVALIDATE)
+                .remoteEval(true)
+                .build()).initialize());
+    }
+
+    @Test
+    @DisplayName("remoteEvalCacheSize bounds the number of cached responses")
+    void growthBookClient_remoteEvalCacheSizeBoundsCachedResponses() throws Exception {
+        try (RemoteEvalTestServer server = new RemoteEvalTestServer(featureResponse(true))) {
+            GrowthBookClient client = new GrowthBookClient(Options.builder()
+                    .apiHost(server.apiHost())
+                    .clientKey("sdk-test")
+                    .remoteEval(true)
+                    .remoteEvalCacheSize(1)
+                    .build());
+            assertTrue(client.initialize());
+
+            UserContext firstUser = UserContext.builder()
+                    .attributes(jsonObject("{\"id\":\"user-1\"}"))
+                    .build();
+            UserContext secondUser = UserContext.builder()
+                    .attributes(jsonObject("{\"id\":\"user-2\"}"))
+                    .build();
+
+            client.isOn("remote-feature", firstUser);
+            client.isOn("remote-feature", secondUser);
+            client.isOn("remote-feature", firstUser);
+
+            assertEquals(3, server.callCount());
+        }
+    }
+
+    @Test
+    @DisplayName("A negative remoteEvalCacheSize disables caching")
+    void growthBookClient_negativeRemoteEvalCacheSizeDisablesCaching() throws Exception {
+        try (RemoteEvalTestServer server = new RemoteEvalTestServer(featureResponse(true))) {
+            GrowthBookClient client = new GrowthBookClient(Options.builder()
+                    .apiHost(server.apiHost())
+                    .clientKey("sdk-test")
+                    .remoteEval(true)
+                    .remoteEvalCacheSize(-1)
+                    .build());
+            assertTrue(client.initialize());
+
+            UserContext userContext = UserContext.builder()
+                    .attributes(jsonObject("{\"id\":\"user-1\"}"))
+                    .build();
+
+            client.isOn("remote-feature", userContext);
+            client.isOn("remote-feature", userContext);
+
+            assertEquals(2, server.callCount());
+        }
+    }
+
+    @Test
+    @DisplayName("Fires tracking callbacks from the response rule.tracks")
+    void growthBookClient_remoteEvalFiresRuleTracks() throws Exception {
+        try (RemoteEvalTestServer server = new RemoteEvalTestServer(trackResponse())) {
+            List<String> tracked = new CopyOnWriteArrayList<>();
+            GrowthBookClient client = new GrowthBookClient(Options.builder()
+                    .apiHost(server.apiHost())
+                    .clientKey("sdk-test")
+                    .remoteEval(true)
+                    .trackingCallBackWithUser(new TrackingCallbackWithUser() {
+                        @Override
+                        public <ValueType> void onTrack(
+                                Experiment<ValueType> experiment,
+                                ExperimentResult<ValueType> experimentResult,
+                                UserContext userContext
+                        ) {
+                            tracked.add(experiment.getKey() + ":" + experimentResult.getVariationId()
+                                    + ":" + userContext.getAttributes().get("id").getAsString());
+                        }
+                    })
+                    .build());
+            assertTrue(client.initialize());
+
+            assertTrue(client.isOn("remote-feature", UserContext.builder()
+                    .attributes(jsonObject("{\"id\":\"user-1\"}"))
+                    .build()));
+
+            assertEquals(Collections.singletonList("track-exp:1:user-1"), tracked);
+        }
+    }
+
+    @Test
+    @DisplayName("Ignores malformed rule.tracks entries")
+    void growthBookClient_remoteEvalIgnoresMalformedTrackEntries() throws Exception {
+        try (RemoteEvalTestServer server = new RemoteEvalTestServer(malformedTrackResponse())) {
+            AtomicInteger trackCount = new AtomicInteger();
+            GrowthBookClient client = new GrowthBookClient(Options.builder()
+                    .apiHost(server.apiHost())
+                    .clientKey("sdk-test")
+                    .remoteEval(true)
+                    .trackingCallBackWithUser(new TrackingCallbackWithUser() {
+                        @Override
+                        public <ValueType> void onTrack(
+                                Experiment<ValueType> experiment,
+                                ExperimentResult<ValueType> experimentResult,
+                                UserContext userContext
+                        ) {
+                            trackCount.incrementAndGet();
+                        }
+                    })
+                    .build());
+            assertTrue(client.initialize());
+
+            assertTrue(client.isOn("remote-feature", UserContext.builder()
+                    .attributes(jsonObject("{\"id\":\"user-1\"}"))
+                    .build()));
+            assertEquals(0, trackCount.get());
+        }
+    }
+
+    @Test
+    @DisplayName("Single-context client fetches on initialization and on attribute updates")
+    void growthBook_remoteEvalFetchesOnInitializationAndAttributeUpdate() throws Exception {
+        try (RemoteEvalTestServer server = new RemoteEvalTestServer(featureResponse(true))) {
+            GBContext context = GBContext.builder()
+                    .apiHost(server.apiHost())
+                    .clientKey("sdk-test")
+                    .remoteEval(true)
+                    .attributes(jsonObject("{\"id\":\"user-1\"}"))
+                    .build();
+
+            GrowthBook growthBook = new GrowthBook(context);
+
+            assertTrue(growthBook.getFeatureValue("remote-feature", false));
+            assertEquals(1, server.callCount());
+
+            growthBook.setAttributes("{\"id\":\"user-2\"}");
+
+            assertTrue(growthBook.getFeatureValue("remote-feature", false));
+            assertEquals(2, server.callCount());
+        }
+    }
+
+    @Test
+    @DisplayName("Remote eval fires tracking once per assignment even when the result is served from cache")
+    void growthBookClient_remoteEvalTrackFiresOncePerCachedAssignment() throws Exception {
+        try (RemoteEvalTestServer server = new RemoteEvalTestServer(trackResponse())) {
+            List<String> tracked = new CopyOnWriteArrayList<>();
+            GrowthBookClient client = trackingClient(server, tracked);
+            assertTrue(client.initialize());
+
+            UserContext user = UserContext.builder().attributes(jsonObject("{\"id\":\"user-1\"}")).build();
+            assertTrue(client.isOn("remote-feature", user));
+            assertTrue(client.isOn("remote-feature", user));
+
+            assertEquals(1, server.callCount());
+            assertEquals(Collections.singletonList("track-exp:1:user-1"), tracked);
+        }
+    }
+
+    @Test
+    @DisplayName("Remote eval tracking fires independently for distinct users")
+    void growthBookClient_remoteEvalTrackFiresPerDistinctUser() throws Exception {
+        try (RemoteEvalTestServer server = new RemoteEvalTestServer(trackResponse())) {
+            server.respondWith(200, trackResponseFor("user-1"));
+            server.respondWith(200, trackResponseFor("user-2"));
+
+            List<String> tracked = new CopyOnWriteArrayList<>();
+            GrowthBookClient client = trackingClient(server, tracked);
+            assertTrue(client.initialize());
+
+            client.isOn("remote-feature", UserContext.builder().attributes(jsonObject("{\"id\":\"user-1\"}")).build());
+            client.isOn("remote-feature", UserContext.builder().attributes(jsonObject("{\"id\":\"user-2\"}")).build());
+
+            assertEquals(2, tracked.size());
+            assertTrue(tracked.contains("track-exp:1:user-1"));
+            assertTrue(tracked.contains("track-exp:1:user-2"));
+        }
+    }
+
+    @Test
+    @DisplayName("Remote eval tracking is isolated per client instance")
+    void growthBookClient_remoteEvalTrackingIsIsolatedPerClient() throws Exception {
+        try (RemoteEvalTestServer server = new RemoteEvalTestServer(trackResponse())) {
+            List<String> trackedA = new CopyOnWriteArrayList<>();
+            List<String> trackedB = new CopyOnWriteArrayList<>();
+            GrowthBookClient clientA = trackingClient(server, trackedA);
+            GrowthBookClient clientB = trackingClient(server, trackedB);
+            assertTrue(clientA.initialize());
+            assertTrue(clientB.initialize());
+
+            UserContext user = UserContext.builder().attributes(jsonObject("{\"id\":\"user-1\"}")).build();
+            clientA.isOn("remote-feature", user);
+            clientB.isOn("remote-feature", user);
+
+            assertEquals(Collections.singletonList("track-exp:1:user-1"), trackedA);
+            assertEquals(Collections.singletonList("track-exp:1:user-1"), trackedB);
+        }
+    }
+
+    @Test
+    @DisplayName("Remote eval cache hits within the TTL and refetches once it expires")
+    void growthBookClient_remoteEvalCacheTtlExpiresViaPublicApi() throws Exception {
+        try (RemoteEvalTestServer server = new RemoteEvalTestServer(featureResponse(true))) {
+            GrowthBookClient client = new GrowthBookClient(Options.builder()
+                    .apiHost(server.apiHost())
+                    .clientKey("sdk-test")
+                    .remoteEval(true)
+                    .remoteEvalCacheTtlSeconds(1)
+                    .build());
+            assertTrue(client.initialize());
+
+            UserContext user = UserContext.builder().attributes(jsonObject("{\"id\":\"user-1\"}")).build();
+            client.isOn("remote-feature", user);
+            client.isOn("remote-feature", user);
+            assertEquals(1, server.callCount());
+
+            Thread.sleep(1200);
+            client.isOn("remote-feature", user);
+            assertEquals(2, server.callCount());
+        }
+    }
+
+    @Test
+    @DisplayName("Remote eval caches do not leak responses between client instances")
+    void growthBookClient_remoteEvalCacheDoesNotLeakBetweenClients() throws Exception {
+        try (RemoteEvalTestServer server = new RemoteEvalTestServer(featureResponse(true))) {
+            GrowthBookClient clientA = new GrowthBookClient(remoteEvalOptions(server));
+            GrowthBookClient clientB = new GrowthBookClient(remoteEvalOptions(server));
+            assertTrue(clientA.initialize());
+            assertTrue(clientB.initialize());
+
+            UserContext user = UserContext.builder().attributes(jsonObject("{\"id\":\"user-1\"}")).build();
+            clientA.isOn("remote-feature", user);
+            clientB.isOn("remote-feature", user);
+
+            assertEquals(2, server.callCount());
+        }
+    }
+
+    @Test
+    @DisplayName("An HTTP error falls back and does not poison the remote eval cache")
+    void growthBookClient_remoteEvalHttpErrorDoesNotPoisonCache() throws Exception {
+        try (RemoteEvalTestServer server = new RemoteEvalTestServer(featureResponse(true))) {
+            server.respondWith(500, "{}");
+            server.respondWith(200, featureResponse(true));
+
+            GrowthBookClient client = new GrowthBookClient(remoteEvalOptions(server));
+            assertTrue(client.initialize());
+
+            UserContext user = UserContext.builder().attributes(jsonObject("{\"id\":\"user-1\"}")).build();
+            assertFalse(client.isOn("remote-feature", user));
+            assertTrue(client.isOn("remote-feature", user));
+            assertEquals(2, server.callCount());
+        }
+    }
+
+    @Test
+    @DisplayName("A malformed JSON response falls back and does not poison the remote eval cache")
+    void growthBookClient_remoteEvalMalformedJsonDoesNotPoisonCache() throws Exception {
+        try (RemoteEvalTestServer server = new RemoteEvalTestServer(featureResponse(true))) {
+            server.respondWith(200, "not-json");
+            server.respondWith(200, featureResponse(true));
+
+            GrowthBookClient client = new GrowthBookClient(remoteEvalOptions(server));
+            assertTrue(client.initialize());
+
+            UserContext user = UserContext.builder().attributes(jsonObject("{\"id\":\"user-1\"}")).build();
+            assertFalse(client.isOn("remote-feature", user));
+            assertTrue(client.isOn("remote-feature", user));
+            assertEquals(2, server.callCount());
+        }
+    }
+
+    @Test
+    @DisplayName("Unknown fields in the remote eval response are tolerated")
+    void growthBookClient_remoteEvalToleratesUnknownResponseFields() throws Exception {
+        String body = "{\"features\":{\"remote-feature\":{\"defaultValue\":true,\"unknownField\":42}},"
+                + "\"savedGroups\":{},\"meta\":{\"proxy\":\"v1\"}}";
+        try (RemoteEvalTestServer server = new RemoteEvalTestServer(body)) {
+            GrowthBookClient client = new GrowthBookClient(remoteEvalOptions(server));
+            assertTrue(client.initialize());
+
+            assertTrue(client.isOn("remote-feature",
+                    UserContext.builder().attributes(jsonObject("{\"id\":\"user-1\"}")).build()));
+        }
+    }
+
+    @Test
+    @DisplayName("A response missing the features field falls back safely")
+    void growthBookClient_remoteEvalMissingFeaturesFieldFallsBack() throws Exception {
+        try (RemoteEvalTestServer server = new RemoteEvalTestServer("{\"savedGroups\":{}}")) {
+            GrowthBookClient client = new GrowthBookClient(remoteEvalOptions(server));
+            assertTrue(client.initialize());
+
+            assertFalse(client.isOn("remote-feature",
+                    UserContext.builder().attributes(jsonObject("{\"id\":\"user-1\"}")).build()));
+        }
+    }
+
+    @Test
+    @DisplayName("Shutting down during an in-flight request does not hang and stays safe afterwards")
+    void growthBookClient_shutdownDuringInflightRequestIsSafe() throws Exception {
+        try (RemoteEvalTestServer server = new RemoteEvalTestServer(featureResponse(true), 300)) {
+            GrowthBookClient client = new GrowthBookClient(remoteEvalOptions(server));
+            assertTrue(client.initialize());
+
+            UserContext user = UserContext.builder().attributes(jsonObject("{\"id\":\"user-1\"}")).build();
+            ExecutorService executor = Executors.newSingleThreadExecutor();
+            try {
+                Future<Boolean> inFlight = executor.submit(() -> client.preloadRemoteEval(user));
+                Thread.sleep(50);
+                client.shutdown();
+
+                inFlight.get(2, TimeUnit.SECONDS);
+
+                assertFalse(client.isOn("remote-feature", user));
+            } finally {
+                executor.shutdownNow();
+            }
+        }
+    }
+
+    @Test
+    @DisplayName("Legacy constructors keep remote eval disabled by default")
+    void oldConstructorsKeepRemoteEvalDisabledByDefault() {
+        Options options = new Options(
+                null, null, null, null, null, null, null, null, null, null, null,
+                null, null, null, null, null, null, null, null, null, null
+        );
+        GBContext context = new GBContext(
+                null, null, null, null, null, null, null, null, null, null, null,
+                null, null, null, null, null
+        );
+
+        assertFalse(options.isRemoteEvalEnabled());
+        assertEquals(RemoteEvalRequestBuilder.DEFAULT_CACHE_SIZE, options.getRemoteEvalCacheSize());
+        assertFalse(context.isRemoteEvalEnabled());
+        assertEquals(RemoteEvalRequestBuilder.DEFAULT_CACHE_SIZE, context.getRemoteEvalCacheSize());
+    }
+
+    @Test
+    @DisplayName("Request body normalizes null fields to empty values")
+    void requestBodyNormalizesNullFields() {
+        RequestBodyForRemoteEval requestBody = new RequestBodyForRemoteEval();
+
+        requestBody.setAttributes(null);
+        requestBody.setForcedFeatures(null);
+        requestBody.setForcedVariations(null);
+        requestBody.setUrl(null);
+
+        assertEquals(new JsonObject(), requestBody.getAttributes());
+        assertTrue(requestBody.getForcedFeatures().isEmpty());
+        assertTrue(requestBody.getForcedVariations().isEmpty());
+        assertEquals("", requestBody.getUrl());
+    }
+
+    private Options remoteEvalOptions(RemoteEvalTestServer server) {
+        return Options.builder()
+                .apiHost(server.apiHost())
+                .clientKey("sdk-test")
+                .remoteEval(true)
+                .build();
+    }
+
+    private JsonObject jsonObject(String json) {
+        return jsonUtils.gson.fromJson(json, JsonObject.class);
+    }
+
+    private static String featureResponse(boolean enabled) {
+        return "{\"features\":{\"remote-feature\":{\"defaultValue\":" + enabled + "}},\"savedGroups\":{}}";
+    }
+
+    private static String malformedTrackResponse() {
+        return "{\"features\":{\"remote-feature\":{\"rules\":[{\"force\":true,\"tracks\":[{}]}]}},\"savedGroups\":{}}";
+    }
+
+    private static String trackResponse() {
+        return trackResponseFor("user-1");
+    }
+
+    private static String trackResponseFor(String hashValue) {
+        return "{\"features\":{\"remote-feature\":{\"defaultValue\":false,\"rules\":[{\"force\":true,\"tracks\":[{"
+                + "\"experiment\":{\"key\":\"track-exp\",\"variations\":[false,true]},"
+                + "\"result\":{\"variationId\":1,\"inExperiment\":true,\"value\":true,\"hashUsed\":true,"
+                + "\"hashAttribute\":\"id\",\"hashValue\":\"" + hashValue + "\",\"featureId\":\"remote-feature\",\"key\":\"1\"}"
+                + "}]}]}},\"savedGroups\":{}}";
+    }
+
+    private GrowthBookClient trackingClient(RemoteEvalTestServer server, List<String> tracked) {
+        return new GrowthBookClient(Options.builder()
+                .apiHost(server.apiHost())
+                .clientKey("sdk-test")
+                .remoteEval(true)
+                .trackingCallBackWithUser(new TrackingCallbackWithUser() {
+                    @Override
+                    public <ValueType> void onTrack(
+                            Experiment<ValueType> experiment,
+                            ExperimentResult<ValueType> experimentResult,
+                            UserContext userContext
+                    ) {
+                        tracked.add(experiment.getKey() + ":" + experimentResult.getVariationId()
+                                + ":" + userContext.getAttributes().get("id").getAsString());
+                    }
+                })
+                .build());
+    }
+
+    private static class RemoteEvalTestServer implements AutoCloseable {
+        private final HttpServer server;
+        private final ExecutorService executor;
+        private final AtomicInteger callCount = new AtomicInteger();
+        private final List<String> bodies = new CopyOnWriteArrayList<>();
+        private final String responseBody;
+        private final int delayMillis;
+
+        RemoteEvalTestServer(String responseBody) throws IOException {
+            this(responseBody, 0);
+        }
+
+        RemoteEvalTestServer(String responseBody, int delayMillis) throws IOException {
+            this.responseBody = responseBody;
+            this.delayMillis = delayMillis;
+            this.server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+            this.executor = Executors.newCachedThreadPool();
+            this.server.createContext("/api/eval/sdk-test", this::handle);
+            this.server.setExecutor(this.executor);
+            this.server.start();
+        }
+
+        private final List<int[]> statuses = new CopyOnWriteArrayList<>();
+        private final List<String> scriptedBodies = new CopyOnWriteArrayList<>();
+
+        /** Append a scripted (status, body) response; used in call order, last entry repeats. */
+        void respondWith(int status, String body) {
+            statuses.add(new int[]{status});
+            scriptedBodies.add(body);
+        }
+
+        String apiHost() {
+            return "http://127.0.0.1:" + this.server.getAddress().getPort();
+        }
+
+        int callCount() {
+            return this.callCount.get();
+        }
+
+        String lastBody() {
+            return this.bodies.get(this.bodies.size() - 1);
+        }
+
+        private void handle(HttpExchange exchange) throws IOException {
+            int n = callCount.incrementAndGet();
+            bodies.add(readBody(exchange));
+            if (delayMillis > 0) {
+                sleep(delayMillis);
+            }
+
+            int status = 200;
+            String body = responseBody;
+            if (!scriptedBodies.isEmpty()) {
+                int index = Math.min(n - 1, scriptedBodies.size() - 1);
+                status = statuses.get(index)[0];
+                body = scriptedBodies.get(index);
+            }
+
+            byte[] response = body.getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().add("Content-Type", "application/json");
+            exchange.sendResponseHeaders(status, response.length == 0 ? -1 : response.length);
+            try (OutputStream outputStream = exchange.getResponseBody()) {
+                outputStream.write(response);
+            }
+        }
+
+        private String readBody(HttpExchange exchange) throws IOException {
+            try (InputStream inputStream = exchange.getRequestBody();
+                 ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+                byte[] buffer = new byte[1024];
+                int read;
+                while ((read = inputStream.read(buffer)) != -1) {
+                    outputStream.write(buffer, 0, read);
+                }
+                return new String(outputStream.toByteArray(), StandardCharsets.UTF_8);
+            }
+        }
+
+        private void sleep(int millis) {
+            try {
+                Thread.sleep(millis);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+
+        @Override
+        public void close() {
+            this.server.stop(0);
+            this.executor.shutdownNow();
+        }
+    }
+}

--- a/lib/src/test/java/growthbook/sdk/java/remoteeval/RemoteEvalSupportTest.java
+++ b/lib/src/test/java/growthbook/sdk/java/remoteeval/RemoteEvalSupportTest.java
@@ -203,33 +203,60 @@ class RemoteEvalSupportTest {
     }
 
     @Test
-    @DisplayName("Forced features are sent in the payload but excluded from the cache key")
-    void growthBookClient_forcedFeaturesAreSentButExcludedFromCacheKey() throws Exception {
+    @DisplayName("Forced features are sent in the payload and contribute to the cache key")
+    void growthBookClient_forcedFeaturesAreSentAndContributeToCacheKey() throws Exception {
         try (RemoteEvalTestServer server = new RemoteEvalTestServer(featureResponse(true))) {
             GrowthBookClient client = new GrowthBookClient(remoteEvalOptions(server));
             assertTrue(client.initialize());
 
             Map<String, Object> firstForcedFeatures = new HashMap<>();
-            firstForcedFeatures.put("irrelevant-feature", true);
+            firstForcedFeatures.put("overridden-feature", true);
             Map<String, Object> secondForcedFeatures = new HashMap<>();
-            secondForcedFeatures.put("irrelevant-feature", false);
+            secondForcedFeatures.put("overridden-feature", false);
 
             JsonObject attributes = jsonObject("{\"id\":\"user-1\"}");
             client.isOn("remote-feature", UserContext.builder()
                     .attributes(attributes)
                     .forcedFeatureValues(firstForcedFeatures)
                     .build());
+            // Same user/url/forced variations but different forced feature values must not reuse the cached response.
             client.isOn("remote-feature", UserContext.builder()
                     .attributes(attributes)
                     .forcedFeatureValues(secondForcedFeatures)
                     .build());
 
-            assertEquals(1, server.callCount());
+            assertEquals(2, server.callCount());
 
             JsonArray forcedFeatures = jsonObject(server.lastBody()).getAsJsonArray("forcedFeatures");
             assertEquals(1, forcedFeatures.size());
-            assertEquals("irrelevant-feature", forcedFeatures.get(0).getAsJsonArray().get(0).getAsString());
-            assertTrue(forcedFeatures.get(0).getAsJsonArray().get(1).getAsBoolean());
+            assertEquals("overridden-feature", forcedFeatures.get(0).getAsJsonArray().get(0).getAsString());
+            assertFalse(forcedFeatures.get(0).getAsJsonArray().get(1).getAsBoolean());
+        }
+    }
+
+    @Test
+    @DisplayName("Reuses the cached response when forced feature values are identical")
+    void growthBookClient_forcedFeaturesReuseCacheWhenIdentical() throws Exception {
+        try (RemoteEvalTestServer server = new RemoteEvalTestServer(featureResponse(true))) {
+            GrowthBookClient client = new GrowthBookClient(remoteEvalOptions(server));
+            assertTrue(client.initialize());
+
+            JsonObject attributes = jsonObject("{\"id\":\"user-1\"}");
+            Map<String, Object> firstForcedFeatures = new HashMap<>();
+            firstForcedFeatures.put("overridden-feature", true);
+            Map<String, Object> sameForcedFeatures = new HashMap<>();
+            sameForcedFeatures.put("overridden-feature", true);
+
+            client.isOn("remote-feature", UserContext.builder()
+                    .attributes(attributes)
+                    .forcedFeatureValues(firstForcedFeatures)
+                    .build());
+            client.isOn("remote-feature", UserContext.builder()
+                    .attributes(attributes)
+                    .forcedFeatureValues(sameForcedFeatures)
+                    .build());
+
+            assertEquals(1, server.callCount());
         }
     }
 


### PR DESCRIPTION
## Summary

Adds remote evaluation support to the Java SDK for both single-context `GrowthBook` usage and multi-user `GrowthBookClient`.

## Changes

- Added remote eval configuration options: `remoteEval`, `apiHost`, `clientKey`, `cacheKeyAttributes`, `remoteEvalCacheSize`, and `remoteEvalCacheTtlSeconds`.
- Added remote eval HTTP service, response parser, endpoint helper, request builder, deterministic cache key builder, and in-memory cache.
- Integrated remote eval into feature evaluation with safe fallback to local/current feature context when remote fetch fails.
- Added remote eval response caching with TTL, stale-while-revalidate support, cache invalidation, and shutdown cleanup.
- Added SSE-based remote eval cache invalidation for multi-user mode.
- Added option validation for unsupported remote eval combinations, including encrypted payloads, sticky bucketing, SWR refresh strategy, and GrowthBook Cloud host usage.
- Updated remote tracking handling so remotely evaluated experiment tracks are deduplicated per assignment.
- Normalized remote eval request payload defaults to avoid null fields.
- Fixed condition evaluator behavior for `$ne`, `$notRegex`, and `$notRegexi` with missing/null attributes.
