### PR TITLE
Feature: Add custom fields

### DIFF
--- a/lib/src/main/java/growthbook/sdk/java/evaluators/FeatureEvaluator.java
+++ b/lib/src/main/java/growthbook/sdk/java/evaluators/FeatureEvaluator.java
@@ -343,6 +343,7 @@ public class FeatureEvaluator implements IFeatureEvaluator {
                                 .hashVersion(rule.getHashVersion())
                                 .filters(rule.getFilters())
                                 .conditionJson(rule.getCondition())
+                                .customFields(rule.getCustomFields())
                                 .build();
 
                         // Only return a value if the user is part of the experiment

--- a/lib/src/main/java/growthbook/sdk/java/model/Experiment.java
+++ b/lib/src/main/java/growthbook/sdk/java/model/Experiment.java
@@ -2,6 +2,7 @@ package growthbook.sdk.java.model;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import com.google.gson.JsonSyntaxException;
 import com.google.gson.annotations.SerializedName;
 import growthbook.sdk.java.util.GrowthBookJsonUtils;
 import lombok.AllArgsConstructor;
@@ -10,6 +11,7 @@ import lombok.Data;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
+import java.util.Map;
 
 /**
  * Defines a single Experiment
@@ -152,6 +154,87 @@ public class Experiment<ValueType> {
      */
     @Nullable
     Integer minBucketVersion;
+
+    @Nullable
+    Map<String, Object> customFields;
+
+    public Experiment(
+            String key,
+            ArrayList<ValueType> variations,
+            @Nullable ArrayList<Float> weights,
+            @Nullable Boolean isActive,
+            @Nullable Float coverage,
+            @Nullable JsonObject conditionJson,
+            @Nullable ArrayList<ParentCondition> parentConditions,
+            @Nullable Namespace namespace,
+            @Nullable Integer force,
+            String hashAttribute,
+            @Nullable Integer hashVersion,
+            @Nullable ArrayList<BucketRange> ranges,
+            @Nullable ArrayList<VariationMeta> meta,
+            @Nullable ArrayList<Filter> filters,
+            @Nullable String seed,
+            @Nullable String name,
+            @Nullable String phase,
+            @Nullable String fallbackAttribute,
+            @Nullable Boolean disableStickyBucketing,
+            @Nullable Integer bucketVersion,
+            @Nullable Integer minBucketVersion
+    ) {
+        this(
+                key,
+                variations,
+                weights,
+                isActive,
+                coverage,
+                conditionJson,
+                parentConditions,
+                namespace,
+                force,
+                hashAttribute,
+                hashVersion,
+                ranges,
+                meta,
+                filters,
+                seed,
+                name,
+                phase,
+                fallbackAttribute,
+                disableStickyBucketing,
+                bucketVersion,
+                minBucketVersion,
+                null
+        );
+    }
+
+    @Nullable
+    public Object getCustomField(String fieldId) {
+        if (customFields == null || fieldId == null) {
+            return null;
+        }
+        return customFields.get(fieldId);
+    }
+
+    public boolean hasCustomField(String fieldId) {
+        return customFields != null && customFields.containsKey(fieldId);
+    }
+
+    @Nullable
+    public <FieldType> FieldType getCustomField(String fieldId, Class<FieldType> fieldType) {
+        Object value = getCustomField(fieldId);
+        if (value == null || fieldType == null) {
+            return null;
+        }
+        if (fieldType.isInstance(value)) {
+            return fieldType.cast(value);
+        }
+        try {
+            JsonElement element = GrowthBookJsonUtils.getInstance().gson.toJsonTree(value);
+            return GrowthBookJsonUtils.getInstance().gson.fromJson(element, fieldType);
+        } catch (JsonSyntaxException | NumberFormatException e) {
+            return null;
+        }
+    }
 
     /**
      * Get a Gson JsonElement of the experiment

--- a/lib/src/main/java/growthbook/sdk/java/model/FeatureRule.java
+++ b/lib/src/main/java/growthbook/sdk/java/model/FeatureRule.java
@@ -16,6 +16,7 @@ import growthbook.sdk.java.serializers.SuperTypeToken;
 import javax.annotation.Nullable;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
+import java.util.Map;
 
 /**
  * Overrides the defaultValue of a Feature based on a set of requirements. Has a number of optional properties
@@ -178,16 +179,72 @@ public class FeatureRule<ValueType> extends SuperTypeToken<ValueType> implements
     @Nullable
     Integer minBucketVersion;
 
+    @Nullable
+    Map<String, Object> customFields;
+
     /**
      * Array of tracking calls to fire
      */
     @Nullable
     ArrayList<TrackData<ValueType>> tracks;
 
+    public FeatureRule(
+            @Nullable String id,
+            @Nullable String key,
+            @Nullable Float coverage,
+            @Nullable OptionalField<ValueType> force,
+            @Nullable ArrayList<ValueType> variations,
+            @Nullable ArrayList<Float> weights,
+            @Nullable Namespace namespace,
+            String hashAttribute,
+            @Nullable JsonObject condition,
+            @Nullable ArrayList<ParentCondition> parentConditions,
+            @Nullable Integer hashVersion,
+            @Nullable BucketRange range,
+            @Nullable ArrayList<BucketRange> ranges,
+            @Nullable ArrayList<VariationMeta> meta,
+            @Nullable ArrayList<Filter> filters,
+            @Nullable String seed,
+            @Nullable String name,
+            @Nullable String phase,
+            @Nullable String fallbackAttribute,
+            @Nullable Boolean disableStickyBucketing,
+            @Nullable Integer bucketVersion,
+            @Nullable Integer minBucketVersion,
+            @Nullable ArrayList<TrackData<ValueType>> tracks
+    ) {
+        this(
+                id,
+                key,
+                coverage,
+                force,
+                variations,
+                weights,
+                namespace,
+                hashAttribute,
+                condition,
+                parentConditions,
+                hashVersion,
+                range,
+                ranges,
+                meta,
+                filters,
+                seed,
+                name,
+                phase,
+                fallbackAttribute,
+                disableStickyBucketing,
+                bucketVersion,
+                minBucketVersion,
+                null,
+                tracks
+        );
+    }
+
     @Override
     public FeatureRule<ValueType> deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) {
         JsonObject jsonObject = json.getAsJsonObject();
-        FeatureRule.FeatureRuleBuilder<ValueType> builder = FeatureRule.builder();
+        FeatureRule.FeatureRuleBuilder<ValueType> builder = FeatureRule.<ValueType>builder();
 
         builder.id(jsonObject.has("id") ? context.deserialize(jsonObject.get("id"), String.class) : "");
         builder.key(jsonObject.has("key") ? context.deserialize(jsonObject.get("key"), String.class) : null);
@@ -250,6 +307,11 @@ public class FeatureRule<ValueType> extends SuperTypeToken<ValueType> implements
         builder.disableStickyBucketing(jsonObject.has("disableStickyBucketing") ? context.deserialize(jsonObject.get("disableStickyBucketing"), Boolean.class) : null);
         builder.bucketVersion(jsonObject.has("bucketVersion") ? context.deserialize(jsonObject.get("bucketVersion"), Integer.class) : null);
         builder.minBucketVersion(jsonObject.has("minBucketVersion") ? context.deserialize(jsonObject.get("minBucketVersion"), Integer.class) : null);
+
+        if (jsonObject.has("customFields")) {
+            builder.customFields(context.deserialize(jsonObject.get("customFields"), new TypeToken<Map<String, Object>>() {
+            }.getType()));
+        }
 
         if (jsonObject.has("tracks")) {
             builder.tracks(context.deserialize(jsonObject.get("tracks"), TypeToken.getParameterized(ArrayList.class, TrackData.class).getType()));

--- a/lib/src/test/java/growthbook/sdk/java/ExperimentTest.java
+++ b/lib/src/test/java/growthbook/sdk/java/ExperimentTest.java
@@ -1,16 +1,21 @@
 package growthbook.sdk.java;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.gson.JsonObject;
 import com.google.gson.reflect.TypeToken;
 import growthbook.sdk.java.model.Experiment;
 import growthbook.sdk.java.model.Namespace;
 import growthbook.sdk.java.util.GrowthBookJsonUtils;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 class ExperimentTest {
 
@@ -152,5 +157,70 @@ class ExperimentTest {
         assertEquals(Boolean.TRUE, subject.getIsActive());
         assertEquals(100, subject.getVariations().get(0));
         assertEquals(200, subject.getVariations().get(1));
+    }
+
+    @Test
+    @DisplayName("Deserializes experiment custom fields with mixed value types")
+    void test_deserializesCustomFields() {
+        Type experimentType = new TypeToken<Experiment<Integer>>() {}.getType();
+
+        Experiment<Integer> subject = jsonUtils.gson.fromJson("{\"key\":\"my_experiment\",\"variations\":[100,200],\"customFields\":{\"cfl_string\":\"text value\",\"cfl_number\":42,\"cfl_decimal\":99.99,\"cfl_bool\":true,\"cfl_null\":null}}", experimentType);
+
+        assertTrue(subject.hasCustomField("cfl_string"));
+        assertTrue(subject.hasCustomField("cfl_null"));
+        assertFalse(subject.hasCustomField("cfl_missing"));
+        assertEquals("text value", subject.getCustomField("cfl_string"));
+        assertEquals(42L, subject.getCustomField("cfl_number"));
+        assertEquals(99.99, subject.getCustomField("cfl_decimal"));
+        assertEquals(Boolean.TRUE, subject.getCustomField("cfl_bool"));
+        assertNull(subject.getCustomField("cfl_null"));
+        assertEquals(Integer.valueOf(42), subject.getCustomField("cfl_number", Integer.class));
+        assertEquals("42", subject.getCustomField("cfl_number", String.class));
+        assertEquals(Boolean.TRUE, subject.getCustomField("cfl_bool", Boolean.class));
+        assertNull(subject.getCustomField("cfl_string", Integer.class));
+    }
+
+    @Test
+    @DisplayName("Typed custom field accessor coerces compatible types, including numeric strings")
+    void test_typedCustomFieldCoercion() {
+        Type experimentType = new TypeToken<Experiment<Integer>>() {}.getType();
+
+        Experiment<Integer> subject = jsonUtils.gson.fromJson("{\"key\":\"my_experiment\",\"variations\":[100,200],\"customFields\":{\"cfl_numeric_string\":\"42\",\"cfl_number\":42}}", experimentType);
+
+        assertEquals(Integer.valueOf(42), subject.getCustomField("cfl_numeric_string", Integer.class));
+        assertEquals(Double.valueOf(42.0), subject.getCustomField("cfl_number", Double.class));
+        assertEquals(Long.valueOf(42), subject.getCustomField("cfl_number", Long.class));
+    }
+
+    @Test
+    @DisplayName("Keeps custom fields nullable when the API omits them")
+    void test_missingCustomFieldsStayNull() {
+        Type experimentType = new TypeToken<Experiment<Integer>>() {}.getType();
+
+        Experiment<Integer> subject = jsonUtils.gson.fromJson("{\"key\":\"my_experiment\",\"variations\":[100,200]}", experimentType);
+
+        assertNull(subject.getCustomFields());
+        assertNull(subject.getCustomField("cfl_missing"));
+        assertFalse(subject.hasCustomField("cfl_missing"));
+    }
+
+    @Test
+    @DisplayName("Serializes custom fields and reads them back")
+    void test_serializesCustomFields() {
+        Type experimentType = new TypeToken<Experiment<Integer>>() {}.getType();
+        Map<String, Object> customFields = new LinkedHashMap<>();
+        customFields.put("cfl_string", "text value");
+        customFields.put("cfl_number", 42);
+
+        Experiment<Integer> subject = Experiment
+                .<Integer>builder()
+                .key("my_experiment")
+                .customFields(customFields)
+                .build();
+
+        Experiment<Integer> deserialized = jsonUtils.gson.fromJson(subject.toJson(), experimentType);
+
+        assertEquals("text value", deserialized.getCustomField("cfl_string"));
+        assertEquals(42L, deserialized.getCustomField("cfl_number"));
     }
 }

--- a/lib/src/test/java/growthbook/sdk/java/FeatureRuleTest.java
+++ b/lib/src/test/java/growthbook/sdk/java/FeatureRuleTest.java
@@ -1,12 +1,17 @@
 package growthbook.sdk.java;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+import com.google.gson.reflect.TypeToken;
 import growthbook.sdk.java.model.FeatureRule;
 import growthbook.sdk.java.model.Namespace;
 import growthbook.sdk.java.model.OptionalField;
+import growthbook.sdk.java.util.GrowthBookJsonUtils;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import java.lang.reflect.Type;
 import java.util.ArrayList;
 
 class FeatureRuleTest {
@@ -113,5 +118,18 @@ class FeatureRuleTest {
         assertNull(subject.getWeights());
         assertEquals("id", subject.getHashAttribute());
         assertEquals("id", subject.getHashAttribute());
+    }
+
+    @Test
+    @DisplayName("Deserializes custom fields on experiment feature rules")
+    void deserializesCustomFields() {
+        Type featureRuleType = new TypeToken<FeatureRule<Boolean>>() {}.getType();
+
+        FeatureRule<Boolean> subject = GrowthBookJsonUtils.getInstance().gson.fromJson("{\"key\":\"experiment-key\",\"variations\":[false,true],\"customFields\":{\"cfl_ticket\":\"APX-123\",\"cfl_priority\":2,\"cfl_reviewed\":true}}", featureRuleType);
+
+        assertNotNull(subject.getCustomFields());
+        assertEquals("APX-123", subject.getCustomFields().get("cfl_ticket"));
+        assertEquals(2L, subject.getCustomFields().get("cfl_priority"));
+        assertEquals(Boolean.TRUE, subject.getCustomFields().get("cfl_reviewed"));
     }
 }

--- a/lib/src/test/java/growthbook/sdk/java/GrowthBookTest.java
+++ b/lib/src/test/java/growthbook/sdk/java/GrowthBookTest.java
@@ -34,6 +34,7 @@ import growthbook.sdk.java.testhelpers.TestCasesJsonHelper;
 import growthbook.sdk.java.testhelpers.TestContext;
 import growthbook.sdk.java.util.GrowthBookJsonUtils;
 import lombok.Getter;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import java.lang.reflect.Type;
@@ -198,6 +199,26 @@ class GrowthBookTest {
         assertEquals("Welcome to our app!!!", value);
         assertEquals("Welcome to our app!!!", featureResult.getValue());
         assertEquals(FeatureResultSource.DEFAULT_VALUE, featureResult.getSource());
+    }
+
+    @Test
+    @DisplayName("Preserves custom fields on the experiment returned by feature evaluation")
+    void test_evalFeature_preservesExperimentCustomFields() {
+        String features = "{\"signup-copy\":{\"defaultValue\":false,\"rules\":[{\"key\":\"signup-copy-exp\",\"variations\":[false,true],\"coverage\":1,\"hashAttribute\":\"id\",\"customFields\":{\"cfl_ticket\":\"APX-123\",\"cfl_owner\":\"growth\"}}]}}";
+        GBContext context = GBContext
+                .builder()
+                .featuresJson(features)
+                .attributesJson("{\"id\":\"user-1\"}")
+                .build();
+        GrowthBook subject = new GrowthBook(context);
+
+        FeatureResult<Boolean> result = subject.evalFeature("signup-copy", Boolean.class);
+
+        assertNotNull(result);
+        assertEquals(FeatureResultSource.EXPERIMENT, result.getSource());
+        assertNotNull(result.getExperiment());
+        assertEquals("APX-123", result.getExperiment().getCustomField("cfl_ticket"));
+        assertEquals("growth", result.getExperiment().getCustomField("cfl_owner"));
     }
 
     @Test


### PR DESCRIPTION
## Summary

Adds support for GrowthBook experiment `customFields` in the Java SDK.

## Changes

- Added `customFields` to `Experiment` so custom fields from GrowthBook API payloads are preserved.
- Added helper methods on `Experiment`:
  - `getCustomField(String fieldId)`
  - `getCustomField(String fieldId, Class<T> fieldType)`
  - `hasCustomField(String fieldId)`
- Added `customFields` to `FeatureRule` and its custom Gson deserializer.
- Propagated `customFields` from feature rules into the `Experiment` object returned by feature evaluation.
- Fixed generic builder inference in `FeatureRule.deserialize` with `FeatureRule.<ValueType>builder()`.
- Kept deprecated `Namespace` support untouched for backward compatibility.
