### PR TITLE
Fix!: Update OkHttp dependencies to version 5.4.0

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -53,9 +53,9 @@ dependencies {
 
 
     // https://square.github.io/okhttp
-    implementation 'com.squareup.okhttp3:okhttp:4.11.0'
+    implementation 'com.squareup.okhttp3:okhttp:5.4.0'
     // https://mvnrepository.com/artifact/com.squareup.okhttp3/okhttp-sse
-    implementation 'com.squareup.okhttp3:okhttp-sse:4.11.0'
+    implementation 'com.squareup.okhttp3:okhttp-sse:5.4.0'
 
     // Adds getter, setter and builder boilerplate
     // https://projectlombok.org/


### PR DESCRIPTION
This pull request updates the versions of the OkHttp and OkHttp-SSE dependencies to ensure the project uses the latest features and security patches.

Dependency updates:

* Upgraded `okhttp` from version 4.11.0 to 5.4.0 in `lib/build.gradle`.
* Upgraded `okhttp-sse` from version 4.11.0 to 5.4.0 in `lib/build.gradle`.