### PR TITLE
feat: add diagnostics API

### DIFF
--- a/lib/src/main/java/growthbook/sdk/java/constants/SDKConstants.java
+++ b/lib/src/main/java/growthbook/sdk/java/constants/SDKConstants.java
@@ -1,0 +1,19 @@
+package growthbook.sdk.java.constants;
+
+import lombok.experimental.UtilityClass;
+
+/**
+ * Shared SDK constants used across repository, refresh, and diagnostics code.
+ */
+@UtilityClass
+public class SDKConstants {
+    public static final int DEFAULT_SWR_TTL_SECONDS = 60;
+
+    @UtilityClass
+    public class Endpoints {
+        public static final String STREAMING_ENDPOINT_PATH = "/sub/";
+        public static final String FEATURES_ENDPOINT_PATH = "/api/features/";
+        public static final String DEFAULT_API_HOST = "https://cdn.growthbook.io";
+        public static final String FEATURES_ENDPOINT_PATTERN = ".*" + FEATURES_ENDPOINT_PATH + "[^/]+";
+    }
+}

--- a/lib/src/main/java/growthbook/sdk/java/diagnostics/model/CacheDiagnostics.java
+++ b/lib/src/main/java/growthbook/sdk/java/diagnostics/model/CacheDiagnostics.java
@@ -1,0 +1,42 @@
+package growthbook.sdk.java.diagnostics.model;
+
+import growthbook.sdk.java.diagnostics.model.enums.CacheState;
+import growthbook.sdk.java.sandbox.CacheMode;
+
+import javax.annotation.Nullable;
+
+import lombok.Builder;
+import lombok.Value;
+
+/**
+ * Feature cache metadata.
+ */
+@Value
+@Builder
+public class CacheDiagnostics {
+    /**
+     * Derived cache state for support/debugging flows.
+     */
+    CacheState state;
+
+    /**
+     * Configured cache mode from client options.
+     */
+    CacheMode mode;
+
+    /**
+     * Whether feature cache persistence is enabled for the active repository/configuration.
+     */
+    boolean enabled;
+
+    /**
+     * Epoch-millis timestamp of the last cache update, or {@code 0} when unavailable.
+     */
+    long lastUpdatedMillis;
+
+    /**
+     * Age in milliseconds since the last cache update.
+     */
+    @Nullable
+    Long ageMillis;
+}

--- a/lib/src/main/java/growthbook/sdk/java/diagnostics/model/ClientDiagnostics.java
+++ b/lib/src/main/java/growthbook/sdk/java/diagnostics/model/ClientDiagnostics.java
@@ -1,0 +1,26 @@
+package growthbook.sdk.java.diagnostics.model;
+
+import lombok.Builder;
+import lombok.Value;
+
+/**
+ * Client lifecycle metadata.
+ */
+@Value
+@Builder
+public class ClientDiagnostics {
+    /**
+     * Whether the client is ready for evaluations.
+     */
+    boolean initialized;
+
+    /**
+     * Whether client-owned background resources have been shut down.
+     */
+    boolean shutdown;
+
+    /**
+     * Whether the client is configured to use remote evaluation.
+     */
+    boolean remoteEvalEnabled;
+}

--- a/lib/src/main/java/growthbook/sdk/java/diagnostics/model/ConfigDiagnostics.java
+++ b/lib/src/main/java/growthbook/sdk/java/diagnostics/model/ConfigDiagnostics.java
@@ -1,0 +1,72 @@
+package growthbook.sdk.java.diagnostics.model;
+
+import javax.annotation.Nullable;
+
+import lombok.Builder;
+import lombok.Value;
+
+/**
+ * Sanitized SDK configuration metadata.
+ */
+@Value
+@Builder
+public class ConfigDiagnostics {
+    /**
+     * Effective API host used by the feature repository.
+     */
+    String apiHost;
+
+    /**
+     * Feature endpoint with the client key masked.
+     */
+    @Nullable
+    String featuresEndpoint;
+
+    /**
+     * Streaming endpoint with the client key masked.
+     */
+    @Nullable
+    String eventsEndpoint;
+
+    /**
+     * Masked GrowthBook client key.
+     */
+    @Nullable
+    String clientKeyMasked;
+
+    /**
+     * Whether encrypted feature payloads are configured. Secret values are never exposed.
+     */
+    boolean encryptionConfigured;
+
+    /**
+     * Stale-while-revalidate TTL in seconds.
+     */
+    int swrTtlSeconds;
+
+    /**
+     * Optional minimum interval between background refreshes, in milliseconds.
+     */
+    @Nullable
+    Long backgroundFetchIntervalMillis;
+
+    /**
+     * Maximum number of feature fetch attempts, including the first attempt.
+     */
+    int retryMaxAttempts;
+
+    /**
+     * Whether evaluations are globally enabled.
+     */
+    boolean enabled;
+
+    /**
+     * Whether QA mode is enabled.
+     */
+    boolean qaMode;
+
+    /**
+     * Whether a sticky bucketing service is configured.
+     */
+    boolean stickyBucketingEnabled;
+}

--- a/lib/src/main/java/growthbook/sdk/java/diagnostics/model/Diagnostics.java
+++ b/lib/src/main/java/growthbook/sdk/java/diagnostics/model/Diagnostics.java
@@ -1,0 +1,70 @@
+package growthbook.sdk.java.diagnostics.model;
+
+import growthbook.sdk.java.util.GrowthBookJsonUtils;
+
+import lombok.Builder;
+import lombok.Value;
+
+/**
+ * Read-only snapshot of the current SDK state.
+ */
+@Value
+@Builder
+public class Diagnostics {
+    /**
+     * Epoch-millis timestamp when this diagnostics snapshot was generated.
+     */
+    long generatedAtMillis;
+
+    /**
+     * SDK build metadata.
+     */
+    SdkDiagnostics sdk;
+
+    /**
+     * High-level health summary with actionable issues.
+     */
+    HealthDiagnostics health;
+
+    /**
+     * Sanitized configuration metadata.
+     */
+    ConfigDiagnostics config;
+
+    /**
+     * Client lifecycle metadata.
+     */
+    ClientDiagnostics client;
+
+    /**
+     * Current feature data metadata.
+     */
+    FeatureDiagnostics features;
+
+    /**
+     * Feature refresh metadata.
+     */
+    RefreshDiagnostics refresh;
+
+    /**
+     * Feature cache metadata.
+     */
+    CacheDiagnostics cache;
+
+    /**
+     * Streaming refresh metadata.
+     */
+    StreamingDiagnostics streaming;
+
+    /**
+     * Remote-eval metadata.
+     */
+    RemoteEvalDiagnostics remoteEval;
+
+    /**
+     * Serializes this SDK-produced diagnostics snapshot as JSON for support/debugging workflows.
+     */
+    public String toJson() {
+        return GrowthBookJsonUtils.getInstance().gson.toJson(this);
+    }
+}

--- a/lib/src/main/java/growthbook/sdk/java/diagnostics/model/DiagnosticsIssue.java
+++ b/lib/src/main/java/growthbook/sdk/java/diagnostics/model/DiagnosticsIssue.java
@@ -1,0 +1,33 @@
+package growthbook.sdk.java.diagnostics.model;
+
+import growthbook.sdk.java.diagnostics.model.enums.DiagnosticsIssueCode;
+import growthbook.sdk.java.diagnostics.model.enums.DiagnosticsIssueSeverity;
+import lombok.Builder;
+import lombok.Value;
+
+/**
+ * Actionable diagnostics issue derived from the raw SDK state snapshot.
+ */
+@Value
+@Builder
+public class DiagnosticsIssue {
+    /**
+     * Stable machine-readable issue code.
+     */
+    DiagnosticsIssueCode code;
+
+    /**
+     * Issue severity for support and alerting flows.
+     */
+    DiagnosticsIssueSeverity severity;
+
+    /**
+     * Human-readable issue summary.
+     */
+    String message;
+
+    /**
+     * Epoch-millis timestamp when the diagnostics snapshot was generated.
+     */
+    long timestampMillis;
+}

--- a/lib/src/main/java/growthbook/sdk/java/diagnostics/model/ErrorDiagnostics.java
+++ b/lib/src/main/java/growthbook/sdk/java/diagnostics/model/ErrorDiagnostics.java
@@ -1,0 +1,34 @@
+package growthbook.sdk.java.diagnostics.model;
+
+import javax.annotation.Nullable;
+
+import lombok.Builder;
+import lombok.Value;
+
+/**
+ * Sanitized error metadata for diagnostics output.
+ */
+@Value
+@Builder
+public class ErrorDiagnostics {
+    /**
+     * Simple class name for the captured error.
+     */
+    String type;
+
+    /**
+     * SDK error code when the error exposes one.
+     */
+    @Nullable
+    String code;
+
+    /**
+     * Sanitized error message.
+     */
+    String message;
+
+    /**
+     * Epoch-millis timestamp when the error was captured.
+     */
+    long timestampMillis;
+}

--- a/lib/src/main/java/growthbook/sdk/java/diagnostics/model/FeatureDiagnostics.java
+++ b/lib/src/main/java/growthbook/sdk/java/diagnostics/model/FeatureDiagnostics.java
@@ -1,0 +1,43 @@
+package growthbook.sdk.java.diagnostics.model;
+
+import growthbook.sdk.java.diagnostics.model.enums.FeatureDataSource;
+import growthbook.sdk.java.diagnostics.model.enums.FeatureState;
+import lombok.Builder;
+import lombok.Value;
+
+/**
+ * Current feature state metadata.
+ */
+@Value
+@Builder
+public class FeatureDiagnostics {
+    /**
+     * Derived feature data state.
+     */
+    FeatureState state;
+
+    /**
+     * Source used to report feature diagnostics.
+     */
+    FeatureDataSource source;
+
+    /**
+     * Whether feature data is currently available for evaluations.
+     */
+    boolean available;
+
+    /**
+     * Number of active feature definitions in the current snapshot.
+     */
+    int activeFeatureCount;
+
+    /**
+     * Total number of feature definitions visible to diagnostics.
+     */
+    int totalFeatureCount;
+
+    /**
+     * Feature key metadata for the current snapshot.
+     */
+    FeatureKeyDiagnostics keys;
+}

--- a/lib/src/main/java/growthbook/sdk/java/diagnostics/model/FeatureKeyDiagnostics.java
+++ b/lib/src/main/java/growthbook/sdk/java/diagnostics/model/FeatureKeyDiagnostics.java
@@ -1,0 +1,45 @@
+package growthbook.sdk.java.diagnostics.model;
+
+import javax.annotation.Nullable;
+import java.util.List;
+
+import lombok.Builder;
+import lombok.Value;
+
+/**
+ * Diagnostics metadata for feature keys in the current snapshot.
+ */
+@Value
+@Builder
+public class FeatureKeyDiagnostics {
+    /**
+     * Whether feature keys were available to inspect.
+     */
+    boolean available;
+
+    /**
+     * Total number of feature keys in the inspected snapshot.
+     */
+    int totalCount;
+
+    /**
+     * Maximum number of keys included in {@link #sample}.
+     */
+    int sampleLimit;
+
+    /**
+     * Stable, sorted sample of feature keys.
+     */
+    List<String> sample;
+
+    /**
+     * Whether the key list was truncated to fit the sample limit.
+     */
+    boolean truncated;
+
+    /**
+     * SHA-256 hash of the sorted feature keys, or {@code null} when keys are unavailable.
+     */
+    @Nullable
+    String sha256;
+}

--- a/lib/src/main/java/growthbook/sdk/java/diagnostics/model/HealthDiagnostics.java
+++ b/lib/src/main/java/growthbook/sdk/java/diagnostics/model/HealthDiagnostics.java
@@ -1,0 +1,24 @@
+package growthbook.sdk.java.diagnostics.model;
+
+import java.util.List;
+
+import growthbook.sdk.java.diagnostics.model.enums.DiagnosticsHealthState;
+import lombok.Builder;
+import lombok.Value;
+
+/**
+ * High-level health summary derived from all diagnostics sections.
+ */
+@Value
+@Builder
+public class HealthDiagnostics {
+    /**
+     * High-level SDK health state.
+     */
+    DiagnosticsHealthState state;
+
+    /**
+     * Actionable issues detected in the current snapshot.
+     */
+    List<DiagnosticsIssue> issues;
+}

--- a/lib/src/main/java/growthbook/sdk/java/diagnostics/model/RefreshDiagnostics.java
+++ b/lib/src/main/java/growthbook/sdk/java/diagnostics/model/RefreshDiagnostics.java
@@ -1,0 +1,82 @@
+package growthbook.sdk.java.diagnostics.model;
+
+import growthbook.sdk.java.repository.FeatureRefreshStrategy;
+
+import javax.annotation.Nullable;
+
+import lombok.Builder;
+import lombok.Value;
+
+/**
+ * Feature refresh metadata.
+ */
+@Value
+@Builder
+public class RefreshDiagnostics {
+    /**
+     * Active feature refresh strategy.
+     */
+    FeatureRefreshStrategy strategy;
+
+    /**
+     * Epoch-millis timestamp of the last successful feature refresh.
+     */
+    @Nullable
+    Long lastSuccessfulRefreshAtMillis;
+
+    /**
+     * Age in milliseconds since the last successful feature refresh.
+     */
+    @Nullable
+    Long lastSuccessfulRefreshAgeMillis;
+
+    /**
+     * Epoch-millis timestamp when the current feature cache expires.
+     */
+    @Nullable
+    Long nextCacheExpiresAtMillis;
+
+    /**
+     * Milliseconds until the current cache expires. Negative values mean it is already stale.
+     */
+    @Nullable
+    Long millisUntilCacheExpiry;
+
+    /**
+     * Whether the current feature data is past its cache expiry.
+     */
+    boolean stale;
+
+    /**
+     * Number of successful refresh events observed by the active repository.
+     */
+    long successCount;
+
+    /**
+     * Number of failed refresh events observed by the active repository.
+     */
+    long failureCount;
+
+    /**
+     * Number of failed refresh events since the last successful refresh event.
+     */
+    long consecutiveFailures;
+
+    /**
+     * Epoch-millis timestamp of the last failed refresh event.
+     */
+    @Nullable
+    Long lastFailureAtMillis;
+
+    /**
+     * Whether the last refresh event loaded feature data from cache.
+     */
+    @Nullable
+    Boolean lastLoadedFromCache;
+
+    /**
+     * Most recent refresh/init error, sanitized for diagnostics output.
+     */
+    @Nullable
+    ErrorDiagnostics lastError;
+}

--- a/lib/src/main/java/growthbook/sdk/java/diagnostics/model/RemoteEvalDiagnostics.java
+++ b/lib/src/main/java/growthbook/sdk/java/diagnostics/model/RemoteEvalDiagnostics.java
@@ -1,0 +1,39 @@
+package growthbook.sdk.java.diagnostics.model;
+
+import javax.annotation.Nullable;
+
+import lombok.Builder;
+import lombok.Value;
+
+/**
+ * Remote evaluation metadata.
+ */
+@Value
+@Builder
+public class RemoteEvalDiagnostics {
+    /**
+     * Whether remote evaluation is enabled by configuration.
+     */
+    boolean enabled;
+
+    /**
+     * Whether remote-eval services are initialized and ready.
+     */
+    boolean ready;
+
+    /**
+     * Whether the remote-eval response cache has been created.
+     */
+    boolean cacheConfigured;
+
+    /**
+     * Configured maximum number of cached remote-eval responses.
+     */
+    int cacheMaxSize;
+
+    /**
+     * Configured hard TTL in seconds for remote-eval cache entries.
+     */
+    @Nullable
+    Integer cacheTtlSeconds;
+}

--- a/lib/src/main/java/growthbook/sdk/java/diagnostics/model/SdkDiagnostics.java
+++ b/lib/src/main/java/growthbook/sdk/java/diagnostics/model/SdkDiagnostics.java
@@ -1,0 +1,16 @@
+package growthbook.sdk.java.diagnostics.model;
+
+import lombok.Builder;
+import lombok.Value;
+
+/**
+ * SDK build metadata.
+ */
+@Value
+@Builder
+public class SdkDiagnostics {
+    /**
+     * SDK version string.
+     */
+    String version;
+}

--- a/lib/src/main/java/growthbook/sdk/java/diagnostics/model/StreamingDiagnostics.java
+++ b/lib/src/main/java/growthbook/sdk/java/diagnostics/model/StreamingDiagnostics.java
@@ -1,0 +1,22 @@
+package growthbook.sdk.java.diagnostics.model;
+
+import growthbook.sdk.java.diagnostics.model.enums.StreamingState;
+import lombok.Builder;
+import lombok.Value;
+
+/**
+ * Streaming refresh connection metadata.
+ */
+@Value
+@Builder
+public class StreamingDiagnostics {
+    /**
+     * Derived streaming connection state.
+     */
+    StreamingState state;
+
+    /**
+     * Current number of scheduled/attempted streaming reconnects.
+     */
+    int reconnectAttempts;
+}

--- a/lib/src/main/java/growthbook/sdk/java/diagnostics/model/enums/CacheState.java
+++ b/lib/src/main/java/growthbook/sdk/java/diagnostics/model/enums/CacheState.java
@@ -1,0 +1,26 @@
+package growthbook.sdk.java.diagnostics.model.enums;
+
+/**
+ * Derived feature cache state.
+ */
+public enum CacheState {
+    /**
+     * Cache persistence is disabled by configuration.
+     */
+    DISABLED,
+
+    /**
+     * Cache could be enabled, but the feature repository has not been initialized yet.
+     */
+    NOT_INITIALIZED,
+
+    /**
+     * Cache is enabled and exposes a last-updated timestamp.
+     */
+    AVAILABLE,
+
+    /**
+     * Cache is enabled, but its last-updated timestamp is unavailable.
+     */
+    UNKNOWN
+}

--- a/lib/src/main/java/growthbook/sdk/java/diagnostics/model/enums/DiagnosticsHealthState.java
+++ b/lib/src/main/java/growthbook/sdk/java/diagnostics/model/enums/DiagnosticsHealthState.java
@@ -1,0 +1,31 @@
+package growthbook.sdk.java.diagnostics.model.enums;
+
+/**
+ * Derived high-level SDK health state.
+ */
+public enum DiagnosticsHealthState {
+    /**
+     * The client is initialized and no actionable diagnostics issues were detected.
+     */
+    READY,
+
+    /**
+     * The client has not finished initialization yet.
+     */
+    NOT_READY,
+
+    /**
+     * The client can still evaluate, but at least one supporting subsystem is degraded.
+     */
+    DEGRADED,
+
+    /**
+     * The client is in an error state that can affect evaluations.
+     */
+    ERROR,
+
+    /**
+     * The client has been shut down.
+     */
+    SHUTDOWN
+}

--- a/lib/src/main/java/growthbook/sdk/java/diagnostics/model/enums/DiagnosticsIssueCode.java
+++ b/lib/src/main/java/growthbook/sdk/java/diagnostics/model/enums/DiagnosticsIssueCode.java
@@ -1,0 +1,66 @@
+package growthbook.sdk.java.diagnostics.model.enums;
+
+/**
+ * Stable machine-readable diagnostics issue codes.
+ */
+public enum DiagnosticsIssueCode {
+    /**
+     * The client has not completed initialization.
+     */
+    CLIENT_NOT_INITIALIZED,
+
+    /**
+     * The client has been shut down.
+     */
+    CLIENT_SHUTDOWN,
+
+    /**
+     * Local feature data is required but not currently loaded.
+     */
+    FEATURES_NOT_LOADED,
+
+    /**
+     * Feature data is loaded but contains no feature definitions.
+     */
+    FEATURES_EMPTY,
+
+    /**
+     * The most recent feature refresh or initialization attempt failed.
+     */
+    REFRESH_FAILED,
+
+    /**
+     * Cache persistence is enabled but cache state cannot be inspected.
+     */
+    CACHE_STATE_UNKNOWN,
+
+    /**
+     * Streaming refresh is configured but not supported by the server response.
+     */
+    STREAMING_UNSUPPORTED,
+
+    /**
+     * Streaming refresh is configured and supported, but is currently reconnecting.
+     */
+    STREAMING_INTERRUPTED,
+
+    /**
+     * Remote evaluation is configured but not ready.
+     */
+    REMOTE_EVAL_NOT_READY,
+
+    /**
+     * Feature data is loaded but past its cache expiry.
+     */
+    FEATURES_STALE,
+
+    /**
+     * SDK evaluations are globally disabled by configuration.
+     */
+    SDK_DISABLED,
+
+    /**
+     * QA mode is enabled by configuration.
+     */
+    QA_MODE_ENABLED
+}

--- a/lib/src/main/java/growthbook/sdk/java/diagnostics/model/enums/DiagnosticsIssueSeverity.java
+++ b/lib/src/main/java/growthbook/sdk/java/diagnostics/model/enums/DiagnosticsIssueSeverity.java
@@ -1,0 +1,21 @@
+package growthbook.sdk.java.diagnostics.model.enums;
+
+/**
+ * Diagnostics issue severity levels.
+ */
+public enum DiagnosticsIssueSeverity {
+    /**
+     * Informational state that is usually not actionable.
+     */
+    INFO,
+
+    /**
+     * Degraded behavior that should be investigated.
+     */
+    WARNING,
+
+    /**
+     * Error state that can affect evaluations or refresh behavior.
+     */
+    ERROR
+}

--- a/lib/src/main/java/growthbook/sdk/java/diagnostics/model/enums/FeatureDataSource.java
+++ b/lib/src/main/java/growthbook/sdk/java/diagnostics/model/enums/FeatureDataSource.java
@@ -1,0 +1,21 @@
+package growthbook.sdk.java.diagnostics.model.enums;
+
+/**
+ * Source used to report feature diagnostics.
+ */
+public enum FeatureDataSource {
+    /**
+     * No feature source is currently available.
+     */
+    NONE,
+
+    /**
+     * Feature data comes from the local feature repository.
+     */
+    LOCAL_REPOSITORY,
+
+    /**
+     * Feature data represents the remote-eval fallback context.
+     */
+    REMOTE_EVAL_FALLBACK
+}

--- a/lib/src/main/java/growthbook/sdk/java/diagnostics/model/enums/FeatureState.java
+++ b/lib/src/main/java/growthbook/sdk/java/diagnostics/model/enums/FeatureState.java
@@ -1,0 +1,21 @@
+package growthbook.sdk.java.diagnostics.model.enums;
+
+/**
+ * Derived feature data state.
+ */
+public enum FeatureState {
+    /**
+     * No feature data has been loaded.
+     */
+    NOT_LOADED,
+
+    /**
+     * Feature data has been loaded, but it contains no feature definitions.
+     */
+    LOADED_EMPTY,
+
+    /**
+     * Feature data has been loaded and contains feature definitions.
+     */
+    LOADED
+}

--- a/lib/src/main/java/growthbook/sdk/java/diagnostics/model/enums/StreamingState.java
+++ b/lib/src/main/java/growthbook/sdk/java/diagnostics/model/enums/StreamingState.java
@@ -1,0 +1,36 @@
+package growthbook.sdk.java.diagnostics.model.enums;
+
+/**
+ * Derived streaming connection state.
+ */
+public enum StreamingState {
+    /**
+     * Streaming is not configured.
+     */
+    DISABLED,
+
+    /**
+     * Client resources have been shut down.
+     */
+    SHUTDOWN,
+
+    /**
+     * Streaming is configured but not yet fully connected or classified.
+     */
+    INITIALIZING,
+
+    /**
+     * Streaming is configured, supported, and connected.
+     */
+    CONNECTED,
+
+    /**
+     * Streaming was connected/supported and is currently reconnecting.
+     */
+    INTERRUPTED,
+
+    /**
+     * Streaming is configured but the server did not allow SSE.
+     */
+    UNSUPPORTED
+}

--- a/lib/src/main/java/growthbook/sdk/java/diagnostics/provider/DiagnosticsProvider.java
+++ b/lib/src/main/java/growthbook/sdk/java/diagnostics/provider/DiagnosticsProvider.java
@@ -1,0 +1,10 @@
+package growthbook.sdk.java.diagnostics.provider;
+
+import growthbook.sdk.java.diagnostics.model.Diagnostics;
+
+/**
+ * Provides read-only diagnostic snapshots.
+ */
+public interface DiagnosticsProvider {
+    Diagnostics getDiagnostics();
+}

--- a/lib/src/main/java/growthbook/sdk/java/diagnostics/provider/GrowthBookClientDiagnosticsProvider.java
+++ b/lib/src/main/java/growthbook/sdk/java/diagnostics/provider/GrowthBookClientDiagnosticsProvider.java
@@ -1,0 +1,363 @@
+package growthbook.sdk.java.diagnostics.provider;
+
+import growthbook.sdk.java.constants.SDKConstants;
+import growthbook.sdk.java.Version;
+import growthbook.sdk.java.diagnostics.model.CacheDiagnostics;
+import growthbook.sdk.java.diagnostics.model.enums.CacheState;
+import growthbook.sdk.java.diagnostics.model.ClientDiagnostics;
+import growthbook.sdk.java.diagnostics.model.ConfigDiagnostics;
+import growthbook.sdk.java.diagnostics.model.Diagnostics;
+import growthbook.sdk.java.diagnostics.model.ErrorDiagnostics;
+import growthbook.sdk.java.diagnostics.model.enums.FeatureDataSource;
+import growthbook.sdk.java.diagnostics.model.FeatureDiagnostics;
+import growthbook.sdk.java.diagnostics.model.HealthDiagnostics;
+import growthbook.sdk.java.diagnostics.model.RefreshDiagnostics;
+import growthbook.sdk.java.diagnostics.model.RemoteEvalDiagnostics;
+import growthbook.sdk.java.diagnostics.model.SdkDiagnostics;
+import growthbook.sdk.java.diagnostics.model.StreamingDiagnostics;
+import growthbook.sdk.java.diagnostics.provider.helper.ConfigDiagnosticsMapper;
+import growthbook.sdk.java.diagnostics.provider.helper.DiagnosticsHealthResolver;
+import growthbook.sdk.java.diagnostics.provider.helper.DiagnosticsSecretMasker;
+import growthbook.sdk.java.diagnostics.provider.helper.ErrorDiagnosticsMapper;
+import growthbook.sdk.java.diagnostics.provider.helper.FeatureDiagnosticsMapper;
+import growthbook.sdk.java.diagnostics.provider.helper.StreamingStateResolveHelper;
+import growthbook.sdk.java.diagnostics.provider.model.DiagnosticsCollectionContext;
+import growthbook.sdk.java.diagnostics.provider.model.DiagnosticsSnapshot;
+import growthbook.sdk.java.diagnostics.provider.model.StreamingStatusSnapshot;
+import growthbook.sdk.java.multiusermode.configurations.Options;
+import growthbook.sdk.java.repository.FeatureRefreshStrategy;
+import growthbook.sdk.java.repository.GBFeaturesRepository;
+import growthbook.sdk.java.sandbox.CacheMode;
+
+import javax.annotation.Nullable;
+
+/**
+ * Provides read-only diagnostic snapshots from a multi-user {@code GrowthBookClient}.
+ */
+public final class GrowthBookClientDiagnosticsProvider implements DiagnosticsProvider {
+
+    /**
+     * Read-only view over the client state required to build diagnostics snapshots.
+     */
+    public interface ClientState {
+
+        @Nullable
+        GBFeaturesRepository currentRepository();
+
+        @Nullable
+        Throwable lastInitializationError();
+
+        long lastInitializationErrorAtMillis();
+
+        boolean isRemoteEvalReady();
+
+        boolean isShutdown();
+
+        boolean isRemoteEvalCacheConfigured();
+
+        int fallbackFeatureCount();
+    }
+
+    private final Options options;
+    private final ClientState clientState;
+    private final ErrorDiagnosticsMapper errorDiagnosticsMapper = new ErrorDiagnosticsMapper();
+    private final ConfigDiagnosticsMapper configDiagnosticsMapper = new ConfigDiagnosticsMapper();
+    private final FeatureDiagnosticsMapper featureDiagnosticsMapper = new FeatureDiagnosticsMapper();
+    private final DiagnosticsHealthResolver diagnosticsHealthResolver = new DiagnosticsHealthResolver();
+    private final StreamingStateResolveHelper streamingStateResolver = new StreamingStateResolveHelper();
+
+    public GrowthBookClientDiagnosticsProvider(Options options, ClientState clientState) {
+        this.options = options;
+        this.clientState = clientState;
+    }
+
+    @Override
+    public Diagnostics getDiagnostics() {
+        DiagnosticsSnapshot snapshot = collectSnapshot(collectionContext());
+        return diagnostics(snapshot);
+    }
+
+    private DiagnosticsCollectionContext collectionContext() {
+        GBFeaturesRepository repository = this.clientState.currentRepository();
+        return DiagnosticsCollectionContext.builder()
+                .generatedAtMillis(System.currentTimeMillis())
+                .repository(repository)
+                .secretMasker(DiagnosticsSecretMasker.from(this.options, repository))
+                .build();
+    }
+
+    private DiagnosticsSnapshot collectSnapshot(DiagnosticsCollectionContext context) {
+        GBFeaturesRepository repository = context.getRepository();
+
+        return DiagnosticsSnapshot.builder()
+                .generatedAtMillis(context.getGeneratedAtMillis())
+                .config(configDiagnostics(repository))
+                .client(clientDiagnostics(repository))
+                .features(featureDiagnostics(repository))
+                .refresh(refreshDiagnostics(context))
+                .cache(cacheDiagnostics(context))
+                .streaming(streamingDiagnostics(repository))
+                .remoteEval(remoteEvalDiagnostics())
+                .build();
+    }
+
+    private Diagnostics diagnostics(DiagnosticsSnapshot snapshot) {
+        return Diagnostics.builder()
+                .generatedAtMillis(snapshot.getGeneratedAtMillis())
+                .sdk(sdkDiagnostics())
+                .health(healthDiagnostics(snapshot))
+                .config(snapshot.getConfig())
+                .client(snapshot.getClient())
+                .features(snapshot.getFeatures())
+                .refresh(snapshot.getRefresh())
+                .cache(snapshot.getCache())
+                .streaming(snapshot.getStreaming())
+                .remoteEval(snapshot.getRemoteEval())
+                .build();
+    }
+
+    private HealthDiagnostics healthDiagnostics(DiagnosticsSnapshot snapshot) {
+        return this.diagnosticsHealthResolver.resolve(snapshot);
+    }
+
+    private ConfigDiagnostics configDiagnostics(GBFeaturesRepository repository) {
+        return this.configDiagnosticsMapper.map(this.options, repository);
+    }
+
+    private SdkDiagnostics sdkDiagnostics() {
+        return SdkDiagnostics.builder()
+                .version(Version.SDK_VERSION)
+                .build();
+    }
+
+    private ClientDiagnostics clientDiagnostics(GBFeaturesRepository repository) {
+        boolean remoteEvalEnabled = this.options.isRemoteEvalEnabled();
+        boolean initialized = remoteEvalEnabled
+                ? this.clientState.isRemoteEvalReady()
+                : repository != null && Boolean.TRUE.equals(repository.getInitialized());
+
+        return ClientDiagnostics.builder()
+                .initialized(initialized)
+                .shutdown(this.clientState.isShutdown())
+                .remoteEvalEnabled(remoteEvalEnabled)
+                .build();
+    }
+
+    private FeatureDiagnostics featureDiagnostics(GBFeaturesRepository repository) {
+        if (this.options.isRemoteEvalEnabled()) {
+            int fallbackFeatureCount = this.clientState.fallbackFeatureCount();
+            return this.featureDiagnosticsMapper.fromCount(
+                    FeatureDataSource.REMOTE_EVAL_FALLBACK,
+                    fallbackFeatureCount > 0,
+                    fallbackFeatureCount
+            );
+        }
+
+        if (repository != null) {
+            return this.featureDiagnosticsMapper.fromFeatureMap(
+                    FeatureDataSource.LOCAL_REPOSITORY,
+                    repository.hasFeatureData(),
+                    repository.getActiveFeatureCount(),
+                    repository.getParsedFeatures()
+            );
+        }
+
+        return this.featureDiagnosticsMapper.unavailable();
+    }
+
+    private RefreshDiagnostics refreshDiagnostics(DiagnosticsCollectionContext context) {
+        GBFeaturesRepository repository = context.getRepository();
+        long generatedAtMillis = context.getGeneratedAtMillis();
+        Long lastSuccessfulRefreshAtMillis = lastSuccessfulRefreshAtMillis(repository);
+        Boolean lastLoadedFromCache = lastRefreshLoadedFromCache(repository);
+        Long nextCacheExpiresAtMillis = nextCacheExpiresAtMillis(repository, lastLoadedFromCache);
+        Long millisUntilCacheExpiry = millisUntil(nextCacheExpiresAtMillis, generatedAtMillis);
+
+        return RefreshDiagnostics.builder()
+                .strategy(refreshStrategy(repository))
+                .lastSuccessfulRefreshAtMillis(lastSuccessfulRefreshAtMillis)
+                .lastSuccessfulRefreshAgeMillis(ageMillis(lastSuccessfulRefreshAtMillis, generatedAtMillis))
+                .nextCacheExpiresAtMillis(nextCacheExpiresAtMillis)
+                .millisUntilCacheExpiry(millisUntilCacheExpiry)
+                .stale(millisUntilCacheExpiry != null && millisUntilCacheExpiry < 0)
+                .successCount(refreshSuccessCount(repository))
+                .failureCount(refreshFailureCount(repository))
+                .consecutiveFailures(refreshConsecutiveFailures(repository))
+                .lastFailureAtMillis(lastRefreshFailureAtMillis(repository))
+                .lastLoadedFromCache(lastLoadedFromCache)
+                .lastError(lastRefreshError(repository, context.getSecretMasker()))
+                .build();
+    }
+
+    private CacheDiagnostics cacheDiagnostics(DiagnosticsCollectionContext context) {
+        GBFeaturesRepository repository = context.getRepository();
+        boolean cacheEnabled = cacheEnabled(repository);
+        Long lastUpdatedMillis = cacheLastUpdatedMillis(repository);
+
+        return CacheDiagnostics.builder()
+                .state(cacheState(repository, cacheEnabled, lastUpdatedMillis))
+                .enabled(cacheEnabled)
+                .mode(this.options.getCacheMode())
+                .lastUpdatedMillis(timestampOrUnknown(lastUpdatedMillis))
+                .ageMillis(ageMillis(lastUpdatedMillis, context.getGeneratedAtMillis()))
+                .build();
+    }
+
+    private Long lastSuccessfulRefreshAtMillis(GBFeaturesRepository repository) {
+        if (repository == null) {
+            return null;
+        }
+        return zeroAsNull(repository.getLastSuccessfulFetchAtMillis());
+    }
+
+    private Long nextCacheExpiresAtMillis(GBFeaturesRepository repository, Boolean lastLoadedFromCache) {
+        if (Boolean.TRUE.equals(lastLoadedFromCache)) {
+            Long cacheLastUpdatedMillis = cacheLastUpdatedMillis(repository);
+            if (cacheLastUpdatedMillis != null && cacheLastUpdatedMillis > 0) {
+                return cacheLastUpdatedMillis + swrTtlMillis(repository);
+            }
+        }
+        if (repository == null || repository.getExpiresAt() == null) {
+            return null;
+        }
+        return repository.getExpiresAt() * 1000L;
+    }
+
+    private long swrTtlMillis(GBFeaturesRepository repository) {
+        Integer ttlSeconds = repository == null ? this.options.getSwrTtlSeconds() : repository.getSwrTtlSeconds();
+        int resolvedTtlSeconds = ttlSeconds == null ? SDKConstants.DEFAULT_SWR_TTL_SECONDS : ttlSeconds;
+        return resolvedTtlSeconds * 1000L;
+    }
+
+    private long refreshSuccessCount(GBFeaturesRepository repository) {
+        return repository == null ? 0L : repository.getRefreshSuccessCount();
+    }
+
+    private long refreshFailureCount(GBFeaturesRepository repository) {
+        return repository == null ? 0L : repository.getRefreshFailureCount();
+    }
+
+    private long refreshConsecutiveFailures(GBFeaturesRepository repository) {
+        return repository == null ? 0L : repository.getRefreshConsecutiveFailureCount();
+    }
+
+    private Long lastRefreshFailureAtMillis(GBFeaturesRepository repository) {
+        if (repository == null) {
+            return null;
+        }
+        return zeroAsNull(repository.getLastRefreshFailureAtMillis());
+    }
+
+    private Boolean lastRefreshLoadedFromCache(GBFeaturesRepository repository) {
+        return repository == null ? null : repository.getLastRefreshLoadedFromCache();
+    }
+
+    private boolean cacheEnabled(GBFeaturesRepository repository) {
+        if (repository == null) {
+            return !Boolean.TRUE.equals(this.options.getIsCacheDisabled())
+                    && this.options.getCacheMode() != CacheMode.NONE;
+        }
+        return !repository.isCacheDisabled();
+    }
+
+    private Long cacheLastUpdatedMillis(GBFeaturesRepository repository) {
+        if (repository == null) {
+            return null;
+        }
+        return repository.getCacheLastUpdatedMillis();
+    }
+
+    private CacheState cacheState(GBFeaturesRepository repository, boolean cacheEnabled, Long lastUpdatedMillis) {
+        if (!cacheEnabled) {
+            return CacheState.DISABLED;
+        }
+        if (repository == null) {
+            return CacheState.NOT_INITIALIZED;
+        }
+        if (lastUpdatedMillis != null && lastUpdatedMillis > 0) {
+            return CacheState.AVAILABLE;
+        }
+        return CacheState.UNKNOWN;
+    }
+
+    private StreamingDiagnostics streamingDiagnostics(GBFeaturesRepository repository) {
+        StreamingStatusSnapshot streamingStatus = streamingStatus(repository);
+        return StreamingDiagnostics.builder()
+                .state(this.streamingStateResolver.resolve(streamingStatus))
+                .reconnectAttempts(streamingStatus.getReconnectAttempts())
+                .build();
+    }
+
+    private StreamingStatusSnapshot streamingStatus(GBFeaturesRepository repository) {
+        boolean initialized = this.options.isRemoteEvalEnabled()
+                ? this.clientState.isRemoteEvalReady()
+                : repository != null && Boolean.TRUE.equals(repository.getInitialized());
+
+        return StreamingStatusSnapshot.builder()
+                .configured(isStreamingConfigured())
+                .allowed(repository != null && repository.isSseAllowed())
+                .connected(repository != null && repository.isSseConnected())
+                .reconnectAttempts(repository == null ? 0 : repository.getSseRetryAttempts())
+                .initialized(initialized)
+                .shutdown(this.clientState.isShutdown())
+                .build();
+    }
+
+    private boolean isStreamingConfigured() {
+        return this.options.getRefreshingStrategy() == FeatureRefreshStrategy.SERVER_SENT_EVENTS;
+    }
+
+    private RemoteEvalDiagnostics remoteEvalDiagnostics() {
+        return RemoteEvalDiagnostics.builder()
+                .enabled(this.options.isRemoteEvalEnabled())
+                .ready(this.clientState.isRemoteEvalReady())
+                .cacheConfigured(this.clientState.isRemoteEvalCacheConfigured())
+                .cacheMaxSize(this.options.getRemoteEvalCacheSize())
+                .cacheTtlSeconds(this.options.getRemoteEvalCacheTtlSeconds())
+                .build();
+    }
+
+    private FeatureRefreshStrategy refreshStrategy(GBFeaturesRepository repository) {
+        if (repository != null && repository.getRefreshStrategy() != null) {
+            return repository.getRefreshStrategy();
+        }
+        return this.options.getRefreshingStrategy();
+    }
+
+    private ErrorDiagnostics lastRefreshError(
+            GBFeaturesRepository repository,
+            DiagnosticsSecretMasker secretMasker
+    ) {
+        Long lastRefreshErrorAtMillis = repository == null ? null : repository.getLastRefreshErrorAtMillis();
+        if (lastRefreshErrorAtMillis != null && lastRefreshErrorAtMillis > 0) {
+            return this.errorDiagnosticsMapper.map(repository.getLastRefreshError(), lastRefreshErrorAtMillis, secretMasker);
+        }
+
+        Throwable initializationError = this.clientState.lastInitializationError();
+        long initializationErrorAtMillis = this.clientState.lastInitializationErrorAtMillis();
+        if (initializationError == null || initializationErrorAtMillis <= 0) {
+            return null;
+        }
+
+        return this.errorDiagnosticsMapper.map(initializationError, initializationErrorAtMillis, secretMasker);
+    }
+
+    private Long zeroAsNull(long timestampMillis) {
+        return timestampMillis <= 0 ? null : timestampMillis;
+    }
+
+    private long timestampOrUnknown(Long timestampMillis) {
+        return timestampMillis == null ? 0L : Math.max(0L, timestampMillis);
+    }
+
+    private Long ageMillis(Long timestampMillis, long generatedAtMillis) {
+        if (timestampMillis == null || timestampMillis <= 0) {
+            return null;
+        }
+        return Math.max(0L, generatedAtMillis - timestampMillis);
+    }
+
+    private Long millisUntil(Long timestampMillis, long generatedAtMillis) {
+        return timestampMillis == null ? null : timestampMillis - generatedAtMillis;
+    }
+}

--- a/lib/src/main/java/growthbook/sdk/java/diagnostics/provider/helper/ConfigDiagnosticsMapper.java
+++ b/lib/src/main/java/growthbook/sdk/java/diagnostics/provider/helper/ConfigDiagnosticsMapper.java
@@ -1,0 +1,140 @@
+package growthbook.sdk.java.diagnostics.provider.helper;
+
+import static growthbook.sdk.java.constants.SDKConstants.Endpoints.DEFAULT_API_HOST;
+import static growthbook.sdk.java.constants.SDKConstants.Endpoints.FEATURES_ENDPOINT_PATH;
+import static growthbook.sdk.java.constants.SDKConstants.Endpoints.STREAMING_ENDPOINT_PATH;
+
+import growthbook.sdk.java.constants.SDKConstants;
+import growthbook.sdk.java.diagnostics.model.ConfigDiagnostics;
+import growthbook.sdk.java.multiusermode.configurations.Options;
+import growthbook.sdk.java.repository.GBFeaturesRepository;
+import growthbook.sdk.java.retry.FeatureFetchRetryPolicy;
+
+import javax.annotation.Nullable;
+import java.time.Duration;
+
+/**
+ * Builds sanitized configuration diagnostics without exposing SDK secrets.
+ */
+public final class ConfigDiagnosticsMapper {
+
+    public ConfigDiagnostics map(Options options, @Nullable GBFeaturesRepository repository) {
+        DiagnosticsSecretMasker secretMasker = DiagnosticsSecretMasker.from(options, repository);
+        String apiHost = apiHost(options, repository);
+        String clientKey = clientKey(options, repository);
+
+        return ConfigDiagnostics.builder()
+                .apiHost(secretMasker.mask(apiHost))
+                .featuresEndpoint(secretMasker.maskEndpoint(featuresEndpoint(apiHost, clientKey, repository)))
+                .eventsEndpoint(secretMasker.maskEndpoint(eventsEndpoint(apiHost, clientKey, repository)))
+                .clientKeyMasked(secretMasker.maskClientKey(clientKey))
+                .encryptionConfigured(encryptionConfigured(options, repository))
+                .swrTtlSeconds(swrTtlSeconds(options, repository))
+                .backgroundFetchIntervalMillis(durationMillis(backgroundFetchInterval(options, repository)))
+                .retryMaxAttempts(retryMaxAttempts(options, repository))
+                .enabled(Boolean.TRUE.equals(options.getEnabled()))
+                .qaMode(Boolean.TRUE.equals(options.getIsQaMode()))
+                .stickyBucketingEnabled(options.getStickyBucketService() != null)
+                .build();
+    }
+
+    private String apiHost(Options options, @Nullable GBFeaturesRepository repository) {
+        String repositoryApiHost = repositoryApiHost(repository);
+        if (repositoryApiHost != null) {
+            return repositoryApiHost;
+        }
+        return options.getApiHost() == null ? DEFAULT_API_HOST : options.getApiHost();
+    }
+
+    @Nullable
+    private String repositoryApiHost(@Nullable GBFeaturesRepository repository) {
+        if (repository == null || repository.getFeaturesEndpoint() == null) {
+            return null;
+        }
+
+        int markerIndex = repository.getFeaturesEndpoint().indexOf(FEATURES_ENDPOINT_PATH);
+        if (markerIndex <= 0) {
+            return null;
+        }
+        return repository.getFeaturesEndpoint().substring(0, markerIndex);
+    }
+
+    @Nullable
+    private String clientKey(Options options, @Nullable GBFeaturesRepository repository) {
+        if (options.getClientKey() != null) {
+            return options.getClientKey();
+        }
+        return repositoryClientKey(repository);
+    }
+
+    @Nullable
+    private String repositoryClientKey(@Nullable GBFeaturesRepository repository) {
+        if (repository == null || repository.getFeaturesEndpoint() == null) {
+            return null;
+        }
+        int markerIndex = repository.getFeaturesEndpoint().indexOf(FEATURES_ENDPOINT_PATH);
+        if (markerIndex < 0) {
+            return null;
+        }
+        return repository.getFeaturesEndpoint().substring(markerIndex + FEATURES_ENDPOINT_PATH.length());
+    }
+
+    @Nullable
+    private String featuresEndpoint(
+            String apiHost,
+            @Nullable String clientKey,
+            @Nullable GBFeaturesRepository repository
+    ) {
+        if (repository != null && repository.getFeaturesEndpoint() != null) {
+            return repository.getFeaturesEndpoint();
+        }
+        return clientKey == null ? null : apiHost + FEATURES_ENDPOINT_PATH + clientKey;
+    }
+
+    @Nullable
+    private String eventsEndpoint(
+            String apiHost,
+            @Nullable String clientKey,
+            @Nullable GBFeaturesRepository repository
+    ) {
+        if (repository != null && repository.getEventsEndpoint() != null) {
+            return repository.getEventsEndpoint();
+        }
+        return clientKey == null ? null : apiHost + STREAMING_ENDPOINT_PATH + clientKey;
+    }
+
+    private boolean encryptionConfigured(Options options, @Nullable GBFeaturesRepository repository) {
+        if (repository != null) {
+            return repository.getDecryptionKey() != null;
+        }
+        return options.getDecryptionKey() != null;
+    }
+
+    private int swrTtlSeconds(Options options, @Nullable GBFeaturesRepository repository) {
+        if (repository != null && repository.getSwrTtlSeconds() != null) {
+            return repository.getSwrTtlSeconds();
+        }
+        return options.getSwrTtlSeconds() == null ? SDKConstants.DEFAULT_SWR_TTL_SECONDS : options.getSwrTtlSeconds();
+    }
+
+    @Nullable
+    private Duration backgroundFetchInterval(Options options, @Nullable GBFeaturesRepository repository) {
+        if (repository != null && repository.getBackgroundFetchInterval() != null) {
+            return repository.getBackgroundFetchInterval();
+        }
+        return options.getBackgroundFetchInterval();
+    }
+
+    private int retryMaxAttempts(Options options, @Nullable GBFeaturesRepository repository) {
+        FeatureFetchRetryPolicy retryPolicy = repository != null && repository.getRetryPolicy() != null
+                ? repository.getRetryPolicy()
+                : options.getRetryPolicy();
+        return retryPolicy == null ? FeatureFetchRetryPolicy.DEFAULT_MAX_ATTEMPTS : retryPolicy.getMaxAttempts();
+    }
+
+    @Nullable
+    private Long durationMillis(@Nullable Duration duration) {
+        return duration == null ? null : duration.toMillis();
+    }
+
+}

--- a/lib/src/main/java/growthbook/sdk/java/diagnostics/provider/helper/DiagnosticsHealthResolver.java
+++ b/lib/src/main/java/growthbook/sdk/java/diagnostics/provider/helper/DiagnosticsHealthResolver.java
@@ -1,0 +1,279 @@
+package growthbook.sdk.java.diagnostics.provider.helper;
+
+import growthbook.sdk.java.diagnostics.model.CacheDiagnostics;
+import growthbook.sdk.java.diagnostics.model.enums.CacheState;
+import growthbook.sdk.java.diagnostics.model.ClientDiagnostics;
+import growthbook.sdk.java.diagnostics.model.ConfigDiagnostics;
+import growthbook.sdk.java.diagnostics.model.enums.DiagnosticsHealthState;
+import growthbook.sdk.java.diagnostics.model.DiagnosticsIssue;
+import growthbook.sdk.java.diagnostics.model.enums.DiagnosticsIssueCode;
+import growthbook.sdk.java.diagnostics.model.enums.DiagnosticsIssueSeverity;
+import growthbook.sdk.java.diagnostics.model.FeatureDiagnostics;
+import growthbook.sdk.java.diagnostics.model.enums.FeatureState;
+import growthbook.sdk.java.diagnostics.model.HealthDiagnostics;
+import growthbook.sdk.java.diagnostics.model.RefreshDiagnostics;
+import growthbook.sdk.java.diagnostics.model.RemoteEvalDiagnostics;
+import growthbook.sdk.java.diagnostics.model.StreamingDiagnostics;
+import growthbook.sdk.java.diagnostics.model.enums.StreamingState;
+import growthbook.sdk.java.diagnostics.provider.model.DiagnosticsSnapshot;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Derives a compact health summary from diagnostics sections.
+ */
+public final class DiagnosticsHealthResolver {
+
+    public HealthDiagnostics resolve(DiagnosticsSnapshot snapshot) {
+        long generatedAtMillis = snapshot.getGeneratedAtMillis();
+        ClientDiagnostics client = snapshot.getClient();
+        FeatureDiagnostics features = snapshot.getFeatures();
+        RefreshDiagnostics refresh = snapshot.getRefresh();
+
+        List<DiagnosticsIssue> issues = new ArrayList<>();
+        addClientIssues(issues, generatedAtMillis, client);
+        addConfigIssues(issues, generatedAtMillis, snapshot.getConfig());
+        addFeatureIssues(issues, generatedAtMillis, client, features);
+        addRefreshIssues(issues, generatedAtMillis, client, features, refresh);
+        addCacheIssues(issues, generatedAtMillis, client, snapshot.getCache());
+        addStreamingIssues(issues, generatedAtMillis, client, snapshot.getStreaming());
+        addRemoteEvalIssues(issues, generatedAtMillis, client, snapshot.getRemoteEval());
+
+        return HealthDiagnostics.builder()
+                .state(resolveState(client, issues))
+                .issues(Collections.unmodifiableList(issues))
+                .build();
+    }
+
+    private void addClientIssues(
+            List<DiagnosticsIssue> issues,
+            long generatedAtMillis,
+            ClientDiagnostics client
+    ) {
+        if (client.isShutdown()) {
+            issues.add(issue(
+                    DiagnosticsIssueCode.CLIENT_SHUTDOWN,
+                    DiagnosticsIssueSeverity.INFO,
+                    "Client has been shut down.",
+                    generatedAtMillis
+            ));
+            return;
+        }
+        if (!client.isInitialized()) {
+            issues.add(issue(
+                    DiagnosticsIssueCode.CLIENT_NOT_INITIALIZED,
+                    DiagnosticsIssueSeverity.WARNING,
+                    "Client has not completed initialization.",
+                    generatedAtMillis
+            ));
+        }
+    }
+
+    private void addConfigIssues(
+            List<DiagnosticsIssue> issues,
+            long generatedAtMillis,
+            ConfigDiagnostics config
+    ) {
+        if (!config.isEnabled()) {
+            issues.add(issue(
+                    DiagnosticsIssueCode.SDK_DISABLED,
+                    DiagnosticsIssueSeverity.WARNING,
+                    "SDK evaluations are globally disabled by configuration.",
+                    generatedAtMillis
+            ));
+        }
+        if (config.isQaMode()) {
+            issues.add(issue(
+                    DiagnosticsIssueCode.QA_MODE_ENABLED,
+                    DiagnosticsIssueSeverity.INFO,
+                    "QA mode is enabled.",
+                    generatedAtMillis
+            ));
+        }
+    }
+
+    private void addFeatureIssues(
+            List<DiagnosticsIssue> issues,
+            long generatedAtMillis,
+            ClientDiagnostics client,
+            FeatureDiagnostics features
+    ) {
+        if (client.isShutdown() || client.isRemoteEvalEnabled() || !client.isInitialized()) {
+            return;
+        }
+        if (!features.isAvailable()) {
+            issues.add(issue(
+                    DiagnosticsIssueCode.FEATURES_NOT_LOADED,
+                    DiagnosticsIssueSeverity.ERROR,
+                    "Local feature data is not loaded.",
+                    generatedAtMillis
+            ));
+            return;
+        }
+        if (features.getState() == FeatureState.LOADED_EMPTY) {
+            issues.add(issue(
+                    DiagnosticsIssueCode.FEATURES_EMPTY,
+                    DiagnosticsIssueSeverity.INFO,
+                    "Feature data is loaded but contains no feature definitions.",
+                    generatedAtMillis
+            ));
+        }
+    }
+
+    private void addRefreshIssues(
+            List<DiagnosticsIssue> issues,
+            long generatedAtMillis,
+            ClientDiagnostics client,
+            FeatureDiagnostics features,
+            RefreshDiagnostics refresh
+    ) {
+        if (!client.isShutdown() && client.isInitialized() && features.isAvailable() && refresh.isStale()) {
+            issues.add(issue(
+                    DiagnosticsIssueCode.FEATURES_STALE,
+                    DiagnosticsIssueSeverity.WARNING,
+                    "Feature data is past its cache expiry.",
+                    generatedAtMillis
+            ));
+        }
+        if (!hasUnresolvedRefreshError(refresh)) {
+            return;
+        }
+
+        DiagnosticsIssueSeverity severity = features.isAvailable()
+                ? DiagnosticsIssueSeverity.WARNING
+                : DiagnosticsIssueSeverity.ERROR;
+        String errorCode = refresh.getLastError().getCode() == null
+                ? refresh.getLastError().getType()
+                : refresh.getLastError().getCode();
+        issues.add(issue(
+                DiagnosticsIssueCode.REFRESH_FAILED,
+                severity,
+                "Last feature refresh failed: " + errorCode + " - " + refresh.getLastError().getMessage(),
+                generatedAtMillis
+        ));
+    }
+
+    private boolean hasUnresolvedRefreshError(RefreshDiagnostics refresh) {
+        if (refresh.getLastError() == null) {
+            return false;
+        }
+        if (refresh.getConsecutiveFailures() > 0) {
+            return true;
+        }
+        Long lastSuccessfulRefreshAtMillis = refresh.getLastSuccessfulRefreshAtMillis();
+        Long lastFailureAtMillis = refresh.getLastFailureAtMillis();
+        if (lastSuccessfulRefreshAtMillis == null) {
+            return true;
+        }
+        return lastFailureAtMillis != null && lastFailureAtMillis > lastSuccessfulRefreshAtMillis;
+    }
+
+    private void addCacheIssues(
+            List<DiagnosticsIssue> issues,
+            long generatedAtMillis,
+            ClientDiagnostics client,
+            CacheDiagnostics cache
+    ) {
+        if (client.isShutdown() || !client.isInitialized()) {
+            return;
+        }
+        if (cache.isEnabled() && cache.getState() == CacheState.UNKNOWN) {
+            issues.add(issue(
+                    DiagnosticsIssueCode.CACHE_STATE_UNKNOWN,
+                    DiagnosticsIssueSeverity.WARNING,
+                    "Cache persistence is enabled but cache state is unavailable.",
+                    generatedAtMillis
+            ));
+        }
+    }
+
+    private void addStreamingIssues(
+            List<DiagnosticsIssue> issues,
+            long generatedAtMillis,
+            ClientDiagnostics client,
+            StreamingDiagnostics streaming
+    ) {
+        if (client.isShutdown() || !client.isInitialized()) {
+            return;
+        }
+        if (streaming.getState() == StreamingState.UNSUPPORTED) {
+            issues.add(issue(
+                    DiagnosticsIssueCode.STREAMING_UNSUPPORTED,
+                    DiagnosticsIssueSeverity.WARNING,
+                    "Streaming refresh is configured but not supported by the server.",
+                    generatedAtMillis
+            ));
+        }
+        if (streaming.getState() == StreamingState.INTERRUPTED) {
+            issues.add(issue(
+                    DiagnosticsIssueCode.STREAMING_INTERRUPTED,
+                    DiagnosticsIssueSeverity.WARNING,
+                    "Streaming refresh is currently reconnecting.",
+                    generatedAtMillis
+            ));
+        }
+    }
+
+    private void addRemoteEvalIssues(
+            List<DiagnosticsIssue> issues,
+            long generatedAtMillis,
+            ClientDiagnostics client,
+            RemoteEvalDiagnostics remoteEval
+    ) {
+        if (client.isShutdown() || !client.isInitialized() || !remoteEval.isEnabled()) {
+            return;
+        }
+        if (!remoteEval.isReady()) {
+            issues.add(issue(
+                    DiagnosticsIssueCode.REMOTE_EVAL_NOT_READY,
+                    DiagnosticsIssueSeverity.ERROR,
+                    "Remote evaluation is enabled but not ready.",
+                    generatedAtMillis
+            ));
+        }
+    }
+
+    private DiagnosticsHealthState resolveState(
+            ClientDiagnostics client,
+            List<DiagnosticsIssue> issues
+    ) {
+        if (client.isShutdown()) {
+            return DiagnosticsHealthState.SHUTDOWN;
+        }
+        if (hasSeverity(issues, DiagnosticsIssueSeverity.ERROR)) {
+            return DiagnosticsHealthState.ERROR;
+        }
+        if (!client.isInitialized()) {
+            return DiagnosticsHealthState.NOT_READY;
+        }
+        if (hasSeverity(issues, DiagnosticsIssueSeverity.WARNING)) {
+            return DiagnosticsHealthState.DEGRADED;
+        }
+        return DiagnosticsHealthState.READY;
+    }
+
+    private boolean hasSeverity(List<DiagnosticsIssue> issues, DiagnosticsIssueSeverity severity) {
+        for (DiagnosticsIssue issue : issues) {
+            if (issue.getSeverity() == severity) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private DiagnosticsIssue issue(
+            DiagnosticsIssueCode code,
+            DiagnosticsIssueSeverity severity,
+            String message,
+            long generatedAtMillis
+    ) {
+        return DiagnosticsIssue.builder()
+                .code(code)
+                .severity(severity)
+                .message(message)
+                .timestampMillis(generatedAtMillis)
+                .build();
+    }
+}

--- a/lib/src/main/java/growthbook/sdk/java/diagnostics/provider/helper/DiagnosticsSecretMasker.java
+++ b/lib/src/main/java/growthbook/sdk/java/diagnostics/provider/helper/DiagnosticsSecretMasker.java
@@ -1,0 +1,219 @@
+package growthbook.sdk.java.diagnostics.provider.helper;
+
+import static growthbook.sdk.java.constants.SDKConstants.Endpoints.FEATURES_ENDPOINT_PATH;
+import static growthbook.sdk.java.constants.SDKConstants.Endpoints.STREAMING_ENDPOINT_PATH;
+
+import growthbook.sdk.java.multiusermode.configurations.Options;
+import growthbook.sdk.java.repository.GBFeaturesRepository;
+
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Masks known diagnostics secrets before they can be exposed in support dumps.
+ */
+public final class DiagnosticsSecretMasker {
+
+    private static final String REDACTED_SECRET = "[redacted]";
+    private static final String REDACTED_QUERY = "?[redacted]";
+    private static final Pattern FEATURES_ENDPOINT_KEY_PATTERN = endpointPathPattern(FEATURES_ENDPOINT_PATH);
+    private static final Pattern STREAMING_ENDPOINT_KEY_PATTERN = endpointPathPattern(STREAMING_ENDPOINT_PATH);
+    private static final Pattern URL_SENSITIVE_PARTS_PATTERN = Pattern.compile(
+            "([A-Za-z][A-Za-z0-9+.-]*://)([^\\s/?#@]+@)?([^\\s?#]*)(\\?[^\\s#]*)?"
+    );
+
+    private final Map<String, String> replacements;
+
+    private DiagnosticsSecretMasker(Map<String, String> replacements) {
+        this.replacements = replacements;
+    }
+
+    public static DiagnosticsSecretMasker from(Options options, @Nullable GBFeaturesRepository repository) {
+        Map<String, String> replacements = new HashMap<>();
+
+        String optionsClientKey = options.getClientKey();
+        addReplacement(replacements, optionsClientKey, maskClientKeyValue(optionsClientKey));
+
+        String repositoryClientKey = repositoryClientKey(repository);
+        addReplacement(replacements, repositoryClientKey, maskClientKeyValue(repositoryClientKey));
+
+        addReplacement(replacements, options.getDecryptionKey(), REDACTED_SECRET);
+        if (repository != null) {
+            addReplacement(replacements, repository.getDecryptionKey(), REDACTED_SECRET);
+            addRepositoryEncryptionKey(replacements, repository);
+        }
+
+        return new DiagnosticsSecretMasker(replacements);
+    }
+
+    public static DiagnosticsSecretMasker empty() {
+        return new DiagnosticsSecretMasker(Collections.emptyMap());
+    }
+
+    @Nullable
+    public String mask(@Nullable String value) {
+        if (value == null || value.isEmpty()) {
+            return value;
+        }
+
+        String masked = value;
+        for (Map.Entry<String, String> replacement : sortedReplacements()) {
+            masked = masked.replace(replacement.getKey(), replacement.getValue());
+        }
+        return redactSensitiveUrlParts(maskEndpointPathSegments(masked));
+    }
+
+    @Nullable
+    public String maskClientKey(@Nullable String clientKey) {
+        return maskClientKeyValue(clientKey);
+    }
+
+    @Nullable
+    public String maskEndpoint(@Nullable String endpoint) {
+        if (endpoint == null || endpoint.isEmpty()) {
+            return endpoint;
+        }
+
+        String masked = applyKnownReplacements(endpoint);
+        masked = maskEndpointPathSegments(masked);
+        masked = maskLastPathSegment(masked);
+        return redactSensitiveUrlParts(masked);
+    }
+
+    private static Pattern endpointPathPattern(String endpointPath) {
+        return Pattern.compile("(" + Pattern.quote(endpointPath) + ")([^/?#\\s]+)");
+    }
+
+    @Nullable
+    private static String repositoryClientKey(@Nullable GBFeaturesRepository repository) {
+        if (repository == null || repository.getFeaturesEndpoint() == null) {
+            return null;
+        }
+        int markerIndex = repository.getFeaturesEndpoint().indexOf(FEATURES_ENDPOINT_PATH);
+        if (markerIndex < 0) {
+            return null;
+        }
+        return repository.getFeaturesEndpoint().substring(markerIndex + FEATURES_ENDPOINT_PATH.length());
+    }
+
+    @SuppressWarnings("deprecation")
+    private static void addRepositoryEncryptionKey(
+            Map<String, String> replacements,
+            GBFeaturesRepository repository
+    ) {
+        addReplacement(replacements, repository.getEncryptionKey(), REDACTED_SECRET);
+    }
+
+    private static void addReplacement(
+            Map<String, String> replacements,
+            @Nullable String raw,
+            @Nullable String masked
+    ) {
+        if (raw == null || raw.isEmpty() || masked == null) {
+            return;
+        }
+        replacements.put(raw, masked);
+    }
+
+    @Nullable
+    private static String maskClientKeyValue(@Nullable String value) {
+        if (value == null || value.isEmpty()) {
+            return null;
+        }
+        if (value.length() <= 5) {
+            return "***";
+        }
+
+        int prefixLength = value.length() <= 8 ? 3 : 4;
+        int suffixLength = value.length() <= 8 ? 2 : 4;
+        return value.substring(0, prefixLength) + "..." + value.substring(value.length() - suffixLength);
+    }
+
+    private String applyKnownReplacements(String value) {
+        String masked = value;
+        for (Map.Entry<String, String> replacement : sortedReplacements()) {
+            masked = masked.replace(replacement.getKey(), replacement.getValue());
+        }
+        return masked;
+    }
+
+    private static String maskEndpointPathSegments(String value) {
+        return maskEndpointPathSegment(
+                STREAMING_ENDPOINT_KEY_PATTERN,
+                maskEndpointPathSegment(FEATURES_ENDPOINT_KEY_PATTERN, value)
+        );
+    }
+
+    private static String maskEndpointPathSegment(Pattern pattern, String value) {
+        Matcher matcher = pattern.matcher(value);
+        StringBuffer buffer = new StringBuffer();
+        while (matcher.find()) {
+            String maskedSegment = maskClientKeyValue(matcher.group(2));
+            String replacement = matcher.group(1) + (maskedSegment == null ? REDACTED_SECRET : maskedSegment);
+            matcher.appendReplacement(buffer, Matcher.quoteReplacement(replacement));
+        }
+        matcher.appendTail(buffer);
+        return buffer.toString();
+    }
+
+    private static String redactSensitiveUrlParts(String value) {
+        Matcher matcher = URL_SENSITIVE_PARTS_PATTERN.matcher(value);
+        StringBuffer buffer = new StringBuffer();
+        while (matcher.find()) {
+            boolean hasUserInfo = matcher.group(2) != null;
+            boolean hasQuery = matcher.group(4) != null;
+            if (!hasUserInfo && !hasQuery) {
+                continue;
+            }
+
+            String replacement = matcher.group(1)
+                    + (hasUserInfo ? REDACTED_SECRET + "@" : "")
+                    + matcher.group(3)
+                    + (hasQuery ? REDACTED_QUERY : "");
+            matcher.appendReplacement(buffer, Matcher.quoteReplacement(replacement));
+        }
+        matcher.appendTail(buffer);
+        return buffer.toString();
+    }
+
+    private String maskLastPathSegment(String endpoint) {
+        int suffixIndex = firstSuffixIndex(endpoint);
+        String path = suffixIndex < 0 ? endpoint : endpoint.substring(0, suffixIndex);
+        String suffix = suffixIndex < 0 ? "" : endpoint.substring(suffixIndex);
+        int lastSlashIndex = path.lastIndexOf('/');
+        if (lastSlashIndex < 0 || lastSlashIndex == path.length() - 1) {
+            return endpoint;
+        }
+        String lastSegment = path.substring(lastSlashIndex + 1);
+        String maskedSegment = maskClientKeyValue(lastSegment);
+        return maskedSegment == null ? endpoint : path.substring(0, lastSlashIndex + 1) + maskedSegment + suffix;
+    }
+
+    private int firstSuffixIndex(String endpoint) {
+        int queryIndex = endpoint.indexOf('?');
+        int fragmentIndex = endpoint.indexOf('#');
+        if (queryIndex < 0) {
+            return fragmentIndex;
+        }
+        if (fragmentIndex < 0) {
+            return queryIndex;
+        }
+        return Math.min(queryIndex, fragmentIndex);
+    }
+
+    private List<Map.Entry<String, String>> sortedReplacements() {
+        List<Map.Entry<String, String>> entries = new ArrayList<>(this.replacements.entrySet());
+        entries.sort(Comparator
+                .comparingInt((Map.Entry<String, String> entry) -> entry.getKey().length())
+                .reversed()
+                .thenComparing(Map.Entry::getKey));
+        return entries;
+    }
+}

--- a/lib/src/main/java/growthbook/sdk/java/diagnostics/provider/helper/ErrorDiagnosticsMapper.java
+++ b/lib/src/main/java/growthbook/sdk/java/diagnostics/provider/helper/ErrorDiagnosticsMapper.java
@@ -1,0 +1,50 @@
+package growthbook.sdk.java.diagnostics.provider.helper;
+
+import growthbook.sdk.java.diagnostics.model.ErrorDiagnostics;
+import growthbook.sdk.java.exception.FeatureFetchException;
+import growthbook.sdk.java.exception.GrowthBookClientInitializationException;
+
+/**
+ * Maps internal exceptions into sanitized diagnostics output.
+ */
+public final class ErrorDiagnosticsMapper {
+
+    public ErrorDiagnostics map(Throwable error, long timestampMillis) {
+        return map(error, timestampMillis, DiagnosticsSecretMasker.empty());
+    }
+
+    public ErrorDiagnostics map(
+            Throwable error,
+            long timestampMillis,
+            DiagnosticsSecretMasker secretMasker
+    ) {
+        Throwable normalizedError = normalize(error);
+        return ErrorDiagnostics.builder()
+                .type(normalizedError.getClass().getSimpleName())
+                .code(errorCode(normalizedError))
+                .message(secretMasker.mask(errorMessage(normalizedError)))
+                .timestampMillis(timestampMillis)
+                .build();
+    }
+
+    private Throwable normalize(Throwable error) {
+        if (error == null) {
+            return new FeatureFetchException(FeatureFetchException.FeatureFetchErrorCode.UNKNOWN);
+        }
+        if (error instanceof GrowthBookClientInitializationException && error.getCause() != null) {
+            return error.getCause();
+        }
+        return error;
+    }
+
+    private String errorCode(Throwable error) {
+        if (error instanceof FeatureFetchException) {
+            return ((FeatureFetchException) error).getErrorCode().name();
+        }
+        return null;
+    }
+
+    private String errorMessage(Throwable error) {
+        return error.getMessage() == null ? error.getClass().getSimpleName() : error.getMessage();
+    }
+}

--- a/lib/src/main/java/growthbook/sdk/java/diagnostics/provider/helper/FeatureDiagnosticsMapper.java
+++ b/lib/src/main/java/growthbook/sdk/java/diagnostics/provider/helper/FeatureDiagnosticsMapper.java
@@ -1,0 +1,132 @@
+package growthbook.sdk.java.diagnostics.provider.helper;
+
+import growthbook.sdk.java.diagnostics.model.enums.FeatureDataSource;
+import growthbook.sdk.java.diagnostics.model.FeatureDiagnostics;
+import growthbook.sdk.java.diagnostics.model.FeatureKeyDiagnostics;
+import growthbook.sdk.java.diagnostics.model.enums.FeatureState;
+import growthbook.sdk.java.model.Feature;
+
+import javax.annotation.Nullable;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Builds feature diagnostics from repository-visible feature state.
+ */
+public final class FeatureDiagnosticsMapper {
+    private static final int FEATURE_KEY_SAMPLE_LIMIT = 20;
+
+    public FeatureDiagnostics fromFeatureMap(
+            FeatureDataSource source,
+            boolean available,
+            int activeFeatureCount,
+            @Nullable Map<String, Feature<?>> features
+    ) {
+        FeatureKeyDiagnostics keys = featureKeys(features);
+        int normalizedActiveCount = nonNegative(activeFeatureCount);
+        int totalFeatureCount = Math.max(keys.getTotalCount(), normalizedActiveCount);
+
+        return FeatureDiagnostics.builder()
+                .state(featureState(available, totalFeatureCount))
+                .source(source)
+                .available(available)
+                .activeFeatureCount(normalizedActiveCount)
+                .totalFeatureCount(totalFeatureCount)
+                .keys(keys)
+                .build();
+    }
+
+    public FeatureDiagnostics fromCount(
+            FeatureDataSource source,
+            boolean available,
+            int activeFeatureCount
+    ) {
+        int normalizedActiveCount = nonNegative(activeFeatureCount);
+        return FeatureDiagnostics.builder()
+                .state(featureState(available, normalizedActiveCount))
+                .source(source)
+                .available(available)
+                .activeFeatureCount(normalizedActiveCount)
+                .totalFeatureCount(normalizedActiveCount)
+                .keys(unavailableFeatureKeys())
+                .build();
+    }
+
+    public FeatureDiagnostics unavailable() {
+        return fromCount(FeatureDataSource.NONE, false, 0);
+    }
+
+    private FeatureState featureState(boolean available, int totalFeatureCount) {
+        if (!available) {
+            return FeatureState.NOT_LOADED;
+        }
+        return totalFeatureCount == 0 ? FeatureState.LOADED_EMPTY : FeatureState.LOADED;
+    }
+
+    private FeatureKeyDiagnostics featureKeys(@Nullable Map<String, Feature<?>> features) {
+        if (features == null) {
+            return unavailableFeatureKeys();
+        }
+
+        List<String> sortedKeys = new ArrayList<>();
+        for (String key : features.keySet()) {
+            if (key != null) {
+                sortedKeys.add(key);
+            }
+        }
+        Collections.sort(sortedKeys);
+
+        int sampleSize = Math.min(sortedKeys.size(), FEATURE_KEY_SAMPLE_LIMIT);
+        List<String> sample = new ArrayList<>(sortedKeys.subList(0, sampleSize));
+
+        return FeatureKeyDiagnostics.builder()
+                .available(true)
+                .totalCount(sortedKeys.size())
+                .sampleLimit(FEATURE_KEY_SAMPLE_LIMIT)
+                .sample(Collections.unmodifiableList(sample))
+                .truncated(sortedKeys.size() > FEATURE_KEY_SAMPLE_LIMIT)
+                .sha256(sha256(sortedKeys))
+                .build();
+    }
+
+    private FeatureKeyDiagnostics unavailableFeatureKeys() {
+        return FeatureKeyDiagnostics.builder()
+                .available(false)
+                .totalCount(0)
+                .sampleLimit(FEATURE_KEY_SAMPLE_LIMIT)
+                .sample(Collections.emptyList())
+                .truncated(false)
+                .sha256(null)
+                .build();
+    }
+
+    private String sha256(List<String> sortedKeys) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            for (String key : sortedKeys) {
+                digest.update(key.getBytes(StandardCharsets.UTF_8));
+                digest.update((byte) 0);
+            }
+            return hex(digest.digest());
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 is not available", e);
+        }
+    }
+
+    private String hex(byte[] bytes) {
+        StringBuilder builder = new StringBuilder(bytes.length * 2);
+        for (byte value : bytes) {
+            builder.append(String.format("%02x", value & 0xff));
+        }
+        return builder.toString();
+    }
+
+    private int nonNegative(int value) {
+        return Math.max(0, value);
+    }
+}

--- a/lib/src/main/java/growthbook/sdk/java/diagnostics/provider/helper/StreamingStateResolveHelper.java
+++ b/lib/src/main/java/growthbook/sdk/java/diagnostics/provider/helper/StreamingStateResolveHelper.java
@@ -1,0 +1,55 @@
+package growthbook.sdk.java.diagnostics.provider.helper;
+
+import growthbook.sdk.java.diagnostics.model.enums.StreamingState;
+import growthbook.sdk.java.diagnostics.provider.model.StreamingStatusSnapshot;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Predicate;
+
+/**
+ * Classifies raw streaming signals into a single diagnostics state.
+ */
+public final class StreamingStateResolveHelper {
+
+    private static final StreamingState DEFAULT_STATE = StreamingState.INITIALIZING;
+
+    private static final List<StreamingStateRule> STATE_RULES = Arrays.asList(
+            streamingStateRule(status -> !status.isConfigured(), StreamingState.DISABLED),
+            streamingStateRule(StreamingStatusSnapshot::isShutdown, StreamingState.SHUTDOWN),
+            streamingStateRule(status -> !status.isInitialized(), StreamingState.INITIALIZING),
+            streamingStateRule(StreamingStatusSnapshot::isConnected, StreamingState.CONNECTED),
+            streamingStateRule(status -> !status.isAllowed(), StreamingState.UNSUPPORTED),
+            streamingStateRule(status -> status.getReconnectAttempts() > 0, StreamingState.INTERRUPTED)
+    );
+
+    public StreamingState resolve(StreamingStatusSnapshot status) {
+        for (StreamingStateRule rule : STATE_RULES) {
+            if (rule.matches(status)) {
+                return rule.state;
+            }
+        }
+        return DEFAULT_STATE;
+    }
+
+    private static StreamingStateRule streamingStateRule(
+            Predicate<StreamingStatusSnapshot> predicate,
+            StreamingState state
+    ) {
+        return new StreamingStateRule(predicate, state);
+    }
+
+    private static final class StreamingStateRule {
+        private final StreamingState state;
+        private final Predicate<StreamingStatusSnapshot> predicate;
+
+        private StreamingStateRule(Predicate<StreamingStatusSnapshot> predicate, StreamingState state) {
+            this.predicate = predicate;
+            this.state = state;
+        }
+
+        private boolean matches(StreamingStatusSnapshot status) {
+            return this.predicate.test(status);
+        }
+    }
+}

--- a/lib/src/main/java/growthbook/sdk/java/diagnostics/provider/model/DiagnosticsCollectionContext.java
+++ b/lib/src/main/java/growthbook/sdk/java/diagnostics/provider/model/DiagnosticsCollectionContext.java
@@ -1,0 +1,23 @@
+package growthbook.sdk.java.diagnostics.provider.model;
+
+import growthbook.sdk.java.diagnostics.provider.helper.DiagnosticsSecretMasker;
+import growthbook.sdk.java.repository.GBFeaturesRepository;
+
+import javax.annotation.Nullable;
+
+import lombok.Builder;
+import lombok.Value;
+
+/**
+ * Runtime context used while collecting a diagnostics snapshot.
+ */
+@Value
+@Builder
+public class DiagnosticsCollectionContext {
+    long generatedAtMillis;
+
+    @Nullable
+    GBFeaturesRepository repository;
+
+    DiagnosticsSecretMasker secretMasker;
+}

--- a/lib/src/main/java/growthbook/sdk/java/diagnostics/provider/model/DiagnosticsSnapshot.java
+++ b/lib/src/main/java/growthbook/sdk/java/diagnostics/provider/model/DiagnosticsSnapshot.java
@@ -1,0 +1,28 @@
+package growthbook.sdk.java.diagnostics.provider.model;
+
+import growthbook.sdk.java.diagnostics.model.CacheDiagnostics;
+import growthbook.sdk.java.diagnostics.model.ClientDiagnostics;
+import growthbook.sdk.java.diagnostics.model.ConfigDiagnostics;
+import growthbook.sdk.java.diagnostics.model.FeatureDiagnostics;
+import growthbook.sdk.java.diagnostics.model.RefreshDiagnostics;
+import growthbook.sdk.java.diagnostics.model.RemoteEvalDiagnostics;
+import growthbook.sdk.java.diagnostics.model.StreamingDiagnostics;
+
+import lombok.Builder;
+import lombok.Value;
+
+/**
+ * Collected diagnostics sections before the final public diagnostics object is assembled.
+ */
+@Value
+@Builder
+public class DiagnosticsSnapshot {
+    long generatedAtMillis;
+    ConfigDiagnostics config;
+    ClientDiagnostics client;
+    FeatureDiagnostics features;
+    RefreshDiagnostics refresh;
+    CacheDiagnostics cache;
+    StreamingDiagnostics streaming;
+    RemoteEvalDiagnostics remoteEval;
+}

--- a/lib/src/main/java/growthbook/sdk/java/diagnostics/provider/model/StreamingStatusSnapshot.java
+++ b/lib/src/main/java/growthbook/sdk/java/diagnostics/provider/model/StreamingStatusSnapshot.java
@@ -1,0 +1,18 @@
+package growthbook.sdk.java.diagnostics.provider.model;
+
+import lombok.Builder;
+import lombok.Value;
+
+/**
+ * Raw streaming signals gathered from the active repository or remote-eval coordinator.
+ */
+@Value
+@Builder
+public class StreamingStatusSnapshot {
+    boolean allowed;
+    boolean shutdown;
+    boolean connected;
+    boolean configured;
+    boolean initialized;
+    int reconnectAttempts;
+}

--- a/lib/src/main/java/growthbook/sdk/java/multiusermode/GrowthBookClient.java
+++ b/lib/src/main/java/growthbook/sdk/java/multiusermode/GrowthBookClient.java
@@ -4,6 +4,10 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import growthbook.sdk.java.callback.ExperimentRunCallback;
 import growthbook.sdk.java.callback.FeatureRefreshCallback;
+import growthbook.sdk.java.constants.SDKConstants;
+import growthbook.sdk.java.diagnostics.model.Diagnostics;
+import growthbook.sdk.java.diagnostics.provider.DiagnosticsProvider;
+import growthbook.sdk.java.diagnostics.provider.GrowthBookClientDiagnosticsProvider;
 import growthbook.sdk.java.evaluators.ExperimentEvaluator;
 import growthbook.sdk.java.evaluators.FeatureEvaluator;
 import growthbook.sdk.java.exception.FeatureFetchException;
@@ -42,12 +46,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
 @Slf4j
 public class GrowthBookClient {
-
-    private static final int DEFAULT_SWR_TTL_SECONDS = 60;
 
     private final Options options;
     private List<ExperimentRunCallback> callbacks;
@@ -59,6 +62,10 @@ public class GrowthBookClient {
     private volatile RemoteEvalService remoteEvalService;
     private volatile RemoteEvalCache remoteEvalCache;
     private final AtomicBoolean remoteEvalReady = new AtomicBoolean(false);
+    private final AtomicBoolean clientShutdown = new AtomicBoolean(false);
+    private final AtomicReference<Throwable> lastInitializationError = new AtomicReference<>();
+    private final AtomicLong lastInitializationErrorAtMillis = new AtomicLong(0);
+    private final DiagnosticsProvider diagnosticsProvider;
 
     public GrowthBookClient() {
         this(Options.builder().build());
@@ -71,6 +78,61 @@ public class GrowthBookClient {
         this.callbacks = new ArrayList<>();
         this.featureEvaluator = new FeatureEvaluator();
         this.experimentEvaluatorEvaluator = new ExperimentEvaluator();
+        this.diagnosticsProvider = new GrowthBookClientDiagnosticsProvider(this.options, clientStateView());
+    }
+
+    private GrowthBookClientDiagnosticsProvider.ClientState clientStateView() {
+        return new GrowthBookClientDiagnosticsProvider.ClientState() {
+            @Override
+            @Nullable
+            public GBFeaturesRepository currentRepository() {
+                return GrowthBookClient.this.repository.get();
+            }
+
+            @Override
+            @Nullable
+            public Throwable lastInitializationError() {
+                return GrowthBookClient.this.lastInitializationError.get();
+            }
+
+            @Override
+            public long lastInitializationErrorAtMillis() {
+                return GrowthBookClient.this.lastInitializationErrorAtMillis.get();
+            }
+
+            @Override
+            public boolean isRemoteEvalReady() {
+                return GrowthBookClient.this.remoteEvalReady.get();
+            }
+
+            @Override
+            public boolean isShutdown() {
+                return GrowthBookClient.this.clientShutdown.get();
+            }
+
+            @Override
+            public boolean isRemoteEvalCacheConfigured() {
+                return GrowthBookClient.this.remoteEvalCache != null;
+            }
+
+            @Override
+            public int fallbackFeatureCount() {
+                GlobalContext context = GrowthBookClient.this.globalContext.get();
+                if (context == null || context.getFeatures() == null) {
+                    return 0;
+                }
+                return context.getFeatures().size();
+            }
+        };
+    }
+
+    /**
+     * Returns a read-only snapshot of the current SDK state.
+     *
+     * @return diagnostics snapshot
+     */
+    public Diagnostics getDiagnostics() {
+        return this.diagnosticsProvider.getDiagnostics();
     }
 
     public boolean initialize() {
@@ -97,14 +159,22 @@ public class GrowthBookClient {
             boolean isReady = this.repository.get() == repositoryToInitialize
                     && repositoryToInitialize.getInitialized();
             if (isReady) {
+                this.lastInitializationError.set(null);
+                this.lastInitializationErrorAtMillis.set(0);
                 log.info("GrowthBookClient initialized repository and registered feature refresh callbacks.");
             }
             return isReady;
         } catch (RuntimeException e) {
+            recordInitializationFailure(e);
             clearFailedInitialization(repositoryToInitialize);
             log.error("Failed to initialize growthbook instance", e);
             return false;
         }
+    }
+
+    private void recordInitializationFailure(Throwable error) {
+        this.lastInitializationError.set(error);
+        this.lastInitializationErrorAtMillis.set(System.currentTimeMillis());
     }
 
     private synchronized GBFeaturesRepository prepareRepositoryForInitialization() {
@@ -297,6 +367,7 @@ public class GrowthBookClient {
     }
 
     public synchronized void shutdown() {
+        this.clientShutdown.set(true);
         GBFeaturesRepository repositorySnapshot = this.repository.getAndSet(null);
         this.globalContext.set(null);
         if (repositorySnapshot != null) {
@@ -517,7 +588,9 @@ public class GrowthBookClient {
             this.remoteEvalCache = new RemoteEvalCache(
                     getRemoteEvalService(),
                     RemoteEvalRequestBuilder.normalizeCacheSize(this.options.getRemoteEvalCacheSize()),
-                    secondsToDuration(this.options.getSwrTtlSeconds() == null ? DEFAULT_SWR_TTL_SECONDS : this.options.getSwrTtlSeconds()),
+                    secondsToDuration(this.options.getSwrTtlSeconds() == null
+                            ? SDKConstants.DEFAULT_SWR_TTL_SECONDS
+                            : this.options.getSwrTtlSeconds()),
                     secondsToDuration(this.options.getRemoteEvalCacheTtlSeconds())
             );
         }

--- a/lib/src/main/java/growthbook/sdk/java/repository/GBFeaturesRepository.java
+++ b/lib/src/main/java/growthbook/sdk/java/repository/GBFeaturesRepository.java
@@ -1,8 +1,14 @@
 package growthbook.sdk.java.repository;
 
+import static growthbook.sdk.java.constants.SDKConstants.Endpoints.DEFAULT_API_HOST;
+import static growthbook.sdk.java.constants.SDKConstants.Endpoints.FEATURES_ENDPOINT_PATH;
+import static growthbook.sdk.java.constants.SDKConstants.Endpoints.FEATURES_ENDPOINT_PATTERN;
+import static growthbook.sdk.java.constants.SDKConstants.Endpoints.STREAMING_ENDPOINT_PATH;
+
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import growthbook.sdk.java.callback.FeatureRefreshCallback;
+import growthbook.sdk.java.constants.SDKConstants;
 import growthbook.sdk.java.exception.FeatureFetchException;
 import growthbook.sdk.java.exception.RetryableFeatureFetchException;
 import growthbook.sdk.java.featurefetch.FeatureFetchFailureHandler;
@@ -57,6 +63,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * This class can be created with its `builder()` or constructor.
@@ -71,7 +78,6 @@ public class GBFeaturesRepository implements IGBFeaturesRepository {
     private static final String FILE_NAME = "FEATURE_CACHE.json";
     public static final String FILE_PATH_FOR_CACHE = "src/main/resources";
     public static final String EMPTY_JSON_OBJECT_STRING = "{}";
-    private static final String FEATURES_PATH_PATTERN = ".*/api/features/[^/]+";
     private static final ThreadFactory SSE_RETRY_THREAD_FACTORY = runnable -> {
         Thread thread = new Thread(runnable, "growthbook-sse-retry");
         thread.setDaemon(true);
@@ -139,13 +145,27 @@ public class GBFeaturesRepository implements IGBFeaturesRepository {
 
     private final AtomicLong lastSuccessfulFetchAtMillis = new AtomicLong(0);
 
+    private final AtomicReference<Throwable> lastRefreshError = new AtomicReference<>();
+
+    private final AtomicLong lastRefreshErrorAtMillis = new AtomicLong(0);
+
+    private final AtomicLong refreshSuccessCount = new AtomicLong(0);
+
+    private final AtomicLong refreshFailureCount = new AtomicLong(0);
+
+    private final AtomicLong refreshConsecutiveFailures = new AtomicLong(0);
+
+    private final AtomicLong lastRefreshFailureAtMillis = new AtomicLong(0);
+
+    private final AtomicReference<Boolean> lastRefreshLoadedFromCache = new AtomicReference<>();
+
     private final AtomicBoolean hasFeatureData = new AtomicBoolean(false);
 
     /**
      * Seconds after that cache is expired
      */
     @Getter
-    private Long expiresAt;
+    private volatile Long expiresAt;
 
     /**
      * Http request client for send GET request
@@ -167,12 +187,12 @@ public class GBFeaturesRepository implements IGBFeaturesRepository {
      * Flag to know whether GBFeatureRepository is initialized
      */
     @Getter
-    private Boolean initialized = false;
+    private volatile Boolean initialized = false;
 
     /**
      * Flag to know whether sse connection is allowed
      */
-    private Boolean sseAllowed = false;
+    private volatile Boolean sseAllowed = false;
 
     @Nullable
     private Request sseRequest = null;
@@ -187,7 +207,7 @@ public class GBFeaturesRepository implements IGBFeaturesRepository {
      */
     @Getter
     @Nullable
-    private String savedGroupsJson = EMPTY_JSON_OBJECT_STRING;
+    private volatile String savedGroupsJson = EMPTY_JSON_OBJECT_STRING;
 
     /**
      * Allows you to get the features JSON from the provided {@link GBFeaturesRepository#getFeaturesEndpoint()}.
@@ -197,7 +217,7 @@ public class GBFeaturesRepository implements IGBFeaturesRepository {
      * @return feature data JSON in a type of String. Handle refresh strategy
      */
     @Getter
-    private String featuresJson = EMPTY_JSON_OBJECT_STRING;
+    private volatile String featuresJson = EMPTY_JSON_OBJECT_STRING;
 
     /**
      * Keys are unique identifiers for the features and the values are Feature objects.
@@ -205,10 +225,10 @@ public class GBFeaturesRepository implements IGBFeaturesRepository {
      */
     //@Getter
     @Getter
-    private Map<String, Feature<?>> parsedFeatures = new HashMap<>();
+    private volatile Map<String, Feature<?>> parsedFeatures = new HashMap<>();
 
     @Getter
-    private JsonObject parsedSavedGroups = new JsonObject();
+    private volatile JsonObject parsedSavedGroups = new JsonObject();
 
     public void setCacheManager(GbCacheManager cacheManager) {
         if (!isCacheDisabled) {
@@ -222,7 +242,7 @@ public class GBFeaturesRepository implements IGBFeaturesRepository {
      * CachingManger allows to cache features data to file
      */
     @Getter
-    private GbCacheManager cacheManager;
+    private volatile GbCacheManager cacheManager;
 
     /**
      * Flag that enable CachingManager
@@ -411,19 +431,19 @@ public class GBFeaturesRepository implements IGBFeaturesRepository {
 
         // Set the defaults when the user does not provide them
         if (apiHost == null) {
-            apiHost = "https://cdn.growthbook.io";
+            apiHost = DEFAULT_API_HOST;
         }
         this.refreshStrategy = refreshStrategy == null ? FeatureRefreshStrategy.STALE_WHILE_REVALIDATE : refreshStrategy;
 
         // Build the endpoints from the apiHost and clientKey
-        this.featuresEndpoint = apiHost + "/api/features/" + clientKey;
-        this.eventsEndpoint = apiHost + "/sub/" + clientKey;
+        this.featuresEndpoint = apiHost + FEATURES_ENDPOINT_PATH + clientKey;
+        this.eventsEndpoint = apiHost + STREAMING_ENDPOINT_PATH + clientKey;
         this.remoteEvalEndPoint = RemoteEvalEndpoints.evalEndpoint(apiHost, clientKey);
 
         this.encryptionKey = decryptionKey;
         this.decryptionKey = decryptionKey;
 
-        this.swrTtlSeconds = swrTtlSeconds == null ? 60 : swrTtlSeconds;
+        this.swrTtlSeconds = swrTtlSeconds == null ? SDKConstants.DEFAULT_SWR_TTL_SECONDS : swrTtlSeconds;
         this.backgroundFetchInterval = backgroundFetchInterval;
         this.retryPolicy = retryPolicy == null ? new FeatureFetchRetryPolicy() : retryPolicy;
         this.featureFetchRetryExecutor = new FeatureFetchRetryExecutor(this.retryPolicy);
@@ -453,6 +473,72 @@ public class GBFeaturesRepository implements IGBFeaturesRepository {
     @Nullable
     public String getEncryptionKey() {
         return encryptionKey;
+    }
+
+    public long getLastSuccessfulFetchAtMillis() {
+        return this.lastSuccessfulFetchAtMillis.get();
+    }
+
+    @Override
+    @Nullable
+    public Throwable getLastRefreshError() {
+        return this.lastRefreshError.get();
+    }
+
+    @Override
+    public long getLastRefreshErrorAtMillis() {
+        return this.lastRefreshErrorAtMillis.get();
+    }
+
+    public boolean hasFeatureData() {
+        return this.hasFeatureData.get();
+    }
+
+    public boolean isCacheDisabled() {
+        return this.isCacheDisabled;
+    }
+
+    @Nullable
+    public Long getCacheLastUpdatedMillis() {
+        return readCacheLastUpdatedMillis();
+    }
+
+    public boolean isSseAllowed() {
+        return Boolean.TRUE.equals(this.sseAllowed);
+    }
+
+    public boolean isSseConnected() {
+        return this.sseConnected.get() && !this.shuttingDown.get();
+    }
+
+    public int getSseRetryAttempts() {
+        return this.sseRetryAttempts.get();
+    }
+
+    @Override
+    public long getRefreshSuccessCount() {
+        return this.refreshSuccessCount.get();
+    }
+
+    @Override
+    public long getRefreshFailureCount() {
+        return this.refreshFailureCount.get();
+    }
+
+    @Override
+    public long getRefreshConsecutiveFailureCount() {
+        return this.refreshConsecutiveFailures.get();
+    }
+
+    @Override
+    public long getLastRefreshFailureAtMillis() {
+        return this.lastRefreshFailureAtMillis.get();
+    }
+
+    @Override
+    @Nullable
+    public Boolean getLastRefreshLoadedFromCache() {
+        return this.lastRefreshLoadedFromCache.get();
     }
 
     /**
@@ -491,6 +577,7 @@ public class GBFeaturesRepository implements IGBFeaturesRepository {
     private final AtomicBoolean polling = new AtomicBoolean(false);
     private ScheduledExecutorService sseRetryScheduler;
     private final AtomicBoolean sseReconnectScheduled = new AtomicBoolean(false);
+    private final AtomicBoolean sseConnected = new AtomicBoolean(false);
     private final AtomicInteger sseRetryAttempts = new AtomicInteger(0);
     private final AtomicBoolean shuttingDown = new AtomicBoolean(false);
 
@@ -560,6 +647,7 @@ public class GBFeaturesRepository implements IGBFeaturesRepository {
      * Assigns a close listener to recreate the connection.
      */
     private void createEventSourceListenerAndStartListening(Boolean retryOnFailure) {
+        this.sseConnected.set(false);
         this.sseEventSource = null;
         this.sseRequest = null;
 
@@ -584,13 +672,21 @@ public class GBFeaturesRepository implements IGBFeaturesRepository {
                         new GBEventSourceHandler() {
                             @Override
                             public void onClose(EventSource eventSource) {
+                                sseConnected.set(false);
                                 eventSource.cancel();
                                 scheduleSseReconnect(retryOnFailure);
                             }
 
                             @Override
                             public void onFeaturesResponse(String featuresJsonResponse) throws FeatureFetchException {
-                                onResponseJson(featuresJsonResponse, false);
+                                try {
+                                    onResponseJson(featuresJsonResponse, false);
+                                    recordRefreshSuccess(false);
+                                } catch (FeatureFetchException e) {
+                                    recordRefreshError(e);
+                                    recordRefreshFailure(false);
+                                    throw e;
+                                }
                                 sseRetryAttempts.set(0);
                                 sseReconnectScheduled.set(false);
                             }
@@ -598,12 +694,14 @@ public class GBFeaturesRepository implements IGBFeaturesRepository {
                             @Override
                             public void onFeaturesUpdated() {
                                 onRefreshSuccess(featuresJson);
+                                recordRefreshSuccess(false);
                             }
                         }
                 ) {
                     @Override
                     public void onFailure(@NotNull EventSource eventSource, @Nullable Throwable t, @Nullable Response response) {
                         super.onFailure(eventSource, t, response);
+                        sseConnected.set(false);
                         eventSource.cancel();
                         scheduleSseReconnect(retryOnFailure);
                     }
@@ -611,6 +709,8 @@ public class GBFeaturesRepository implements IGBFeaturesRepository {
                     @Override
                     public void onOpen(@NotNull EventSource eventSource, @NotNull Response response) {
                         super.onOpen(eventSource, response);
+                        sseConnected.set(true);
+                        sseRetryAttempts.set(0);
                         sseReconnectScheduled.set(false);
                     }
                 };
@@ -701,7 +801,7 @@ public class GBFeaturesRepository implements IGBFeaturesRepository {
                 refreshMode == RefreshMode.FORCE,
                 this.backgroundFetchInterval,
                 this.lastSuccessfulFetchAtMillis::get,
-                () -> FeatureRefreshCacheFreshness.timestampMillisOrUnknown(getCacheLastUpdatedMillis()),
+                () -> FeatureRefreshCacheFreshness.timestampMillisOrUnknown(readCacheLastUpdatedMillis()),
                 this.hasFeatureData::get,
                 this::loadCachedFeaturesIfAvailable
         );
@@ -752,7 +852,7 @@ public class GBFeaturesRepository implements IGBFeaturesRepository {
         Request.Builder requestBuilder = new Request.Builder()
                 .url(this.featuresEndpoint);
 
-        if (this.featuresEndpoint.matches(FEATURES_PATH_PATTERN)) {
+        if (this.featuresEndpoint.matches(FEATURES_ENDPOINT_PATTERN)) {
             if (refreshMode == RefreshMode.FORCE) {
                 requestBuilder.header(HttpHeaders.CACHE_CONTROL.getHeader(), "no-cache");
             } else {
@@ -781,16 +881,20 @@ public class GBFeaturesRepository implements IGBFeaturesRepository {
     }
 
     private void handleFetchFailure(FeatureFetchException failure) throws FeatureFetchException {
+        boolean hadFeatureData = this.hasFeatureData.get();
+        recordRefreshError(failure);
         FeatureFetchFailureHandler.handle(
                 failure,
                 this::onRefreshFailed,
                 this.hasFeatureData::get,
                 this::loadCachedFeaturesIfAvailable
         );
+        boolean loadedFromCache = !hadFeatureData && this.hasFeatureData.get();
+        recordRefreshFailure(loadedFromCache);
     }
 
     @Nullable
-    private Long getCacheLastUpdatedMillis() {
+    private Long readCacheLastUpdatedMillis() {
         if (this.isCacheDisabled || this.cacheManager == null) {
             return null;
         }
@@ -819,6 +923,27 @@ public class GBFeaturesRepository implements IGBFeaturesRepository {
             log.warn("Failed to load cached features.", cacheException);
             return false;
         }
+    }
+
+    private void recordRefreshError(Throwable throwable) {
+        Throwable error = throwable == null
+                ? new FeatureFetchException(FeatureFetchException.FeatureFetchErrorCode.UNKNOWN)
+                : throwable;
+        this.lastRefreshError.set(error);
+        this.lastRefreshErrorAtMillis.set(System.currentTimeMillis());
+    }
+
+    private void recordRefreshSuccess(boolean loadedFromCache) {
+        this.refreshSuccessCount.incrementAndGet();
+        this.refreshConsecutiveFailures.set(0);
+        this.lastRefreshLoadedFromCache.set(loadedFromCache);
+    }
+
+    private void recordRefreshFailure(boolean loadedFromCache) {
+        this.refreshFailureCount.incrementAndGet();
+        this.refreshConsecutiveFailures.incrementAndGet();
+        this.lastRefreshFailureAtMillis.set(System.currentTimeMillis());
+        this.lastRefreshLoadedFromCache.set(loadedFromCache);
     }
 
     /**
@@ -929,6 +1054,10 @@ public class GBFeaturesRepository implements IGBFeaturesRepository {
         }
     }
 
+    public int getActiveFeatureCount() {
+        return this.parsedFeatures == null ? 0 : this.parsedFeatures.size();
+    }
+
     /**
      * Handles the successful features fetching response
      *
@@ -942,6 +1071,7 @@ public class GBFeaturesRepository implements IGBFeaturesRepository {
                 log.info("Features not modified (304). Using existing data.");
                 this.refreshExpiresAt();
                 this.onRefreshSuccess(this.featuresJson);
+                recordRefreshSuccess(false);
                 return;
             }
 
@@ -972,7 +1102,7 @@ public class GBFeaturesRepository implements IGBFeaturesRepository {
                 );
             }
 
-            if (response.code() == HttpURLConnection.HTTP_OK && this.featuresEndpoint.matches(FEATURES_PATH_PATTERN)) {
+            if (response.code() == HttpURLConnection.HTTP_OK && this.featuresEndpoint.matches(FEATURES_ENDPOINT_PATTERN)) {
                 String newETag = response.header("ETag");
                 if (newETag != null) {
                     eTagCache.put(this.featuresEndpoint, newETag);
@@ -980,6 +1110,7 @@ public class GBFeaturesRepository implements IGBFeaturesRepository {
             }
 
             onResponseJson(responseBody.string(), false);
+            recordRefreshSuccess(false);
 
         } catch (IOException e) {
             log.error("FeatureFetchException: UNKNOWN feature fetch error code {}", e.getMessage(), e);
@@ -1047,6 +1178,7 @@ public class GBFeaturesRepository implements IGBFeaturesRepository {
 
     public void shutdown() {
         this.shuttingDown.set(true);
+        this.sseConnected.set(false);
         this.featureRefreshScheduler.shutdown();
         // stop polling
         if (this.pollScheduler != null) {
@@ -1109,11 +1241,17 @@ public class GBFeaturesRepository implements IGBFeaturesRepository {
             if (response.isSuccessful() && response.code() == 200) {
                 onSuccess(response);
             } else {
-                onRefreshFailed(new Throwable("Response is not success, response code is:" + response.code() + ". And message is: " + response.message()));
+                Throwable error = new Throwable("Response is not success, response code is:" + response.code() + ". And message is: " + response.message());
+                recordRefreshError(error);
+                recordRefreshFailure(false);
+                onRefreshFailed(error);
             }
         } catch (IOException e) {
             log.error(e.getMessage(), e);
-            throw new FeatureFetchException(FeatureFetchException.FeatureFetchErrorCode.NO_RESPONSE_ERROR, e.getMessage());
+            FeatureFetchException fetchException = new FeatureFetchException(FeatureFetchException.FeatureFetchErrorCode.NO_RESPONSE_ERROR, e.getMessage());
+            recordRefreshError(fetchException);
+            recordRefreshFailure(false);
+            throw fetchException;
         }
     }
 

--- a/lib/src/main/java/growthbook/sdk/java/repository/IGBFeaturesRepository.java
+++ b/lib/src/main/java/growthbook/sdk/java/repository/IGBFeaturesRepository.java
@@ -3,6 +3,8 @@ package growthbook.sdk.java.repository;
 import growthbook.sdk.java.exception.FeatureFetchException;
 import growthbook.sdk.java.callback.FeatureRefreshCallback;
 
+import javax.annotation.Nullable;
+
 /**
  * INTERNAL: Interface that is used internally for the {@link GBFeaturesRepository}
  */
@@ -22,4 +24,45 @@ public interface IGBFeaturesRepository {
      * Clears the feature refresh callbacks
      */
     void clearCallbacks();
+
+    /**
+     * Returns the most recent feature refresh error, if any. Used for diagnostics only.
+     *
+     * @return the last refresh {@link Throwable}, or {@code null} when no refresh has failed
+     */
+    @Nullable
+    default Throwable getLastRefreshError() {
+        return null;
+    }
+
+    /**
+     * Returns the epoch-millis timestamp of the most recent feature refresh error. Used for
+     * diagnostics only.
+     *
+     * @return the timestamp in milliseconds, or {@code 0} when no refresh has failed
+     */
+    default long getLastRefreshErrorAtMillis() {
+        return 0L;
+    }
+
+    default long getRefreshSuccessCount() {
+        return 0L;
+    }
+
+    default long getRefreshFailureCount() {
+        return 0L;
+    }
+
+    default long getRefreshConsecutiveFailureCount() {
+        return 0L;
+    }
+
+    default long getLastRefreshFailureAtMillis() {
+        return 0L;
+    }
+
+    @Nullable
+    default Boolean getLastRefreshLoadedFromCache() {
+        return null;
+    }
 }

--- a/lib/src/main/java/growthbook/sdk/java/repository/NativeJavaGbFeatureRepository.java
+++ b/lib/src/main/java/growthbook/sdk/java/repository/NativeJavaGbFeatureRepository.java
@@ -1,7 +1,13 @@
 package growthbook.sdk.java.repository;
 
+import static growthbook.sdk.java.constants.SDKConstants.Endpoints.DEFAULT_API_HOST;
+import static growthbook.sdk.java.constants.SDKConstants.Endpoints.FEATURES_ENDPOINT_PATH;
+import static growthbook.sdk.java.constants.SDKConstants.Endpoints.FEATURES_ENDPOINT_PATTERN;
+import static growthbook.sdk.java.constants.SDKConstants.Endpoints.STREAMING_ENDPOINT_PATH;
+
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import growthbook.sdk.java.constants.SDKConstants;
 import growthbook.sdk.java.exception.RetryableFeatureFetchException;
 import growthbook.sdk.java.featurefetch.FeatureFetchFailureHandler;
 import growthbook.sdk.java.featurefetch.FeatureFetchHttpStatus;
@@ -63,7 +69,6 @@ public class NativeJavaGbFeatureRepository implements IGBFeaturesRepository {
     private static final String FILE_NAME_FOR_CACHE = "FEATURE_CACHE.json";
     public static final String FILE_PATH_FOR_CACHE = "src/main/resources";
     public static final String EMPTY_JSON_OBJECT_STRING = "{}";
-    private static final String FEATURES_PATH_PATTERN = ".*/api/features/[^/]+";
 
     /**
      * Thread-safe LRU cache with max 100 entries to prevent unbounded growth
@@ -232,16 +237,18 @@ public class NativeJavaGbFeatureRepository implements IGBFeaturesRepository {
             throw new IllegalArgumentException("backgroundFetchInterval must not be negative");
         }
         if (apiHost == null) {
-            apiHost = "https://cdn.growthbook.io";
+            apiHost = DEFAULT_API_HOST;
         }
         this.refreshStrategy = refreshStrategy == null ? FeatureRefreshStrategy.STALE_WHILE_REVALIDATE : refreshStrategy;
-        this.featuresEndpoint = apiHost + "/api/features/" + clientKey;
-        this.eventsEndpoint = apiHost + "/sub/" + clientKey;
+        this.featuresEndpoint = apiHost + FEATURES_ENDPOINT_PATH + clientKey;
+        this.eventsEndpoint = apiHost + STREAMING_ENDPOINT_PATH + clientKey;
         this.remoteEvalEndPoint = RemoteEvalEndpoints.evalEndpoint(apiHost, clientKey);
         this.requestBodyForRemoteEval = requestBodyForRemoteEval;
 
         this.encryptionKey = encryptionKey;
-        this.swrTtlSeconds = swrTtlSeconds == null ? new AtomicInteger(60) : new AtomicInteger(swrTtlSeconds);
+        this.swrTtlSeconds = swrTtlSeconds == null
+                ? new AtomicInteger(SDKConstants.DEFAULT_SWR_TTL_SECONDS)
+                : new AtomicInteger(swrTtlSeconds);
         this.backgroundFetchInterval = backgroundFetchInterval;
         this.retryPolicy = retryPolicy == null ? new FeatureFetchRetryPolicy() : retryPolicy;
         this.featureFetchRetryExecutor = new FeatureFetchRetryExecutor(this.retryPolicy);
@@ -429,7 +436,7 @@ public class NativeJavaGbFeatureRepository implements IGBFeaturesRepository {
             URL url = new URL(this.featuresEndpoint);
             connection = (HttpURLConnection) url.openConnection();
             connection.setRequestMethod(HttpMethods.GET.getMethod());
-            if (this.featuresEndpoint.matches(FEATURES_PATH_PATTERN)) {
+            if (this.featuresEndpoint.matches(FEATURES_ENDPOINT_PATTERN)) {
                 if (refreshMode == RefreshMode.FORCE) {
                     connection.setRequestProperty(HttpHeaders.CACHE_CONTROL.getHeader(), "no-cache");
                 } else {
@@ -451,7 +458,7 @@ public class NativeJavaGbFeatureRepository implements IGBFeaturesRepository {
             }
 
             if (responseCode == HttpURLConnection.HTTP_OK) {
-                if (this.featuresEndpoint.matches(FEATURES_PATH_PATTERN)) {
+                if (this.featuresEndpoint.matches(FEATURES_ENDPOINT_PATTERN)) {
                     String newEtag = connection.getHeaderField("ETag");
                     if (newEtag != null) {
                         eTagCache.put(this.featuresEndpoint, newEtag);

--- a/lib/src/test/java/growthbook/sdk/java/multiusermode/GrowthBookClientDiagnosticsTest.java
+++ b/lib/src/test/java/growthbook/sdk/java/multiusermode/GrowthBookClientDiagnosticsTest.java
@@ -1,0 +1,526 @@
+package growthbook.sdk.java.multiusermode;
+
+import growthbook.sdk.java.Version;
+import growthbook.sdk.java.diagnostics.model.Diagnostics;
+import growthbook.sdk.java.diagnostics.model.enums.CacheState;
+import growthbook.sdk.java.diagnostics.model.enums.DiagnosticsHealthState;
+import growthbook.sdk.java.diagnostics.model.enums.DiagnosticsIssueCode;
+import growthbook.sdk.java.diagnostics.model.enums.FeatureDataSource;
+import growthbook.sdk.java.diagnostics.model.enums.FeatureState;
+import growthbook.sdk.java.diagnostics.model.enums.StreamingState;
+import growthbook.sdk.java.exception.FeatureFetchException;
+import growthbook.sdk.java.multiusermode.configurations.Options;
+import growthbook.sdk.java.repository.FeatureRefreshStrategy;
+import growthbook.sdk.java.repository.GBFeaturesRepository;
+import growthbook.sdk.java.sandbox.CacheMode;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+
+import static growthbook.sdk.java.multiusermode.GrowthBookClientTestFixtures.createDefaultOptions;
+import static growthbook.sdk.java.multiusermode.GrowthBookClientTestFixtures.createMockBuilder;
+import static growthbook.sdk.java.multiusermode.GrowthBookClientTestFixtures.createMockRepository;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.when;
+
+class GrowthBookClientDiagnosticsTest {
+
+    private GBFeaturesRepository mockRepository;
+    private GBFeaturesRepository.GBFeaturesRepositoryBuilder mockBuilder;
+
+    @Test
+    void test_getDiagnostics_beforeInitializeReportsDefaultState() {
+        GrowthBookClient client = new GrowthBookClient(createDefaultOptions(null));
+
+        Diagnostics diagnostics = client.getDiagnostics();
+
+        assertNotNull(diagnostics);
+        assertTrue(diagnostics.getGeneratedAtMillis() > 0);
+        assertEquals(Version.SDK_VERSION, diagnostics.getSdk().getVersion());
+        assertEquals(DiagnosticsHealthState.NOT_READY, diagnostics.getHealth().getState());
+        assertEquals(1, diagnostics.getHealth().getIssues().size());
+        assertEquals(
+                DiagnosticsIssueCode.CLIENT_NOT_INITIALIZED,
+                diagnostics.getHealth().getIssues().get(0).getCode()
+        );
+        assertEquals("https://custom.growthbook.io", diagnostics.getConfig().getApiHost());
+        assertEquals("cust..._key", diagnostics.getConfig().getClientKeyMasked());
+        assertEquals(
+                "https://custom.growthbook.io/api/features/cust..._key",
+                diagnostics.getConfig().getFeaturesEndpoint()
+        );
+        assertEquals("https://custom.growthbook.io/sub/cust..._key", diagnostics.getConfig().getEventsEndpoint());
+        assertTrue(diagnostics.getConfig().isEncryptionConfigured());
+        assertEquals(60, diagnostics.getConfig().getSwrTtlSeconds());
+        assertNull(diagnostics.getConfig().getBackgroundFetchIntervalMillis());
+        assertEquals(5, diagnostics.getConfig().getRetryMaxAttempts());
+        assertTrue(diagnostics.getConfig().isEnabled());
+        assertFalse(diagnostics.getConfig().isQaMode());
+        assertFalse(diagnostics.getConfig().isStickyBucketingEnabled());
+        assertFalse(diagnostics.getClient().isInitialized());
+        assertFalse(diagnostics.getClient().isShutdown());
+        assertFalse(diagnostics.getClient().isRemoteEvalEnabled());
+        assertEquals(FeatureState.NOT_LOADED, diagnostics.getFeatures().getState());
+        assertEquals(FeatureDataSource.NONE, diagnostics.getFeatures().getSource());
+        assertFalse(diagnostics.getFeatures().isAvailable());
+        assertEquals(0, diagnostics.getFeatures().getActiveFeatureCount());
+        assertEquals(0, diagnostics.getFeatures().getTotalFeatureCount());
+        assertFalse(diagnostics.getFeatures().getKeys().isAvailable());
+        assertTrue(diagnostics.getFeatures().getKeys().getSample().isEmpty());
+        assertNull(diagnostics.getFeatures().getKeys().getSha256());
+        assertEquals(FeatureRefreshStrategy.STALE_WHILE_REVALIDATE, diagnostics.getRefresh().getStrategy());
+        assertNull(diagnostics.getRefresh().getLastSuccessfulRefreshAtMillis());
+        assertNull(diagnostics.getRefresh().getLastSuccessfulRefreshAgeMillis());
+        assertNull(diagnostics.getRefresh().getNextCacheExpiresAtMillis());
+        assertNull(diagnostics.getRefresh().getMillisUntilCacheExpiry());
+        assertFalse(diagnostics.getRefresh().isStale());
+        assertEquals(0L, diagnostics.getRefresh().getSuccessCount());
+        assertEquals(0L, diagnostics.getRefresh().getFailureCount());
+        assertEquals(0L, diagnostics.getRefresh().getConsecutiveFailures());
+        assertNull(diagnostics.getRefresh().getLastFailureAtMillis());
+        assertNull(diagnostics.getRefresh().getLastLoadedFromCache());
+        assertNull(diagnostics.getRefresh().getLastError());
+        assertTrue(diagnostics.getCache().isEnabled());
+        assertEquals(CacheState.NOT_INITIALIZED, diagnostics.getCache().getState());
+        assertEquals(CacheMode.AUTO, diagnostics.getCache().getMode());
+        assertEquals(0L, diagnostics.getCache().getLastUpdatedMillis());
+        assertNull(diagnostics.getCache().getAgeMillis());
+        assertEquals(StreamingState.DISABLED, diagnostics.getStreaming().getState());
+        assertFalse(diagnostics.getRemoteEval().isEnabled());
+        assertFalse(diagnostics.getRemoteEval().isReady());
+
+        String diagnosticsJson = diagnostics.toJson();
+        assertTrue(diagnosticsJson.contains("\"config\""));
+        assertTrue(diagnosticsJson.contains("cust..._key"));
+        assertFalse(diagnosticsJson.contains("custom_key"));
+        assertFalse(diagnosticsJson.contains("test_key"));
+    }
+
+    @Test
+    void test_getDiagnostics_afterInitializeReportsRepositoryState() {
+        mockRepository = createMockRepository();
+        mockBuilder = createMockBuilder(mockRepository);
+
+        try (MockedStatic<GBFeaturesRepository> mockedStatic = mockStatic(GBFeaturesRepository.class)) {
+            mockedStatic.when(GBFeaturesRepository::builder).thenReturn(mockBuilder);
+
+            GrowthBookClient client = new GrowthBookClient(createDefaultOptions(null));
+            assertTrue(client.initialize());
+
+            Diagnostics diagnostics = client.getDiagnostics();
+
+            assertEquals(DiagnosticsHealthState.READY, diagnostics.getHealth().getState());
+            assertTrue(diagnostics.getHealth().getIssues().isEmpty());
+            assertEquals("https://custom.growthbook.io", diagnostics.getConfig().getApiHost());
+            assertEquals("cust..._key", diagnostics.getConfig().getClientKeyMasked());
+            assertEquals(
+                    "https://custom.growthbook.io/api/features/cust..._key",
+                    diagnostics.getConfig().getFeaturesEndpoint()
+            );
+            assertEquals("https://custom.growthbook.io/sub/cust..._key", diagnostics.getConfig().getEventsEndpoint());
+            assertTrue(diagnostics.getConfig().isEncryptionConfigured());
+            assertEquals(60, diagnostics.getConfig().getSwrTtlSeconds());
+            assertEquals(5, diagnostics.getConfig().getRetryMaxAttempts());
+            assertTrue(diagnostics.getClient().isInitialized());
+            assertFalse(diagnostics.getClient().isShutdown());
+            assertEquals(FeatureState.LOADED, diagnostics.getFeatures().getState());
+            assertEquals(FeatureDataSource.LOCAL_REPOSITORY, diagnostics.getFeatures().getSource());
+            assertTrue(diagnostics.getFeatures().isAvailable());
+            assertEquals(1, diagnostics.getFeatures().getActiveFeatureCount());
+            assertEquals(1, diagnostics.getFeatures().getTotalFeatureCount());
+            assertTrue(diagnostics.getFeatures().getKeys().isAvailable());
+            assertEquals(1, diagnostics.getFeatures().getKeys().getTotalCount());
+            assertEquals(20, diagnostics.getFeatures().getKeys().getSampleLimit());
+            assertEquals(Collections.singletonList("test-feature"), diagnostics.getFeatures().getKeys().getSample());
+            assertFalse(diagnostics.getFeatures().getKeys().isTruncated());
+            assertEquals(
+                    "283ea234b7cfc1f14d1965e98fbef70dec5524ce5cbc38d946846648572501f6",
+                    diagnostics.getFeatures().getKeys().getSha256()
+            );
+            assertEquals(FeatureRefreshStrategy.STALE_WHILE_REVALIDATE, diagnostics.getRefresh().getStrategy());
+            assertNotNull(diagnostics.getRefresh().getLastSuccessfulRefreshAtMillis());
+            assertNotNull(diagnostics.getRefresh().getLastSuccessfulRefreshAgeMillis());
+            assertTrue(diagnostics.getRefresh().getLastSuccessfulRefreshAgeMillis() >= 0);
+            assertTrue(diagnostics.getRefresh().getLastSuccessfulRefreshAgeMillis() < TimeUnit.SECONDS.toMillis(10));
+            assertNotNull(diagnostics.getRefresh().getNextCacheExpiresAtMillis());
+            assertNotNull(diagnostics.getRefresh().getMillisUntilCacheExpiry());
+            assertTrue(diagnostics.getRefresh().getMillisUntilCacheExpiry() > 0);
+            assertFalse(diagnostics.getRefresh().isStale());
+            assertEquals(1L, diagnostics.getRefresh().getSuccessCount());
+            assertEquals(0L, diagnostics.getRefresh().getFailureCount());
+            assertEquals(0L, diagnostics.getRefresh().getConsecutiveFailures());
+            assertNull(diagnostics.getRefresh().getLastFailureAtMillis());
+            assertEquals(Boolean.FALSE, diagnostics.getRefresh().getLastLoadedFromCache());
+            assertNull(diagnostics.getRefresh().getLastError());
+            assertTrue(diagnostics.getCache().isEnabled());
+            assertEquals(CacheState.AVAILABLE, diagnostics.getCache().getState());
+            assertTrue(diagnostics.getCache().getLastUpdatedMillis() > 0);
+            assertNotNull(diagnostics.getCache().getAgeMillis());
+            assertTrue(diagnostics.getCache().getAgeMillis() >= 0);
+            assertTrue(diagnostics.getCache().getAgeMillis() < TimeUnit.SECONDS.toMillis(10));
+            assertEquals(StreamingState.DISABLED, diagnostics.getStreaming().getState());
+            assertEquals(0, diagnostics.getStreaming().getReconnectAttempts());
+
+            String diagnosticsJson = diagnostics.toJson();
+            assertTrue(diagnosticsJson.contains("cust..._key"));
+            assertFalse(diagnosticsJson.contains("custom_key"));
+            assertFalse(diagnosticsJson.contains("test_key"));
+        }
+    }
+
+    @Test
+    void test_getDiagnostics_reportsStaleFeatureData() {
+        mockRepository = createMockRepository();
+        long nowMillis = System.currentTimeMillis();
+        when(mockRepository.getLastSuccessfulFetchAtMillis()).thenReturn(nowMillis - TimeUnit.MINUTES.toMillis(5));
+        when(mockRepository.getExpiresAt()).thenReturn(TimeUnit.MILLISECONDS.toSeconds(nowMillis - TimeUnit.SECONDS.toMillis(1)));
+        mockBuilder = createMockBuilder(mockRepository);
+
+        try (MockedStatic<GBFeaturesRepository> mockedStatic = mockStatic(GBFeaturesRepository.class)) {
+            mockedStatic.when(GBFeaturesRepository::builder).thenReturn(mockBuilder);
+
+            GrowthBookClient client = new GrowthBookClient(createDefaultOptions(null));
+            assertTrue(client.initialize());
+
+            Diagnostics diagnostics = client.getDiagnostics();
+
+            assertTrue(diagnostics.getRefresh().isStale());
+            assertNotNull(diagnostics.getRefresh().getMillisUntilCacheExpiry());
+            assertTrue(diagnostics.getRefresh().getMillisUntilCacheExpiry() < 0);
+            assertEquals(DiagnosticsHealthState.DEGRADED, diagnostics.getHealth().getState());
+            assertTrue(diagnostics.getHealth().getIssues().stream()
+                    .anyMatch(issue -> issue.getCode() == DiagnosticsIssueCode.FEATURES_STALE));
+        }
+    }
+
+    @Test
+    void test_getDiagnostics_reportsStaleFeatureDataWhenOldCacheFallbackWasLoaded() {
+        mockRepository = createMockRepository();
+        long nowMillis = System.currentTimeMillis();
+        long cacheUpdatedMillis = nowMillis - TimeUnit.MINUTES.toMillis(5);
+        when(mockRepository.getLastSuccessfulFetchAtMillis()).thenReturn(0L);
+        when(mockRepository.getLastRefreshLoadedFromCache()).thenReturn(true);
+        when(mockRepository.getCacheLastUpdatedMillis()).thenReturn(cacheUpdatedMillis);
+        when(mockRepository.getExpiresAt()).thenReturn(TimeUnit.MILLISECONDS.toSeconds(nowMillis + TimeUnit.MINUTES.toMillis(5)));
+        mockBuilder = createMockBuilder(mockRepository);
+
+        try (MockedStatic<GBFeaturesRepository> mockedStatic = mockStatic(GBFeaturesRepository.class)) {
+            mockedStatic.when(GBFeaturesRepository::builder).thenReturn(mockBuilder);
+
+            GrowthBookClient client = new GrowthBookClient(createDefaultOptions(null));
+            assertTrue(client.initialize());
+
+            Diagnostics diagnostics = client.getDiagnostics();
+
+            assertEquals(cacheUpdatedMillis + TimeUnit.SECONDS.toMillis(60), diagnostics.getRefresh().getNextCacheExpiresAtMillis());
+            assertTrue(diagnostics.getRefresh().isStale());
+            assertTrue(diagnostics.getRefresh().getMillisUntilCacheExpiry() < 0);
+            assertEquals(DiagnosticsHealthState.DEGRADED, diagnostics.getHealth().getState());
+            assertTrue(diagnostics.getHealth().getIssues().stream()
+                    .anyMatch(issue -> issue.getCode() == DiagnosticsIssueCode.FEATURES_STALE));
+        }
+    }
+
+    @Test
+    void test_getDiagnostics_keepsHistoricalErrorWithoutDegradingHealthAfterRecovery() {
+        mockRepository = createMockRepository();
+        long nowMillis = System.currentTimeMillis();
+        when(mockRepository.getLastSuccessfulFetchAtMillis()).thenReturn(nowMillis);
+        when(mockRepository.getRefreshFailureCount()).thenReturn(1L);
+        when(mockRepository.getRefreshConsecutiveFailureCount()).thenReturn(0L);
+        when(mockRepository.getLastRefreshFailureAtMillis()).thenReturn(nowMillis - TimeUnit.SECONDS.toMillis(1));
+        when(mockRepository.getLastRefreshErrorAtMillis()).thenReturn(nowMillis - TimeUnit.SECONDS.toMillis(1));
+        when(mockRepository.getLastRefreshError()).thenReturn(new FeatureFetchException(
+                FeatureFetchException.FeatureFetchErrorCode.NO_RESPONSE_ERROR,
+                "temporary outage for custom_key"
+        ));
+        mockBuilder = createMockBuilder(mockRepository);
+
+        try (MockedStatic<GBFeaturesRepository> mockedStatic = mockStatic(GBFeaturesRepository.class)) {
+            mockedStatic.when(GBFeaturesRepository::builder).thenReturn(mockBuilder);
+
+            GrowthBookClient client = new GrowthBookClient(createDefaultOptions(null));
+            assertTrue(client.initialize());
+
+            Diagnostics diagnostics = client.getDiagnostics();
+
+            assertNotNull(diagnostics.getRefresh().getLastError());
+            assertEquals(DiagnosticsHealthState.READY, diagnostics.getHealth().getState());
+            assertFalse(diagnostics.getHealth().getIssues().stream()
+                    .anyMatch(issue -> issue.getCode() == DiagnosticsIssueCode.REFRESH_FAILED));
+        }
+    }
+
+    @Test
+    void test_getDiagnostics_reportsUnresolvedRefreshFailureAfterPriorSuccess() {
+        mockRepository = createMockRepository();
+        long nowMillis = System.currentTimeMillis();
+        when(mockRepository.getLastSuccessfulFetchAtMillis()).thenReturn(nowMillis - TimeUnit.SECONDS.toMillis(2));
+        when(mockRepository.getRefreshFailureCount()).thenReturn(1L);
+        when(mockRepository.getRefreshConsecutiveFailureCount()).thenReturn(1L);
+        when(mockRepository.getLastRefreshFailureAtMillis()).thenReturn(nowMillis - TimeUnit.SECONDS.toMillis(1));
+        when(mockRepository.getLastRefreshErrorAtMillis()).thenReturn(nowMillis - TimeUnit.SECONDS.toMillis(1));
+        when(mockRepository.getLastRefreshError()).thenReturn(new FeatureFetchException(
+                FeatureFetchException.FeatureFetchErrorCode.NO_RESPONSE_ERROR,
+                "temporary outage for custom_key"
+        ));
+        mockBuilder = createMockBuilder(mockRepository);
+
+        try (MockedStatic<GBFeaturesRepository> mockedStatic = mockStatic(GBFeaturesRepository.class)) {
+            mockedStatic.when(GBFeaturesRepository::builder).thenReturn(mockBuilder);
+
+            GrowthBookClient client = new GrowthBookClient(createDefaultOptions(null));
+            assertTrue(client.initialize());
+
+            Diagnostics diagnostics = client.getDiagnostics();
+
+            assertEquals(DiagnosticsHealthState.DEGRADED, diagnostics.getHealth().getState());
+            assertTrue(diagnostics.getHealth().getIssues().stream()
+                    .anyMatch(issue -> issue.getCode() == DiagnosticsIssueCode.REFRESH_FAILED));
+        }
+    }
+
+    @Test
+    void test_getDiagnostics_afterShutdownDoesNotReportStaleFeatureCount() {
+        mockRepository = createMockRepository();
+        mockBuilder = createMockBuilder(mockRepository);
+
+        try (MockedStatic<GBFeaturesRepository> mockedStatic = mockStatic(GBFeaturesRepository.class)) {
+            mockedStatic.when(GBFeaturesRepository::builder).thenReturn(mockBuilder);
+
+            GrowthBookClient client = new GrowthBookClient(createDefaultOptions(null));
+            assertTrue(client.initialize());
+
+            client.shutdown();
+            Diagnostics diagnostics = client.getDiagnostics();
+
+            assertEquals(DiagnosticsHealthState.SHUTDOWN, diagnostics.getHealth().getState());
+            assertEquals(1, diagnostics.getHealth().getIssues().size());
+            assertEquals(
+                    DiagnosticsIssueCode.CLIENT_SHUTDOWN,
+                    diagnostics.getHealth().getIssues().get(0).getCode()
+            );
+            assertTrue(diagnostics.getClient().isShutdown());
+            assertFalse(diagnostics.getFeatures().isAvailable());
+            assertEquals(0, diagnostics.getFeatures().getActiveFeatureCount());
+        }
+    }
+
+    @Test
+    void test_getDiagnostics_reportsFailedInitializationError() throws FeatureFetchException {
+        mockRepository = mock(GBFeaturesRepository.class);
+        when(mockRepository.getInitialized()).thenReturn(false);
+        String unsafeErrorMessage = "network unavailable for "
+                + "https://user:pass@custom.growthbook.io/api/features/custom_key?token=secret using test_key";
+        doThrow(new FeatureFetchException(FeatureFetchException.FeatureFetchErrorCode.NO_RESPONSE_ERROR, unsafeErrorMessage))
+                .when(mockRepository).initialize();
+        mockBuilder = createMockBuilder(mockRepository);
+
+        try (MockedStatic<GBFeaturesRepository> mockedStatic = mockStatic(GBFeaturesRepository.class)) {
+            mockedStatic.when(GBFeaturesRepository::builder).thenReturn(mockBuilder);
+
+            GrowthBookClient client = new GrowthBookClient(createDefaultOptions(null));
+            assertFalse(client.initialize());
+
+            Diagnostics diagnostics = client.getDiagnostics();
+
+            assertFalse(diagnostics.getClient().isInitialized());
+            assertEquals(DiagnosticsHealthState.ERROR, diagnostics.getHealth().getState());
+            assertTrue(diagnostics.getHealth().getIssues().stream()
+                    .anyMatch(issue -> issue.getCode() == DiagnosticsIssueCode.REFRESH_FAILED));
+            assertNotNull(diagnostics.getRefresh().getLastError());
+            assertEquals("FeatureFetchException", diagnostics.getRefresh().getLastError().getType());
+            assertEquals(
+                    FeatureFetchException.FeatureFetchErrorCode.NO_RESPONSE_ERROR.name(),
+                    diagnostics.getRefresh().getLastError().getCode()
+            );
+            assertTrue(diagnostics.getRefresh().getLastError().getMessage().contains("network unavailable"));
+            assertTrue(diagnostics.getRefresh().getLastError().getMessage().contains("cust..._key"));
+            assertFalse(diagnostics.getRefresh().getLastError().getMessage().contains("custom_key"));
+            assertFalse(diagnostics.getRefresh().getLastError().getMessage().contains("user:pass"));
+            assertFalse(diagnostics.getRefresh().getLastError().getMessage().contains("token=secret"));
+            assertFalse(diagnostics.getRefresh().getLastError().getMessage().contains("test_key"));
+            assertTrue(diagnostics.getRefresh().getLastError().getTimestampMillis() > 0);
+
+            String diagnosticsJson = diagnostics.toJson();
+            assertTrue(diagnosticsJson.contains("cust..._key"));
+            assertFalse(diagnosticsJson.contains("custom_key"));
+            assertFalse(diagnosticsJson.contains("user:pass"));
+            assertFalse(diagnosticsJson.contains("token=secret"));
+            assertFalse(diagnosticsJson.contains("test_key"));
+        }
+    }
+
+    @Test
+    void test_getDiagnostics_masksShortClientKeys() {
+        Options options = Options.builder()
+                .apiHost("https://custom.growthbook.io")
+                .clientKey("abc")
+                .build();
+
+        GrowthBookClient client = new GrowthBookClient(options);
+        Diagnostics diagnostics = client.getDiagnostics();
+
+        assertEquals("***", diagnostics.getConfig().getClientKeyMasked());
+        assertEquals("https://custom.growthbook.io/api/features/***", diagnostics.getConfig().getFeaturesEndpoint());
+        assertEquals("https://custom.growthbook.io/sub/***", diagnostics.getConfig().getEventsEndpoint());
+        assertFalse(diagnostics.toJson().contains("/abc"));
+    }
+
+    @Test
+    void test_getDiagnostics_redactsUrlUserInfoAndQueryParams() {
+        Options options = Options.builder()
+                .apiHost("https://user:pass@custom.growthbook.io?token=secret")
+                .clientKey("custom_key")
+                .decryptionKey("super-secret")
+                .build();
+
+        GrowthBookClient client = new GrowthBookClient(options);
+        Diagnostics diagnostics = client.getDiagnostics();
+        String diagnosticsJson = diagnostics.toJson();
+
+        assertFalse(diagnostics.getConfig().getApiHost().contains("user:pass"));
+        assertFalse(diagnostics.getConfig().getApiHost().contains("token=secret"));
+        assertFalse(diagnosticsJson.contains("user:pass"));
+        assertFalse(diagnosticsJson.contains("token=secret"));
+        assertFalse(diagnosticsJson.contains("custom_key"));
+        assertFalse(diagnosticsJson.contains("super-secret"));
+    }
+
+    @Test
+    void test_getDiagnostics_beforeInitializeDoesNotCreateRepository() {
+        try (MockedStatic<GBFeaturesRepository> mockedStatic = mockStatic(GBFeaturesRepository.class)) {
+            GrowthBookClient client = new GrowthBookClient(createDefaultOptions(null));
+
+            client.getDiagnostics();
+
+            mockedStatic.verify(GBFeaturesRepository::builder, never());
+        }
+    }
+
+    @Test
+    void test_getDiagnostics_reportsDerivedStreamingState() {
+        mockRepository = createMockRepository();
+        when(mockRepository.getRefreshStrategy()).thenReturn(FeatureRefreshStrategy.SERVER_SENT_EVENTS);
+        when(mockRepository.isSseAllowed()).thenReturn(true);
+        when(mockRepository.isSseConnected()).thenReturn(true);
+        mockBuilder = createMockBuilder(mockRepository);
+
+        try (MockedStatic<GBFeaturesRepository> mockedStatic = mockStatic(GBFeaturesRepository.class)) {
+            mockedStatic.when(GBFeaturesRepository::builder).thenReturn(mockBuilder);
+
+            Options options = Options.builder()
+                    .apiHost("https://custom.growthbook.io")
+                    .clientKey("custom_key")
+                    .decryptionKey("test_key")
+                    .refreshStrategy(FeatureRefreshStrategy.SERVER_SENT_EVENTS)
+                        .build();
+
+            GrowthBookClient client = new GrowthBookClient(options);
+            assertTrue(client.initialize());
+
+            Diagnostics diagnostics = client.getDiagnostics();
+
+            assertEquals(StreamingState.CONNECTED, diagnostics.getStreaming().getState());
+            assertEquals(DiagnosticsHealthState.READY, diagnostics.getHealth().getState());
+        }
+    }
+
+    @Test
+    void test_getDiagnostics_reportsUnsupportedStreamingStateWhenServerDoesNotAllowSse() {
+        mockRepository = createMockRepository();
+        when(mockRepository.getRefreshStrategy()).thenReturn(FeatureRefreshStrategy.SERVER_SENT_EVENTS);
+        when(mockRepository.isSseAllowed()).thenReturn(false);
+        when(mockRepository.isSseConnected()).thenReturn(false);
+        mockBuilder = createMockBuilder(mockRepository);
+
+        try (MockedStatic<GBFeaturesRepository> mockedStatic = mockStatic(GBFeaturesRepository.class)) {
+            mockedStatic.when(GBFeaturesRepository::builder).thenReturn(mockBuilder);
+
+            Options options = Options.builder()
+                    .apiHost("https://custom.growthbook.io")
+                    .clientKey("custom_key")
+                    .decryptionKey("test_key")
+                    .refreshStrategy(FeatureRefreshStrategy.SERVER_SENT_EVENTS)
+                        .build();
+
+            GrowthBookClient client = new GrowthBookClient(options);
+            assertTrue(client.initialize());
+
+            Diagnostics diagnostics = client.getDiagnostics();
+
+            assertEquals(StreamingState.UNSUPPORTED, diagnostics.getStreaming().getState());
+            assertEquals(DiagnosticsHealthState.DEGRADED, diagnostics.getHealth().getState());
+            assertTrue(diagnostics.getHealth().getIssues().stream()
+                    .anyMatch(issue -> issue.getCode() == DiagnosticsIssueCode.STREAMING_UNSUPPORTED));
+        }
+    }
+
+    @Test
+    void test_getDiagnostics_reportsInterruptedStreamingStateWhileReconnecting() {
+        mockRepository = createMockRepository();
+        when(mockRepository.getRefreshStrategy()).thenReturn(FeatureRefreshStrategy.SERVER_SENT_EVENTS);
+        when(mockRepository.isSseAllowed()).thenReturn(true);
+        when(mockRepository.isSseConnected()).thenReturn(false);
+        when(mockRepository.getSseRetryAttempts()).thenReturn(3);
+        mockBuilder = createMockBuilder(mockRepository);
+
+        try (MockedStatic<GBFeaturesRepository> mockedStatic = mockStatic(GBFeaturesRepository.class)) {
+            mockedStatic.when(GBFeaturesRepository::builder).thenReturn(mockBuilder);
+
+            Options options = Options.builder()
+                    .apiHost("https://custom.growthbook.io")
+                    .clientKey("custom_key")
+                    .decryptionKey("test_key")
+                    .refreshStrategy(FeatureRefreshStrategy.SERVER_SENT_EVENTS)
+                        .build();
+
+            GrowthBookClient client = new GrowthBookClient(options);
+            assertTrue(client.initialize());
+
+            Diagnostics diagnostics = client.getDiagnostics();
+
+            assertEquals(StreamingState.INTERRUPTED, diagnostics.getStreaming().getState());
+            assertEquals(3, diagnostics.getStreaming().getReconnectAttempts());
+            assertEquals(DiagnosticsHealthState.DEGRADED, diagnostics.getHealth().getState());
+            assertTrue(diagnostics.getHealth().getIssues().stream()
+                    .anyMatch(issue -> issue.getCode() == DiagnosticsIssueCode.STREAMING_INTERRUPTED));
+        }
+    }
+
+    @Test
+    void test_getDiagnostics_remoteEvalBeforeInitializeReportsRemoteEvalConfiguration() {
+        Options options = Options.builder()
+                .apiHost("https://custom.growthbook.io")
+                .clientKey("custom_key")
+                .remoteEval(true)
+                .remoteEvalCacheSize(42)
+                .build();
+
+        GrowthBookClient client = new GrowthBookClient(options);
+        Diagnostics diagnostics = client.getDiagnostics();
+
+        assertTrue(diagnostics.getClient().isRemoteEvalEnabled());
+        assertFalse(diagnostics.getClient().isInitialized());
+        assertEquals(DiagnosticsHealthState.NOT_READY, diagnostics.getHealth().getState());
+        assertTrue(diagnostics.getRemoteEval().isEnabled());
+        assertFalse(diagnostics.getRemoteEval().isReady());
+        assertFalse(diagnostics.getRemoteEval().isCacheConfigured());
+        assertEquals(42, diagnostics.getRemoteEval().getCacheMaxSize());
+        assertEquals(StreamingState.DISABLED, diagnostics.getStreaming().getState());
+        assertEquals(FeatureDataSource.REMOTE_EVAL_FALLBACK, diagnostics.getFeatures().getSource());
+        assertEquals(FeatureState.NOT_LOADED, diagnostics.getFeatures().getState());
+        assertEquals(0, diagnostics.getFeatures().getActiveFeatureCount());
+        assertFalse(diagnostics.getFeatures().getKeys().isAvailable());
+    }
+}

--- a/lib/src/test/java/growthbook/sdk/java/multiusermode/GrowthBookClientTest.java
+++ b/lib/src/test/java/growthbook/sdk/java/multiusermode/GrowthBookClientTest.java
@@ -27,6 +27,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static growthbook.sdk.java.multiusermode.GrowthBookClientTestFixtures.createDefaultOptions;
+import static growthbook.sdk.java.multiusermode.GrowthBookClientTestFixtures.createMockBuilder;
+import static growthbook.sdk.java.multiusermode.GrowthBookClientTestFixtures.createMockRepository;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
@@ -524,42 +527,4 @@ class GrowthBookClientTest {
         }
     }
 
-    private GBFeaturesRepository createMockRepository() {
-        GBFeaturesRepository repository = mock(GBFeaturesRepository.class);
-        when(repository.getInitialized()).thenReturn(true);
-        when(repository.getFeaturesJson()).thenReturn("{}");
-        when(repository.getSavedGroupsJson()).thenReturn("{}");
-        when(repository.getParsedFeatures()).thenReturn(new HashMap<>());
-        when(repository.getParsedSavedGroups()).thenReturn(new com.google.gson.JsonObject());
-        return repository;
-    }
-
-    private GBFeaturesRepository.GBFeaturesRepositoryBuilder createMockBuilder(GBFeaturesRepository repository) {
-        GBFeaturesRepository.GBFeaturesRepositoryBuilder builder =
-                mock(GBFeaturesRepository.GBFeaturesRepositoryBuilder.class);
-
-        when(builder.apiHost(anyString())).thenReturn(builder);
-        when(builder.clientKey(anyString())).thenReturn(builder);
-        when(builder.decryptionKey(anyString())).thenReturn(builder);
-        when(builder.refreshStrategy(any())).thenReturn(builder);
-        when(builder.swrTtlSeconds(any())).thenReturn(builder);
-        when(builder.isCacheDisabled(anyBoolean())).thenReturn(builder);
-        when(builder.requestBodyForRemoteEval(any())).thenReturn(builder);
-        when(builder.cacheManager(any())).thenReturn(builder);
-        when(builder.backgroundFetchInterval(any())).thenReturn(builder);
-        when(builder.retryPolicy(any())).thenReturn(builder);
-        when(builder.build()).thenReturn(repository);
-
-        return builder;
-    }
-
-    private Options createDefaultOptions(FeatureRefreshCallback callback) {
-        return Options.builder()
-                .apiHost("https://custom.growthbook.io")
-                .clientKey("custom_key")
-                .decryptionKey("test_key")
-                .refreshStrategy(FeatureRefreshStrategy.STALE_WHILE_REVALIDATE)
-                .featureRefreshCallback(callback)
-                .build();
-    }
 }

--- a/lib/src/test/java/growthbook/sdk/java/multiusermode/GrowthBookClientTestFixtures.java
+++ b/lib/src/test/java/growthbook/sdk/java/multiusermode/GrowthBookClientTestFixtures.java
@@ -1,0 +1,84 @@
+package growthbook.sdk.java.multiusermode;
+
+import com.google.gson.JsonObject;
+import growthbook.sdk.java.callback.FeatureRefreshCallback;
+import growthbook.sdk.java.model.Feature;
+import growthbook.sdk.java.multiusermode.configurations.Options;
+import growthbook.sdk.java.repository.FeatureRefreshStrategy;
+import growthbook.sdk.java.repository.GBFeaturesRepository;
+
+import java.util.HashMap;
+import java.util.concurrent.TimeUnit;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+final class GrowthBookClientTestFixtures {
+
+    private GrowthBookClientTestFixtures() {
+    }
+
+    static GBFeaturesRepository createMockRepository() {
+        GBFeaturesRepository repository = mock(GBFeaturesRepository.class);
+        HashMap<String, Feature<?>> features = new HashMap<>();
+        long nowMillis = System.currentTimeMillis();
+        features.put("test-feature", new Feature<>());
+        when(repository.getInitialized()).thenReturn(true);
+        when(repository.getFeaturesEndpoint()).thenReturn("https://custom.growthbook.io/api/features/custom_key");
+        when(repository.getEventsEndpoint()).thenReturn("https://custom.growthbook.io/sub/custom_key");
+        when(repository.getDecryptionKey()).thenReturn("test_key");
+        when(repository.getSwrTtlSeconds()).thenReturn(60);
+        when(repository.getFeaturesJson()).thenReturn("{}");
+        when(repository.getSavedGroupsJson()).thenReturn("{}");
+        when(repository.getParsedFeatures()).thenReturn(features);
+        when(repository.getParsedSavedGroups()).thenReturn(new JsonObject());
+        when(repository.getRefreshStrategy()).thenReturn(FeatureRefreshStrategy.STALE_WHILE_REVALIDATE);
+        when(repository.hasFeatureData()).thenReturn(true);
+        when(repository.getActiveFeatureCount()).thenReturn(features.size());
+        when(repository.getLastSuccessfulFetchAtMillis()).thenReturn(nowMillis - TimeUnit.SECONDS.toMillis(1));
+        when(repository.getExpiresAt()).thenReturn(TimeUnit.MILLISECONDS.toSeconds(nowMillis + TimeUnit.SECONDS.toMillis(60)));
+        when(repository.isCacheDisabled()).thenReturn(false);
+        when(repository.getCacheLastUpdatedMillis()).thenReturn(nowMillis - 500L);
+        when(repository.getRefreshSuccessCount()).thenReturn(1L);
+        when(repository.getRefreshFailureCount()).thenReturn(0L);
+        when(repository.getRefreshConsecutiveFailureCount()).thenReturn(0L);
+        when(repository.getLastRefreshFailureAtMillis()).thenReturn(0L);
+        when(repository.getLastRefreshLoadedFromCache()).thenReturn(false);
+        when(repository.isSseAllowed()).thenReturn(true);
+        when(repository.isSseConnected()).thenReturn(false);
+        when(repository.getSseRetryAttempts()).thenReturn(0);
+        return repository;
+    }
+
+    static GBFeaturesRepository.GBFeaturesRepositoryBuilder createMockBuilder(GBFeaturesRepository repository) {
+        GBFeaturesRepository.GBFeaturesRepositoryBuilder builder =
+                mock(GBFeaturesRepository.GBFeaturesRepositoryBuilder.class);
+
+        when(builder.apiHost(anyString())).thenReturn(builder);
+        when(builder.clientKey(anyString())).thenReturn(builder);
+        when(builder.decryptionKey(anyString())).thenReturn(builder);
+        when(builder.refreshStrategy(any())).thenReturn(builder);
+        when(builder.swrTtlSeconds(any())).thenReturn(builder);
+        when(builder.isCacheDisabled(anyBoolean())).thenReturn(builder);
+        when(builder.requestBodyForRemoteEval(any())).thenReturn(builder);
+        when(builder.cacheManager(any())).thenReturn(builder);
+        when(builder.backgroundFetchInterval(any())).thenReturn(builder);
+        when(builder.retryPolicy(any())).thenReturn(builder);
+        when(builder.build()).thenReturn(repository);
+
+        return builder;
+    }
+
+    static Options createDefaultOptions(FeatureRefreshCallback callback) {
+        return Options.builder()
+                .apiHost("https://custom.growthbook.io")
+                .clientKey("custom_key")
+                .decryptionKey("test_key")
+                .refreshStrategy(FeatureRefreshStrategy.STALE_WHILE_REVALIDATE)
+                .featureRefreshCallback(callback)
+                .build();
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds a diagnostics API for `GrowthBookClient`.

The new API exposes a read-only snapshot of the current SDK state:

```java
Diagnostics diagnostics = client.getDiagnostics();
String json = diagnostics.toJson();
```

The goal is to make SDK support and debugging easier by answering common runtime questions:

* Is the client initialized?
* Is feature data loaded?
* When were features last refreshed?
* Is the current feature data stale?
* Is caching enabled and when was it updated?
* Is streaming configured, connected, or interrupted?
* What SDK configuration is currently active?
* What was the last refresh error?
* Are refreshes succeeding or repeatedly failing?

## Motivation

Before this change, users had very limited visibility into the internal SDK state.

If feature evaluations behaved unexpectedly, support and debugging usually required manually checking configuration, logs, cache state, refresh behavior, and streaming behavior separately.

This PR introduces a structured diagnostics snapshot that can be inspected programmatically or copied as JSON into a support ticket.

## Public API

A new method is available on `GrowthBookClient`:

```java
Diagnostics diagnostics = client.getDiagnostics();
```

The returned object is immutable and read-only.

Calling `getDiagnostics()` does not trigger:

* feature evaluation
* feature refresh
* network calls
* state mutation

A JSON helper is also available:

```java
String diagnosticsJson = diagnostics.toJson();
```

## Diagnostics Response

The diagnostics response is organized into several sections.

### `sdk`

SDK metadata.

```json
{
  "sdk": {
    "version": "..."
  }
}
```

### `health`

A high-level derived health summary.

```json
{
  "health": {
    "state": "READY",
    "issues": []
  }
}
```

Possible health states:

* `READY`
* `NOT_READY`
* `DEGRADED`
* `ERROR`
* `SHUTDOWN`

Health issues include stable machine-readable codes, severity, message, and timestamp.

Example:

```json
{
  "code": "FEATURES_STALE",
  "severity": "WARNING",
  "message": "Feature data is past its cache expiry.",
  "timestampMillis": 123456789
}
```

### `config`

Sanitized SDK configuration metadata.

```json
{
  "config": {
    "apiHost": "https://custom.growthbook.io",
    "featuresEndpoint": "https://custom.growthbook.io/api/features/cust..._key",
    "eventsEndpoint": "https://custom.growthbook.io/sub/cust..._key",
    "clientKeyMasked": "cust..._key",
    "encryptionConfigured": true,
    "swrTtlSeconds": 60,
    "backgroundFetchIntervalMillis": null,
    "retryMaxAttempts": 5,
    "enabled": true,
    "qaMode": false,
    "stickyBucketingEnabled": false
  }
}
```

Sensitive values are not exposed:

* `clientKey` is masked
* encryption/decryption keys are never returned
* encryption state is exposed only as `encryptionConfigured`

### `client`

Client lifecycle state.

```json
{
  "client": {
    "initialized": true,
    "shutdown": false,
    "remoteEvalEnabled": false
  }
}
```

### `features`

Current feature data state.

```json
{
  "features": {
    "state": "LOADED",
    "source": "LOCAL_REPOSITORY",
    "available": true,
    "activeFeatureCount": 12,
    "totalFeatureCount": 12,
    "keys": {
      "available": true,
      "totalCount": 12,
      "sampleLimit": 20,
      "sample": ["checkout-flow", "payment-config"],
      "truncated": false,
      "sha256": "..."
    }
  }
}
```

Feature keys are sampled and hashed to make it easier to compare feature snapshots without dumping the full feature payload.

### `refresh`

Feature refresh state, freshness, errors, and counters.

```json
{
  "refresh": {
    "strategy": "STALE_WHILE_REVALIDATE",
    "lastSuccessfulRefreshAtMillis": 123456789,
    "lastSuccessfulRefreshAgeMillis": 1000,
    "nextCacheExpiresAtMillis": 123516789,
    "millisUntilCacheExpiry": 59000,
    "stale": false,
    "successCount": 1,
    "failureCount": 0,
    "consecutiveFailures": 0,
    "lastFailureAtMillis": null,
    "lastLoadedFromCache": false,
    "lastError": null
  }
}
```

This makes it possible to distinguish between:

* features were never refreshed
* features were recently refreshed
* current feature data is stale
* refresh is repeatedly failing
* SDK is falling back to cached data

### `cache`

Cache status and freshness.

```json
{
  "cache": {
    "state": "AVAILABLE",
    "mode": "AUTO",
    "enabled": true,
    "lastUpdatedMillis": 123456789,
    "ageMillis": 1000
  }
}
```

### `streaming`

Streaming / SSE state.

```json
{
  "streaming": {
    "state": "CONNECTED",
    "reconnectAttempts": 0
  }
}
```

Possible streaming states include:

* `DISABLED`
* `INITIALIZING`
* `CONNECTED`
* `INTERRUPTED`
* `UNSUPPORTED`
* `SHUTDOWN`

### `remoteEval`

Remote evaluation configuration and status.

```json
{
  "remoteEval": {
    "enabled": false,
    "ready": false,
    "cacheConfigured": false,
    "cacheSize": 1000,
    "cacheTtlSeconds": null
  }
}
```

Note: `cacheSize` and `cacheTtlSeconds` currently represent configured remote-eval cache values, not live cache occupancy.

## Security

Diagnostics output is intended to be safe for support workflows.

This PR avoids exposing sensitive values:

* raw `clientKey` is masked
* full feature and SSE endpoints are masked
* `decryptionKey` / legacy `encryptionKey` values are never returned
* refresh error messages are sanitized before being exposed
* `toJson()` serializes already-sanitized diagnostics data

Example:

```text
https://custom.growthbook.io/api/features/custom_key using test_key
```

becomes:

```text
https://custom.growthbook.io/api/features/cust..._key using [redacted]
```

## Implementation Notes

* Diagnostics are built as a fresh snapshot on each `getDiagnostics()` call.
* The API is read-only and does not affect feature evaluation.
* Health is derived from lower-level diagnostics sections.
* Feature key diagnostics include a sorted sample and SHA-256 hash.
* Refresh counters are tracked in `FeatureRefreshNotifier`, even when no listeners are registered.
* Shared endpoint and default constants were moved to `SDKConstants`.

esEndpoint() != null) {
lib/src/main/java/growthbook/sdk/java/diagnostics/provider/helper/ConfigDiagnosticsMapper.java:89:            return repository.getFeaturesEndpoint();
lib/src/main/java/growthbook/sdk/java/diagnostics/provider/helper/ConfigDiagnosticsMapper.java:100:        if (repository != null && repository.getEventsEndpoint() != null) {
lib/src/main/java/growthbook/sdk/java/diagnostics/provider/helper/ConfigDiagnosticsMapper.java:101:            return repository.getEventsEndpoint();

## Tests

Added dedicated diagnostics coverage for:

* diagnostics before initialization
* diagnostics after initialization
* shutdown state
* failed initialization errors
* sanitized error messages in `toJson()`
* stale feature data health issue
* streaming derived states
* remote-eval diagnostics

Also moved diagnostics-related `GrowthBookClient` tests into a dedicated
`GrowthBookClientDiagnosticsTest` class and extracted shared test fixtures.
