### PR TITLE
feat: add JCache (JSR-107) cache adapter module

### DIFF
--- a/growthbook-cache-jcache/build.gradle
+++ b/growthbook-cache-jcache/build.gradle
@@ -1,0 +1,73 @@
+plugins {
+    id 'java-library'
+    id 'maven-publish'
+}
+
+sourceCompatibility = JavaVersion.VERSION_1_8
+targetCompatibility = JavaVersion.VERSION_1_8
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    api project(':lib')
+
+    api 'javax.cache:cache-api:1.1.1'
+
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.8.2'
+    // A JSR-107 provider implementation is required to run the tests.
+    testRuntimeOnly 'org.ehcache:ehcache:3.10.8'
+}
+
+java {
+    withSourcesJar()
+    withJavadocJar()
+}
+
+tasks.named('test') {
+    useJUnitPlatform()
+}
+
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            from components.java
+
+            pom {
+                name = 'GrowthBook SDK Java JCache Cache Adapter'
+                description = 'Optional JSR-107 (JCache) cache adapter for the GrowthBook Java SDK'
+                url = 'https://github.com/growthbook/growthbook-sdk-java'
+                licenses {
+                    license {
+                        name = 'MIT License'
+                        url = 'https://github.com/growthbook/growthbook-sdk-java/blob/main/LICENSE'
+                    }
+                }
+                developers {
+                    developer {
+                        id = 'growthbook'
+                        name = 'GrowthBook'
+                        email = 'hello@growthbook.io'
+                    }
+                }
+                scm {
+                    connection = 'scm:git:git://github.com/growthbook/growthbook-sdk-java.git'
+                    developerConnection = 'scm:git:ssh://github.com:growthbook/growthbook-sdk-java.git'
+                    url = 'https://github.com/growthbook/growthbook-sdk-java'
+                }
+            }
+        }
+    }
+
+    repositories {
+        maven {
+            name = "GitHubPackages"
+            url = uri("https://maven.pkg.github.com/growthbook/growthbook-sdk-java")
+            credentials {
+                username = System.getenv("GITHUB_ACTOR")
+                password = System.getenv("GITHUB_TOKEN")
+            }
+        }
+    }
+}

--- a/growthbook-cache-jcache/src/main/java/growthbook/sdk/java/cache/jcache/JCacheCacheEntry.java
+++ b/growthbook-cache-jcache/src/main/java/growthbook/sdk/java/cache/jcache/JCacheCacheEntry.java
@@ -1,0 +1,30 @@
+package growthbook.sdk.java.cache.jcache;
+
+import java.io.Serializable;
+
+/**
+ * Cached payload plus the epoch-millis timestamp of when it was written.
+ *
+ * <p>Implements {@link Serializable} because JSR-107 caches default to store-by-value semantics,
+ * where the provider copies values via serialization.
+ */
+final class JCacheCacheEntry implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final String data;
+    private final long lastUpdatedMillis;
+
+    JCacheCacheEntry(String data, long lastUpdatedMillis) {
+        this.data = data;
+        this.lastUpdatedMillis = lastUpdatedMillis;
+    }
+
+    String getData() {
+        return data;
+    }
+
+    long getLastUpdatedMillis() {
+        return lastUpdatedMillis;
+    }
+}

--- a/growthbook-cache-jcache/src/main/java/growthbook/sdk/java/cache/jcache/JCacheCacheOptions.java
+++ b/growthbook-cache-jcache/src/main/java/growthbook/sdk/java/cache/jcache/JCacheCacheOptions.java
@@ -1,0 +1,90 @@
+package growthbook.sdk.java.cache.jcache;
+
+import javax.cache.CacheManager;
+import java.time.Clock;
+import java.util.Objects;
+
+/**
+ * Configuration for {@link JCacheGbCacheManager}.
+ *
+ * <p>Unlike an embedded cache, a JSR-107 cache is created and configured by its provider, so the
+ * adapter is given a {@link CacheManager} plus the name of the cache to use. Eviction, expiry, and
+ * sizing are the provider's responsibility and are configured on the provider side.
+ */
+public final class JCacheCacheOptions {
+
+    public static final String DEFAULT_CACHE_NAME = "growthbook-features";
+
+    private final CacheManager cacheManager;
+    private final String cacheName;
+    private final Clock clock;
+
+    private JCacheCacheOptions(Builder builder) {
+        this.cacheManager = builder.cacheManager;
+        this.cacheName = builder.cacheName;
+        this.clock = builder.clock;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public CacheManager getCacheManager() {
+        return cacheManager;
+    }
+
+    public String getCacheName() {
+        return cacheName;
+    }
+
+    public Clock getClock() {
+        return clock;
+    }
+
+    public static final class Builder {
+        private CacheManager cacheManager;
+        private String cacheName = DEFAULT_CACHE_NAME;
+        private Clock clock = Clock.systemUTC();
+
+        private Builder() {
+        }
+
+        /**
+         * The JSR-107 cache manager used to obtain (or create) the feature cache. Required.
+         */
+        public Builder cacheManager(CacheManager cacheManager) {
+            this.cacheManager = Objects.requireNonNull(cacheManager, "cacheManager");
+            return this;
+        }
+
+        /**
+         * Name of the cache within the {@link CacheManager}. Defaults to {@value #DEFAULT_CACHE_NAME}.
+         */
+        public Builder cacheName(String cacheName) {
+            if (cacheName == null || cacheName.trim().isEmpty()) {
+                throw new IllegalArgumentException("cacheName must not be null or blank");
+            }
+            this.cacheName = cacheName;
+            return this;
+        }
+
+        public Builder clock(Clock clock) {
+            this.clock = Objects.requireNonNull(clock, "clock");
+            return this;
+        }
+
+        public JCacheCacheOptions build() {
+            Objects.requireNonNull(cacheManager, "cacheManager must be provided");
+            return new JCacheCacheOptions(this);
+        }
+
+        /**
+         * Convenience terminal that builds these options into a ready-to-use cache manager.
+         *
+         * @return a {@link JCacheGbCacheManager} configured with these options
+         */
+        public JCacheGbCacheManager buildManager() {
+            return JCacheGbCacheManager.create(build());
+        }
+    }
+}

--- a/growthbook-cache-jcache/src/main/java/growthbook/sdk/java/cache/jcache/JCacheGbCacheManager.java
+++ b/growthbook-cache-jcache/src/main/java/growthbook/sdk/java/cache/jcache/JCacheGbCacheManager.java
@@ -1,0 +1,115 @@
+package growthbook.sdk.java.cache.jcache;
+
+import growthbook.sdk.java.exception.FeatureCacheException;
+import growthbook.sdk.java.sandbox.GbCacheManager;
+
+import javax.cache.Cache;
+import javax.cache.CacheException;
+import javax.cache.CacheManager;
+import javax.cache.configuration.MutableConfiguration;
+import java.time.Clock;
+import java.util.Objects;
+
+/**
+ * JSR-107 (JCache) backed implementation of {@link GbCacheManager}.
+ *
+ * <p>Wraps a {@link Cache} obtained from a JCache {@link CacheManager}. The underlying provider
+ * (Ehcache, Hazelcast, Caffeine-JCache, the reference implementation, etc.) owns eviction, expiry,
+ * and sizing; this adapter only stores feature payloads with their last-updated timestamp.
+ */
+public final class JCacheGbCacheManager implements GbCacheManager {
+
+    private final Clock clock;
+    private final Cache<String, JCacheCacheEntry> cache;
+
+    private JCacheGbCacheManager(JCacheCacheOptions options) {
+        this.cache = resolveCache(options);
+        this.clock = options.getClock();
+    }
+
+    public static JCacheGbCacheManager create(JCacheCacheOptions options) {
+        return new JCacheGbCacheManager(Objects.requireNonNull(options, "options"));
+    }
+
+    public static JCacheGbCacheManager create(CacheManager cacheManager) {
+        return create(JCacheCacheOptions.builder().cacheManager(cacheManager).build());
+    }
+
+    /**
+     * @return the shared configuration builder; call
+     * {@link JCacheCacheOptions.Builder#buildManager()} to obtain a configured cache manager
+     */
+    public static JCacheCacheOptions.Builder builder() {
+        return JCacheCacheOptions.builder();
+    }
+
+    @Override
+    public void saveContent(String key, String data) {
+        try {
+            cache.put(key, new JCacheCacheEntry(data, clock.millis()));
+        } catch (RuntimeException e) {
+            throw new FeatureCacheException("Failed to save GrowthBook feature cache entry for key: " + key, e);
+        }
+    }
+
+    @Override
+    public String loadCache(String key) {
+        JCacheCacheEntry entry = lookup(key);
+        return entry == null ? null : entry.getData();
+    }
+
+    @Override
+    public Long getLastUpdatedMillis(String key) {
+        JCacheCacheEntry entry = lookup(key);
+        return entry == null ? null : entry.getLastUpdatedMillis();
+    }
+
+    @Override
+    public void clearCache() {
+        try {
+            cache.clear();
+        } catch (RuntimeException e) {
+            throw new FeatureCacheException("Failed to clear GrowthBook feature cache", e);
+        }
+    }
+
+    /**
+     * Reads an entry from the cache, distinguishing the two outcomes callers care about: an absent
+     * key is a normal <em>cache miss</em> and returns {@code null}, while a genuine cache-access
+     * failure is wrapped in a {@link FeatureCacheException} with the offending key for context.
+     *
+     * @param key cache key to look up
+     * @return the cached entry, or {@code null} when the key is absent
+     */
+    private JCacheCacheEntry lookup(String key) {
+        try {
+            return cache.get(key);
+        } catch (RuntimeException e) {
+            throw new FeatureCacheException("Failed to load GrowthBook feature cache entry for key: " + key, e);
+        }
+    }
+
+    private static Cache<String, JCacheCacheEntry> resolveCache(JCacheCacheOptions options) {
+        CacheManager cacheManager = options.getCacheManager();
+        String cacheName = options.getCacheName();
+
+        Cache<String, JCacheCacheEntry> existing = cacheManager.getCache(cacheName, String.class, JCacheCacheEntry.class);
+        if (existing != null) {
+            return existing;
+        }
+
+        MutableConfiguration<String, JCacheCacheEntry> configuration =
+                new MutableConfiguration<String, JCacheCacheEntry>()
+                        .setTypes(String.class, JCacheCacheEntry.class);
+        try {
+            return cacheManager.createCache(cacheName, configuration);
+        } catch (CacheException e) {
+            // Another caller created the cache concurrently; reuse it instead of failing.
+            Cache<String, JCacheCacheEntry> created = cacheManager.getCache(cacheName, String.class, JCacheCacheEntry.class);
+            if (created != null) {
+                return created;
+            }
+            throw new FeatureCacheException("Failed to create JCache feature cache: " + cacheName, e);
+        }
+    }
+}

--- a/growthbook-cache-jcache/src/test/java/growthbook/sdk/java/cache/jcache/JCacheGbCacheManagerTest.java
+++ b/growthbook-cache-jcache/src/test/java/growthbook/sdk/java/cache/jcache/JCacheGbCacheManagerTest.java
@@ -1,0 +1,155 @@
+package growthbook.sdk.java.cache.jcache;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import javax.cache.CacheManager;
+import javax.cache.Caching;
+import javax.cache.spi.CachingProvider;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class JCacheGbCacheManagerTest {
+
+    private CachingProvider cachingProvider;
+    private CacheManager cacheManager;
+
+    @BeforeEach
+    void setUp() {
+        cachingProvider = Caching.getCachingProvider();
+        cacheManager = cachingProvider.getCacheManager();
+    }
+
+    @AfterEach
+    void tearDown() {
+        cacheManager.close();
+    }
+
+    @Test
+    @DisplayName("Verify: cached content is saved with a last-updated timestamp and can be loaded")
+    void savesAndLoadsContent() {
+        // Given
+        JCacheGbCacheManager cache = JCacheGbCacheManager.builder().cacheManager(cacheManager).buildManager();
+
+        // When
+        cache.saveContent("features", "{\"features\":{}}");
+
+        // Then
+        assertEquals("{\"features\":{}}", cache.loadCache("features"));
+        assertNotNull(cache.getLastUpdatedMillis("features"));
+    }
+
+    @Test
+    @DisplayName("Verify: missing entries return null content and null last-updated timestamp")
+    void returnsNullForMissingEntry() {
+        // Given
+        JCacheGbCacheManager cache = JCacheGbCacheManager.builder().cacheManager(cacheManager).buildManager();
+
+        // Then
+        assertNull(cache.loadCache("features"));
+        assertNull(cache.getLastUpdatedMillis("features"));
+    }
+
+    @Test
+    @DisplayName("Verify: clearing cache removes stored content and timestamps")
+    void clearsEntries() {
+        // Given
+        JCacheGbCacheManager cache = JCacheGbCacheManager.builder().cacheManager(cacheManager).buildManager();
+        cache.saveContent("features", "cached");
+
+        // When
+        cache.clearCache();
+
+        // Then
+        assertNull(cache.loadCache("features"));
+        assertNull(cache.getLastUpdatedMillis("features"));
+    }
+
+    @Test
+    @DisplayName("Verify: overwriting content replaces the cached value and timestamp")
+    void overwritesContentAndTimestamp() {
+        // Given
+        MutableClock clock = new MutableClock(1000L);
+        JCacheGbCacheManager cache = JCacheGbCacheManager.builder()
+                .cacheManager(cacheManager)
+                .clock(clock)
+                .buildManager();
+
+        // When
+        cache.saveContent("features", "first");
+        clock.setMillis(2000L);
+        cache.saveContent("features", "second");
+
+        // Then
+        assertEquals("second", cache.loadCache("features"));
+        assertEquals(2000L, cache.getLastUpdatedMillis("features"));
+    }
+
+    @Test
+    @DisplayName("Verify: invalid options fail fast")
+    void validatesOptions() {
+        // Given
+        JCacheCacheOptions.Builder options = JCacheGbCacheManager.builder();
+
+        // When & Then
+        assertThrows(NullPointerException.class, () -> JCacheGbCacheManager.create((JCacheCacheOptions) null));
+        assertThrows(NullPointerException.class, () -> options.cacheManager(null));
+        assertThrows(IllegalArgumentException.class, () -> options.cacheName(" "));
+        assertThrows(NullPointerException.class, () -> options.clock(null));
+        assertThrows(NullPointerException.class, () -> options.build());
+    }
+
+    @Test
+    @DisplayName("Verify: default cache name and clock are applied")
+    void usesDefaults() {
+        // Given
+        JCacheCacheOptions options = JCacheGbCacheManager.builder().cacheManager(cacheManager).build();
+
+        // Then
+        assertEquals(JCacheCacheOptions.DEFAULT_CACHE_NAME, options.getCacheName());
+        assertNotNull(options.getClock());
+        assertNotNull(options.getCacheManager());
+    }
+
+    private static final class MutableClock extends Clock {
+        private final AtomicLong millis;
+        private final ZoneId zone;
+
+        private MutableClock(long millis) {
+            this(millis, ZoneId.of("UTC"));
+        }
+
+        private MutableClock(long millis, ZoneId zone) {
+            this.millis = new AtomicLong(millis);
+            this.zone = zone;
+        }
+
+        void setMillis(long millis) {
+            this.millis.set(millis);
+        }
+
+        @Override
+        public ZoneId getZone() {
+            return zone;
+        }
+
+        @Override
+        public Clock withZone(ZoneId zone) {
+            return new MutableClock(millis.get(), zone);
+        }
+
+        @Override
+        public Instant instant() {
+            return Instant.ofEpochMilli(millis.get());
+        }
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -9,3 +9,4 @@
 
 rootProject.name = 'growthbook-sdk-java'
 include('lib')
+include('growthbook-cache-jcache')


### PR DESCRIPTION
# Add JCache (JSR-107) cache adapter (`growthbook-cache-jcache`)

## Summary

Adds a new optional Gradle module, `growthbook-cache-jcache`, that provides a JSR-107 (JCache) backed implementation of the SDK's `GbCacheManager`. This lets applications plug the GrowthBook feature cache into any standard JCache provider (Ehcache, Hazelcast, Caffeine-JCache, the JSR-107 reference implementation, etc.) instead of keeping it in-process or on the local filesystem.

The adapter depends only on the `javax.cache:cache-api` interfaces — the consumer brings their own provider on the runtime classpath.

## Design

- **Provider-owned semantics.** Unlike an embedded cache, a JSR-107 cache is created and configured by its provider, so the adapter is given a `CacheManager` plus the name of the cache to use. Eviction, expiry, and sizing are the provider's responsibility and are configured on the provider side — the adapter only stores feature payloads with their last-updated timestamp.
- **Storage format.** Each entry is a `JCacheCacheEntry` holding the payload and an `updatedAt` (epoch millis) timestamp. It implements `Serializable` because JSR-107 caches default to store-by-value semantics, where the provider copies values via serialization. `getLastUpdatedMillis()` is backed by that timestamp, enabling the SDK's freshness-based refresh skipping.
- **Cache resolution.** `resolveCache` reuses an existing cache when present, otherwise creates one with a typed `MutableConfiguration`. A concurrent-creation race (another caller created the cache first) is handled by re-fetching the cache rather than failing.
- **Configuration** via a builder (`JCacheCacheOptions`):
  - `cacheManager` — the JSR-107 cache manager used to obtain (or create) the feature cache. Required.
  - `cacheName` — name of the cache within the manager (default `growthbook-features`).
  - `clock` — injectable for testing.
- **Error handling.** An absent key is a normal cache miss (`null`); genuine access failures are wrapped in `FeatureCacheException` with the offending key for context.

## Usage

```java
GbCacheManager cache = JCacheGbCacheManager.builder()
        .cacheManager(cacheManager)      // your JSR-107 CacheManager
        .cacheName("growthbook-features")
        .buildManager();

// Or, with defaults:
GbCacheManager cache = JCacheGbCacheManager.create(cacheManager);
```

## Testing

- **Unit tests** (`JCacheGbCacheManagerTest`) run against the Ehcache JSR-107 provider (`testRuntimeOnly`), exercising save/load, last-updated tracking, cache miss, and clear behaviour.

## Build / packaging

- New module registered in `settings.gradle`.
- Targets Java 8 (`sourceCompatibility`/`targetCompatibility = 1.8`).
- Depends on `javax.cache:cache-api:1.1.1` (as `api`); a provider is required only at runtime.
- Publishes `sources` and `javadoc` jars to GitHub Packages, consistent with the existing `lib` module.
