### PR TITLE
feat: add Caffeine cache adapter module

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,38 @@ The SDK supports multiple cache modes for persisting feature payloads:
 
 You can configure these through `Options` when using `GrowthBookClient`, or via the repository builder’s `cacheManager` directly. When cache is disabled (`isCacheDisabled=true`), the repository won’t attempt any persistence.
 
+### Caffeine cache adapter
+
+The optional `growthbook-cache-caffeine` module provides a Caffeine-backed `GbCacheManager` for applications that want a production-ready in-process cache without using filesystem persistence.
+
+```groovy
+dependencies {
+    implementation 'com.github.growthbook:growthbook-sdk-java:<version>'
+    implementation 'com.github.growthbook:growthbook-cache-caffeine:<version>'
+}
+```
+
+```java
+import growthbook.sdk.java.cache.caffeine.CaffeineGbCacheManager;
+import growthbook.sdk.java.multiusermode.GrowthBookClient;
+import growthbook.sdk.java.multiusermode.configurations.Options;
+import growthbook.sdk.java.sandbox.CacheMode;
+
+import java.time.Duration;
+
+Options options = Options.builder()
+        .apiHost("https://cdn.growthbook.io")
+        .clientKey("sdk-abc123")
+        .cacheMode(CacheMode.CUSTOM)
+        .cacheManager(CaffeineGbCacheManager.builder()
+                .maximumSize(1000)
+                .expireAfterWrite(Duration.ofMinutes(30))
+                .buildManager())
+        .build();
+
+GrowthBookClient gb = new GrowthBookClient(options);
+```
+
 ### STALE_WHILE_REVALIDATE (default)
 
 With the SWR strategy, the repository will:

--- a/growthbook-cache-caffeine/build.gradle
+++ b/growthbook-cache-caffeine/build.gradle
@@ -1,0 +1,71 @@
+plugins {
+    id 'java-library'
+    id 'maven-publish'
+}
+
+sourceCompatibility = JavaVersion.VERSION_1_8
+targetCompatibility = JavaVersion.VERSION_1_8
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    api project(':lib')
+
+    implementation 'com.github.ben-manes.caffeine:caffeine:2.9.3'
+
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.8.2'
+}
+
+java {
+    withSourcesJar()
+    withJavadocJar()
+}
+
+tasks.named('test') {
+    useJUnitPlatform()
+}
+
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            from components.java
+
+            pom {
+                name = 'GrowthBook SDK Java Caffeine Cache Adapter'
+                description = 'Optional Caffeine cache adapter for the GrowthBook Java SDK'
+                url = 'https://github.com/growthbook/growthbook-sdk-java'
+                licenses {
+                    license {
+                        name = 'MIT License'
+                        url = 'https://github.com/growthbook/growthbook-sdk-java/blob/main/LICENSE'
+                    }
+                }
+                developers {
+                    developer {
+                        id = 'growthbook'
+                        name = 'GrowthBook'
+                        email = 'hello@growthbook.io'
+                    }
+                }
+                scm {
+                    connection = 'scm:git:git://github.com/growthbook/growthbook-sdk-java.git'
+                    developerConnection = 'scm:git:ssh://github.com:growthbook/growthbook-sdk-java.git'
+                    url = 'https://github.com/growthbook/growthbook-sdk-java'
+                }
+            }
+        }
+    }
+
+    repositories {
+        maven {
+            name = "GitHubPackages"
+            url = uri("https://maven.pkg.github.com/growthbook/growthbook-sdk-java")
+            credentials {
+                username = System.getenv("GITHUB_ACTOR")
+                password = System.getenv("GITHUB_TOKEN")
+            }
+        }
+    }
+}

--- a/growthbook-cache-caffeine/src/main/java/growthbook/sdk/java/cache/caffeine/CaffeineCacheEntry.java
+++ b/growthbook-cache-caffeine/src/main/java/growthbook/sdk/java/cache/caffeine/CaffeineCacheEntry.java
@@ -1,0 +1,20 @@
+package growthbook.sdk.java.cache.caffeine;
+
+final class CaffeineCacheEntry {
+
+    private final String data;
+    private final long lastUpdatedMillis;
+
+    CaffeineCacheEntry(String data, long lastUpdatedMillis) {
+        this.data = data;
+        this.lastUpdatedMillis = lastUpdatedMillis;
+    }
+
+    String getData() {
+        return data;
+    }
+
+    long getLastUpdatedMillis() {
+        return lastUpdatedMillis;
+    }
+}

--- a/growthbook-cache-caffeine/src/main/java/growthbook/sdk/java/cache/caffeine/CaffeineCacheOptions.java
+++ b/growthbook-cache-caffeine/src/main/java/growthbook/sdk/java/cache/caffeine/CaffeineCacheOptions.java
@@ -1,0 +1,166 @@
+package growthbook.sdk.java.cache.caffeine;
+
+import com.github.benmanes.caffeine.cache.Ticker;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.util.Objects;
+
+/**
+ * Configuration for {@link CaffeineGbCacheManager}.
+ */
+public final class CaffeineCacheOptions {
+
+    public static final long DEFAULT_MAXIMUM_SIZE = 1000L;
+
+    private final Clock clock;
+    private final Ticker ticker;
+    private final long maximumSize;
+    private final Long maximumWeight;
+    private final boolean recordStats;
+    private final Duration expireAfterWrite;
+    private final Duration expireAfterAccess;
+
+    private CaffeineCacheOptions(Builder builder) {
+        this.maximumSize = builder.maximumSize;
+        this.maximumWeight = builder.maximumWeight;
+        this.expireAfterWrite = builder.expireAfterWrite;
+        this.expireAfterAccess = builder.expireAfterAccess;
+        this.recordStats = builder.recordStats;
+        this.clock = builder.clock;
+        this.ticker = builder.ticker;
+    }
+
+    public static CaffeineCacheOptions defaults() {
+        return builder().build();
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public long getMaximumSize() {
+        return maximumSize;
+    }
+
+    /**
+     * @return the maximum total payload weight (in bytes) before size-based eviction, or
+     * {@code null} when entry-count bounding ({@link #getMaximumSize()}) is used instead
+     */
+    public Long getMaximumWeight() {
+        return maximumWeight;
+    }
+
+    public Duration getExpireAfterWrite() {
+        return expireAfterWrite;
+    }
+
+    public Duration getExpireAfterAccess() {
+        return expireAfterAccess;
+    }
+
+    public boolean isRecordStats() {
+        return recordStats;
+    }
+
+    public Clock getClock() {
+        return clock;
+    }
+
+    public Ticker getTicker() {
+        return ticker;
+    }
+
+    public static final class Builder {
+        private long maximumSize = DEFAULT_MAXIMUM_SIZE;
+        private Long maximumWeight;
+        private Duration expireAfterWrite;
+        private Duration expireAfterAccess;
+        private boolean recordStats;
+        private Clock clock = Clock.systemUTC();
+        private Ticker ticker;
+
+        private Builder() {
+        }
+
+        /**
+         * Bounds the cache by entry count. Ignored when {@link #maximumWeight(long)} is set, which
+         * takes precedence.
+         */
+        public Builder maximumSize(long maximumSize) {
+            if (maximumSize <= 0) {
+                throw new IllegalArgumentException("maximumSize must be greater than 0");
+            }
+            this.maximumSize = maximumSize;
+            return this;
+        }
+
+        /**
+         * Bounds the cache by total payload weight in bytes (UTF-8 length of cached values).
+         *
+         * <p>This is the recommended bound for the GrowthBook feature cache: it stores a single
+         * large JSON payload per endpoint, so entry-count limits via {@link #maximumSize(long)} do
+         * not meaningfully constrain memory. When set, {@code maximumWeight} takes precedence over
+         * {@code maximumSize}.
+         */
+        public Builder maximumWeight(long maximumWeight) {
+            if (maximumWeight <= 0) {
+                throw new IllegalArgumentException("maximumWeight must be greater than 0");
+            }
+            this.maximumWeight = maximumWeight;
+            return this;
+        }
+
+        public Builder expireAfterWrite(Duration expireAfterWrite) {
+            if (expireAfterWrite != null && (expireAfterWrite.isZero() || expireAfterWrite.isNegative())) {
+                throw new IllegalArgumentException("expireAfterWrite must be greater than 0");
+            }
+            this.expireAfterWrite = expireAfterWrite;
+            return this;
+        }
+
+        /**
+         * Evicts an entry when it has not been accessed for the given duration.
+         *
+         * <p>Note: cache reads count as accesses. Because the SDK reads through
+         * {@code loadCache} and {@code getLastUpdatedMillis} (both lookups), each read resets this
+         * timer — an entry expires only after it has been idle (neither written nor read) for the
+         * configured duration.
+         */
+        public Builder expireAfterAccess(Duration expireAfterAccess) {
+            if (expireAfterAccess != null && (expireAfterAccess.isZero() || expireAfterAccess.isNegative())) {
+                throw new IllegalArgumentException("expireAfterAccess must be greater than 0");
+            }
+            this.expireAfterAccess = expireAfterAccess;
+            return this;
+        }
+
+        public Builder recordStats(boolean recordStats) {
+            this.recordStats = recordStats;
+            return this;
+        }
+
+        public Builder clock(Clock clock) {
+            this.clock = Objects.requireNonNull(clock, "clock");
+            return this;
+        }
+
+        public Builder ticker(Ticker ticker) {
+            this.ticker = Objects.requireNonNull(ticker, "ticker");
+            return this;
+        }
+
+        public CaffeineCacheOptions build() {
+            return new CaffeineCacheOptions(this);
+        }
+
+        /**
+         * Convenience terminal that builds these options into a ready-to-use cache manager.
+         *
+         * @return a {@link CaffeineGbCacheManager} configured with these options
+         */
+        public CaffeineGbCacheManager buildManager() {
+            return CaffeineGbCacheManager.create(build());
+        }
+    }
+}

--- a/growthbook-cache-caffeine/src/main/java/growthbook/sdk/java/cache/caffeine/CaffeineCacheStats.java
+++ b/growthbook-cache-caffeine/src/main/java/growthbook/sdk/java/cache/caffeine/CaffeineCacheStats.java
@@ -1,0 +1,77 @@
+package growthbook.sdk.java.cache.caffeine;
+
+/**
+ * Immutable snapshot of {@link CaffeineGbCacheManager} cache statistics.
+ *
+ * <p>Values are meaningful only when statistics recording is enabled via
+ * {@link CaffeineCacheOptions.Builder#recordStats(boolean)}; otherwise every counter is {@code 0}.
+ * This type intentionally does not expose the underlying Caffeine {@code CacheStats}, so callers
+ * (for example the SDK diagnostics layer) can read cache health without a Caffeine dependency.
+ */
+public final class CaffeineCacheStats {
+
+    private final long hitCount;
+    private final long missCount;
+    private final boolean recording;
+    private final long evictionCount;
+
+    CaffeineCacheStats(boolean recording, long hitCount, long missCount, long evictionCount) {
+        this.recording = recording;
+        this.hitCount = hitCount;
+        this.missCount = missCount;
+        this.evictionCount = evictionCount;
+    }
+
+    /**
+     * @return whether statistics recording is enabled; when {@code false} all counters are {@code 0}
+     */
+    public boolean isRecording() {
+        return recording;
+    }
+
+    /**
+     * @return number of cache lookups that returned a stored value
+     */
+    public long getHitCount() {
+        return hitCount;
+    }
+
+    /**
+     * @return number of cache lookups that did not return a stored value
+     */
+    public long getMissCount() {
+        return missCount;
+    }
+
+    /**
+     * @return number of cache lookups recorded ({@code hitCount + missCount})
+     */
+    public long getRequestCount() {
+        return hitCount + missCount;
+    }
+
+    /**
+     * @return ratio of hits to lookups in {@code [0.0, 1.0]}, or {@code 1.0} when no lookups occurred
+     */
+    public double getHitRate() {
+        long requestCount = getRequestCount();
+        return requestCount == 0 ? 1.0 : (double) hitCount / requestCount;
+    }
+
+    /**
+     * @return number of entries evicted (by size or expiry)
+     */
+    public long getEvictionCount() {
+        return evictionCount;
+    }
+
+    @Override
+    public String toString() {
+        return "CaffeineCacheStats{"
+                + "recording=" + recording
+                + ", hitCount=" + hitCount
+                + ", missCount=" + missCount
+                + ", evictionCount=" + evictionCount
+                + '}';
+    }
+}

--- a/growthbook-cache-caffeine/src/main/java/growthbook/sdk/java/cache/caffeine/CaffeineGbCacheManager.java
+++ b/growthbook-cache-caffeine/src/main/java/growthbook/sdk/java/cache/caffeine/CaffeineGbCacheManager.java
@@ -1,0 +1,159 @@
+package growthbook.sdk.java.cache.caffeine;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.Weigher;
+import com.github.benmanes.caffeine.cache.stats.CacheStats;
+import growthbook.sdk.java.exception.FeatureCacheException;
+import growthbook.sdk.java.sandbox.GbCacheManager;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Clock;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Caffeine-backed implementation of {@link GbCacheManager}.
+ */
+public final class CaffeineGbCacheManager implements GbCacheManager {
+
+    private final Clock clock;
+    private final boolean recordStats;
+    private final Cache<String, CaffeineCacheEntry> cache;
+
+    private CaffeineGbCacheManager(CaffeineCacheOptions options) {
+        this.cache = createCache(options);
+        this.clock = options.getClock();
+        this.recordStats = options.isRecordStats();
+    }
+
+    public static CaffeineGbCacheManager create() {
+        return new CaffeineGbCacheManager(CaffeineCacheOptions.defaults());
+    }
+
+    public static CaffeineGbCacheManager create(CaffeineCacheOptions options) {
+        return new CaffeineGbCacheManager(options);
+    }
+
+    /**
+     * @return the shared configuration builder; call
+     * {@link CaffeineCacheOptions.Builder#buildManager()} to obtain a configured cache manager
+     */
+    public static CaffeineCacheOptions.Builder builder() {
+        return CaffeineCacheOptions.builder();
+    }
+
+    @Override
+    public void saveContent(String key, String data) {
+        try {
+            cache.put(key, new CaffeineCacheEntry(data, clock.millis()));
+        } catch (RuntimeException e) {
+            throw new FeatureCacheException("Failed to save GrowthBook feature cache entry for key: " + key, e);
+        }
+    }
+
+    @Override
+    public String loadCache(String key) {
+        CaffeineCacheEntry entry = lookup(key);
+        return entry == null ? null : entry.getData();
+    }
+
+    @Override
+    public Long getLastUpdatedMillis(String key) {
+        CaffeineCacheEntry entry = lookup(key);
+        return entry == null ? null : entry.getLastUpdatedMillis();
+    }
+
+    /**
+     * Reads an entry from the cache, distinguishing the two outcomes callers care about: an absent
+     * key is a normal <em>cache miss</em> and returns {@code null}, while a genuine cache-access
+     * failure is wrapped in a {@link FeatureCacheException} with the offending key for context.
+     *
+     * @param key cache key to look up
+     * @return the cached entry, or {@code null} when the key is absent
+     */
+    private CaffeineCacheEntry lookup(String key) {
+        try {
+            return cache.getIfPresent(key);
+        } catch (RuntimeException e) {
+            throw new FeatureCacheException("Failed to read GrowthBook feature cache entry for key: " + key, e);
+        }
+    }
+
+    @Override
+    public void clearCache() {
+        try {
+            cache.invalidateAll();
+        } catch (RuntimeException e) {
+            throw new FeatureCacheException("Failed to clear GrowthBook feature cache", e);
+        }
+    }
+
+    /**
+     * Returns a snapshot of cache statistics. Counters are meaningful only when statistics
+     * recording was enabled via {@link CaffeineCacheOptions.Builder#recordStats(boolean)};
+     * otherwise every counter is {@code 0}.
+     *
+     * @return immutable cache statistics snapshot
+     */
+    public CaffeineCacheStats stats() {
+        CacheStats snapshot = cache.stats();
+        return new CaffeineCacheStats(
+                recordStats,
+                snapshot.hitCount(),
+                snapshot.missCount(),
+                snapshot.evictionCount()
+        );
+    }
+
+    /**
+     * Performs any pending cache maintenance, such as applying size/weight-based eviction.
+     * Eviction is otherwise performed asynchronously; this is primarily useful for deterministic
+     * tests and for forcing reclamation on demand.
+     */
+    public void cleanUp() {
+        cache.cleanUp();
+    }
+
+    /**
+     * Weighs an entry by the UTF-8 byte length of its payload (the cache key is negligible for the
+     * single-payload-per-endpoint usage, so only the value contributes to the weight bound).
+     */
+    private static final Weigher<String, CaffeineCacheEntry> PAYLOAD_WEIGHER = (key, entry) -> {
+        String data = entry.getData();
+        return data == null ? 0 : data.getBytes(StandardCharsets.UTF_8).length;
+    };
+
+    private static Cache<String, CaffeineCacheEntry> createCache(CaffeineCacheOptions options) {
+        Caffeine<Object, Object> builder = Caffeine.newBuilder();
+        applySizeBound(builder, options);
+        applyExpiry(builder, options);
+        if (options.isRecordStats()) {
+            builder.recordStats();
+        }
+        if (options.getTicker() != null) {
+            builder.ticker(options.getTicker());
+        }
+        return builder.build();
+    }
+
+    private static void applySizeBound(Caffeine<Object, Object> builder, CaffeineCacheOptions options) {
+        Long maximumWeight = options.getMaximumWeight();
+        if (maximumWeight != null) {
+            builder.maximumWeight(maximumWeight).weigher(PAYLOAD_WEIGHER);
+        } else {
+            builder.maximumSize(options.getMaximumSize());
+        }
+    }
+
+    private static void applyExpiry(Caffeine<Object, Object> builder, CaffeineCacheOptions options) {
+        Duration expireAfterWrite = options.getExpireAfterWrite();
+        if (expireAfterWrite != null) {
+            builder.expireAfterWrite(expireAfterWrite.toNanos(), TimeUnit.NANOSECONDS);
+        }
+        Duration expireAfterAccess = options.getExpireAfterAccess();
+        if (expireAfterAccess != null) {
+            builder.expireAfterAccess(expireAfterAccess.toNanos(), TimeUnit.NANOSECONDS);
+        }
+    }
+}

--- a/growthbook-cache-caffeine/src/test/java/growthbook/sdk/java/cache/caffeine/CaffeineGbCacheManagerTest.java
+++ b/growthbook-cache-caffeine/src/test/java/growthbook/sdk/java/cache/caffeine/CaffeineGbCacheManagerTest.java
@@ -1,0 +1,258 @@
+package growthbook.sdk.java.cache.caffeine;
+
+import com.github.benmanes.caffeine.cache.Ticker;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CaffeineGbCacheManagerTest {
+
+    @Test
+    @DisplayName("Verify: cached content is saved with a last-updated timestamp and can be loaded")
+    void savesAndLoadsContent() {
+        // Given
+        CaffeineGbCacheManager cacheManager = CaffeineGbCacheManager.create();
+
+        // When
+        cacheManager.saveContent("features", "{\"features\":{}}");
+
+        // Then
+        assertEquals("{\"features\":{}}", cacheManager.loadCache("features"));
+        assertNotNull(cacheManager.getLastUpdatedMillis("features"));
+    }
+
+    @Test
+    @DisplayName("Verify: missing cache entries return null content and null last-updated timestamp")
+    void returnsNullForMissingEntry() {
+        // Given
+        CaffeineGbCacheManager cacheManager = CaffeineGbCacheManager.create();
+
+        // Then
+        assertNull(cacheManager.loadCache("features"));
+        assertNull(cacheManager.getLastUpdatedMillis("features"));
+    }
+
+    @Test
+    @DisplayName("Verify: clearing cache removes stored content and last-updated timestamps")
+    void clearsEntriesAndTimestamps() {
+        // Given
+        CaffeineGbCacheManager cacheManager = CaffeineGbCacheManager.create();
+        cacheManager.saveContent("features", "cached");
+
+        // When
+        cacheManager.clearCache();
+
+        // Then
+        assertNull(cacheManager.loadCache("features"));
+        assertNull(cacheManager.getLastUpdatedMillis("features"));
+    }
+
+    @Test
+    @DisplayName("Verify: overwriting content replaces the cached value and timestamp")
+    void overwritesContentAndLastUpdatedTime() {
+        // Given
+        MutableClock clock = new MutableClock(1000L);
+        CaffeineGbCacheManager cacheManager = CaffeineGbCacheManager.builder()
+                .clock(clock)
+                .buildManager();
+
+        // When
+        cacheManager.saveContent("features", "first");
+        clock.setMillis(2000L);
+        cacheManager.saveContent("features", "second");
+
+        // Then
+        assertEquals("second", cacheManager.loadCache("features"));
+        assertEquals(2000L, cacheManager.getLastUpdatedMillis("features"));
+    }
+
+    @Test
+    @DisplayName("Verify: entries expire when expire-after-write is configured")
+    void expiresEntriesWhenExpireAfterWriteIsConfigured() {
+        // Given
+        MutableTicker ticker = new MutableTicker();
+        CaffeineGbCacheManager cacheManager = CaffeineGbCacheManager.builder()
+                .expireAfterWrite(Duration.ofMillis(10))
+                .ticker(ticker)
+                .buildManager();
+
+        // When
+        cacheManager.saveContent("features", "cached");
+        ticker.advance(Duration.ofMillis(11));
+
+        // Then
+        assertNull(cacheManager.loadCache("features"));
+        assertNull(cacheManager.getLastUpdatedMillis("features"));
+    }
+
+    @Test
+    @DisplayName("Verify: invalid Caffeine cache options fail fast")
+    void validatesOptions() {
+        // Given
+        CaffeineCacheOptions.Builder options = CaffeineCacheOptions.builder();
+
+        // When & Then
+        assertThrows(NullPointerException.class, () -> CaffeineGbCacheManager.create(null));
+        assertThrows(IllegalArgumentException.class, () -> options.maximumSize(0));
+        assertThrows(IllegalArgumentException.class, () -> options.maximumWeight(0));
+        assertThrows(IllegalArgumentException.class, () -> options.expireAfterWrite(Duration.ZERO));
+        assertThrows(NullPointerException.class, () -> options.clock(null));
+        assertThrows(NullPointerException.class, () -> options.ticker(null));
+    }
+
+    @Test
+    @DisplayName("Verify: default Caffeine cache options are usable")
+    void usesDefaultOptions() {
+        CaffeineCacheOptions options = CaffeineCacheOptions.defaults();
+
+        assertEquals(CaffeineCacheOptions.DEFAULT_MAXIMUM_SIZE, options.getMaximumSize());
+        assertNull(options.getExpireAfterWrite());
+        assertNotNull(options.getClock());
+        assertNull(options.getTicker());
+        assertTrue(options.getClock().millis() > 0);
+    }
+
+    @Test
+    @DisplayName("Verify: hit/miss statistics are recorded when stats recording is enabled")
+    void recordsHitAndMissStatisticsWhenEnabled() {
+        CaffeineGbCacheManager cacheManager = CaffeineGbCacheManager.builder()
+                .recordStats(true)
+                .buildManager();
+
+        cacheManager.saveContent("features", "cached");
+        cacheManager.loadCache("features");
+        cacheManager.loadCache("absent");
+
+        CaffeineCacheStats stats = cacheManager.stats();
+        assertTrue(stats.isRecording());
+        assertEquals(1L, stats.getHitCount());
+        assertEquals(1L, stats.getMissCount());
+        assertEquals(2L, stats.getRequestCount());
+        assertEquals(0.5, stats.getHitRate());
+    }
+
+    @Test
+    @DisplayName("Verify: statistics are inert (zero, not recording) by default")
+    void statisticsAreInertWhenRecordingDisabled() {
+        CaffeineGbCacheManager cacheManager = CaffeineGbCacheManager.create();
+
+        cacheManager.saveContent("features", "cached");
+        cacheManager.loadCache("features");
+        cacheManager.loadCache("absent");
+
+        CaffeineCacheStats stats = cacheManager.stats();
+        assertFalse(stats.isRecording());
+        assertEquals(0L, stats.getHitCount());
+        assertEquals(0L, stats.getMissCount());
+        assertEquals(0L, stats.getRequestCount());
+        assertEquals(1.0, stats.getHitRate());
+    }
+
+    @Test
+    @DisplayName("Verify: entries expire when expire-after-access is configured")
+    void expiresEntriesWhenExpireAfterAccessIsConfigured() {
+        MutableTicker ticker = new MutableTicker();
+        CaffeineGbCacheManager cacheManager = CaffeineGbCacheManager.builder()
+                .expireAfterAccess(Duration.ofMillis(10))
+                .ticker(ticker)
+                .buildManager();
+
+        cacheManager.saveContent("features", "cached");
+        ticker.advance(Duration.ofMillis(11));
+
+        assertNull(cacheManager.loadCache("features"));
+        assertNull(cacheManager.getLastUpdatedMillis("features"));
+    }
+
+    @Test
+    @DisplayName("Verify: new options expose safe defaults and validate input")
+    void newOptionsHaveDefaultsAndValidation() {
+        // Given
+        CaffeineCacheOptions defaults = CaffeineCacheOptions.defaults();
+        CaffeineCacheOptions.Builder options = CaffeineCacheOptions.builder();
+        Duration negativeDuration = Duration.ofMillis(-1);
+
+        // When & Then
+        assertNull(defaults.getExpireAfterAccess());
+        assertNull(defaults.getMaximumWeight());
+        assertFalse(defaults.isRecordStats());
+        assertThrows(IllegalArgumentException.class, () -> options.expireAfterAccess(Duration.ZERO));
+        assertThrows(IllegalArgumentException.class, () -> options.expireAfterAccess(negativeDuration));
+    }
+
+    @Test
+    @DisplayName("Verify: weight-based bounding evicts by total payload size, not entry count")
+    void evictsByWeightWhenMaximumWeightConfigured() {
+        // Given: room for roughly one small payload (10 bytes)
+        CaffeineGbCacheManager cacheManager = CaffeineGbCacheManager.builder()
+                .maximumWeight(10)
+                .recordStats(true)
+                .buildManager();
+
+        // When: two 8-byte payloads (16 bytes total) exceed the weight bound
+        cacheManager.saveContent("a", "01234567");
+        cacheManager.saveContent("b", "89abcdef");
+        cacheManager.cleanUp();
+
+        // Then: at least one entry was evicted to honour the weight bound
+        assertTrue(cacheManager.stats().getEvictionCount() >= 1);
+    }
+
+    private static final class MutableClock extends Clock {
+        private final AtomicLong millis;
+        private final ZoneId zone;
+
+        private MutableClock(long millis) {
+            this(millis, ZoneId.of("UTC"));
+        }
+
+        private MutableClock(long millis, ZoneId zone) {
+            this.millis = new AtomicLong(millis);
+            this.zone = zone;
+        }
+
+        void setMillis(long millis) {
+            this.millis.set(millis);
+        }
+
+        @Override
+        public ZoneId getZone() {
+            return zone;
+        }
+
+        @Override
+        public Clock withZone(ZoneId zone) {
+            return new MutableClock(millis.get(), zone);
+        }
+
+        @Override
+        public Instant instant() {
+            return Instant.ofEpochMilli(millis.get());
+        }
+    }
+
+    private static final class MutableTicker implements Ticker {
+        private final AtomicLong nanos = new AtomicLong();
+
+        void advance(Duration duration) {
+            nanos.addAndGet(duration.toNanos());
+        }
+
+        @Override
+        public long read() {
+            return nanos.get();
+        }
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -9,3 +9,4 @@
 
 rootProject.name = 'growthbook-sdk-java'
 include('lib')
+include('growthbook-cache-caffeine')


### PR DESCRIPTION
# Add Caffeine cache adapter (`growthbook-cache-caffeine`)

## Summary

Adds a new optional Gradle module, `growthbook-cache-caffeine`, that provides a [Caffeine](https://github.com/ben-manes/caffeine)-backed implementation of the SDK's `GbCacheManager`. It gives applications a production-ready, high-performance in-process cache for feature payloads — with bounded size, expiry, and optional statistics — without falling back to filesystem persistence.

## Design

- **Bounding by size or weight.** The cache can be bounded either by entry count (`maximumSize`, default `1000`) or by total payload weight in bytes (`maximumWeight`). Weight is the recommended bound for the GrowthBook feature cache, since it stores a single large JSON payload per endpoint — so entry-count limits don't meaningfully constrain memory. A `Weigher` measures each entry by the UTF-8 byte length of its payload; when `maximumWeight` is set it takes precedence over `maximumSize`.
- **Expiry.** Optional `expireAfterWrite` and `expireAfterAccess` durations map onto Caffeine's eviction. Note that the SDK's reads (`loadCache`, `getLastUpdatedMillis`) count as accesses, so `expireAfterAccess` only expires entries that have been fully idle.
- **Storage format.** Each entry is a `CaffeineCacheEntry` holding the payload and an `updatedAt` (epoch millis) timestamp, recorded from an injectable `Clock`. `getLastUpdatedMillis()` is backed by that timestamp, enabling the SDK's freshness-based refresh skipping.
- **Statistics.** When enabled via `recordStats(true)`, `stats()` returns an immutable `CaffeineCacheStats` snapshot (hits, misses, hit rate, evictions). This type deliberately does **not** leak Caffeine's `CacheStats`, so callers (e.g. an SDK diagnostics layer) can read cache health without taking on a Caffeine dependency.
- **Error handling.** An absent key is a normal cache miss (`null`); genuine access failures are wrapped in `FeatureCacheException` with the offending key for context.
- **Testability.** An injectable `Ticker` allows deterministic expiry tests, and `cleanUp()` forces pending size/weight eviction on demand (Caffeine evicts asynchronously by default).

## Configuration (`CaffeineCacheOptions`)

- `maximumSize` — entry-count bound (default `1000`).
- `maximumWeight` — total payload-byte bound; takes precedence over `maximumSize`.
- `expireAfterWrite` / `expireAfterAccess` — optional eviction durations.
- `recordStats` — enable statistics recording (default off).
- `clock` / `ticker` — injectable for testing.

## Usage

```java
Options options = Options.builder()
        .apiHost("https://cdn.growthbook.io")
        .clientKey("sdk-abc123")
        .cacheMode(CacheMode.CUSTOM)
        .cacheManager(CaffeineGbCacheManager.builder()
                .maximumSize(1000)
                .expireAfterWrite(Duration.ofMinutes(30))
                .buildManager())
        .build();

GrowthBookClient gb = new GrowthBookClient(options);
```

## Documentation

- Adds a **Caffeine cache adapter** section to `README.md` with dependency coordinates and a `GrowthBookClient` usage example.

## Testing

- **Unit tests** (`CaffeineGbCacheManagerTest`) cover save/load, last-updated tracking, cache miss, clear, size- and weight-based eviction, expiry (via injected `Ticker`), and statistics.

## Build / packaging

- New module registered in `settings.gradle`.
- Targets Java 8 (`sourceCompatibility`/`targetCompatibility = 1.8`).
- Depends on `com.github.ben-manes.caffeine:caffeine:2.9.3` (as `implementation`, so it is not leaked onto consumers' compile classpath).
- Publishes `sources` and `javadoc` jars to GitHub Packages, consistent with the existing `lib` module.
