### PR TITLE
feat: add configuration validation at client start-up

### DIFF
--- a/lib/src/main/java/growthbook/sdk/java/exception/InvalidOptionsException.java
+++ b/lib/src/main/java/growthbook/sdk/java/exception/InvalidOptionsException.java
@@ -1,0 +1,39 @@
+package growthbook.sdk.java.exception;
+
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Thrown when GrowthBook options fail start-up validation.
+ *
+ * <p>Extends {@link IllegalArgumentException} so existing callers that catch invalid-argument errors
+ * keep working, while exposing the full list of problems via {@link #getViolations()} for callers
+ * that want structured access (diagnostics, health checks, structured logging).
+ */
+@Getter
+public class InvalidOptionsException extends IllegalArgumentException {
+
+    /**
+     * The individual, human-readable validation problems that were detected.
+     */
+    private final List<String> violations;
+
+    public InvalidOptionsException(String message, List<String> violations) {
+        super(message);
+        this.violations = violations == null
+                ? Collections.emptyList()
+                : Collections.unmodifiableList(new ArrayList<>(violations));
+    }
+
+    /**
+     * Creates an exception for a single validation problem, using the message as the only violation.
+     *
+     * @param message the problem description, used both as the exception message and the sole violation
+     */
+    public InvalidOptionsException(String message) {
+        this(message, Collections.singletonList(message));
+    }
+}

--- a/lib/src/main/java/growthbook/sdk/java/multiusermode/GrowthBookClient.java
+++ b/lib/src/main/java/growthbook/sdk/java/multiusermode/GrowthBookClient.java
@@ -8,6 +8,7 @@ import growthbook.sdk.java.evaluators.ExperimentEvaluator;
 import growthbook.sdk.java.evaluators.FeatureEvaluator;
 import growthbook.sdk.java.exception.FeatureFetchException;
 import growthbook.sdk.java.exception.GrowthBookClientInitializationException;
+import growthbook.sdk.java.exception.InvalidOptionsException;
 import growthbook.sdk.java.model.AssignedExperiment;
 import growthbook.sdk.java.model.Experiment;
 import growthbook.sdk.java.model.ExperimentResult;
@@ -16,6 +17,7 @@ import growthbook.sdk.java.model.RequestBodyForRemoteEval;
 import growthbook.sdk.java.multiusermode.configurations.EvaluationContext;
 import growthbook.sdk.java.multiusermode.configurations.GlobalContext;
 import growthbook.sdk.java.multiusermode.configurations.Options;
+import growthbook.sdk.java.multiusermode.configurations.OptionsValidator;
 import growthbook.sdk.java.multiusermode.configurations.UserContext;
 import growthbook.sdk.java.remoteeval.RemoteEvalCache;
 import growthbook.sdk.java.remoteeval.RemoteEvalCacheKey;
@@ -74,6 +76,13 @@ public class GrowthBookClient {
     }
 
     public boolean initialize() {
+        try {
+            OptionsValidator.validate(this.options);
+        } catch (InvalidOptionsException e) {
+            log.error("Failed to initialize growthbook instance", e);
+            return false;
+        }
+
         if (this.options.isRemoteEvalEnabled()) {
             try {
                 return ensureRemoteEvalReady();

--- a/lib/src/main/java/growthbook/sdk/java/multiusermode/configurations/OptionsValidator.java
+++ b/lib/src/main/java/growthbook/sdk/java/multiusermode/configurations/OptionsValidator.java
@@ -1,0 +1,151 @@
+package growthbook.sdk.java.multiusermode.configurations;
+
+import growthbook.sdk.java.exception.InvalidOptionsException;
+import growthbook.sdk.java.remoteeval.RemoteEvalOptionsValidator;
+import growthbook.sdk.java.sandbox.CacheMode;
+import growthbook.sdk.java.util.StringUtils;
+
+import javax.annotation.Nullable;
+import java.net.URI;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Validates {@link Options} once, at client start-up, so misconfigurations are reported up front with
+ * a clear message instead of surfacing later as an opaque fetch failure.
+ *
+ * <p>All independent problems are collected and reported together, so a caller fixing several
+ * misconfigured options sees every issue at once rather than one per restart.
+ *
+ * <p>Checks performed:
+ * <ul>
+ *     <li>{@code apiHost} is present and a syntactically valid {@code http(s)} URL.</li>
+ *     <li>{@code clientKey} is present.</li>
+ *     <li>{@code swrTtlSeconds} (refresh interval) is positive when set.</li>
+ *     <li>{@code backgroundFetchInterval} is non-negative when set.</li>
+ *     <li>{@code remoteEvalCacheTtlSeconds} is positive when set.</li>
+ *     <li>No contradictory cache configuration (e.g. a {@code cacheManager} supplied while caching
+ *     is disabled, or {@link CacheMode#CUSTOM} without a {@code cacheManager}).</li>
+ *     <li>Remote-eval incompatibilities, delegated to
+ *     {@code RemoteEvalOptionsValidator#remoteEvalViolations} so all problems surface together.</li>
+ * </ul>
+ */
+public final class OptionsValidator {
+
+    private static final String HTTP = "http";
+    private static final String HTTPS = "https";
+    private static final String SCHEME_SEPARATOR = "://";
+
+    private OptionsValidator() {
+    }
+
+    /**
+     * Validates the supplied options, throwing when any option is invalid or contradictory.
+     *
+     * @param options client options to validate; {@code null} is treated as nothing to validate
+     * @throws InvalidOptionsException listing every problem found (a subtype of
+     *         {@link IllegalArgumentException})
+     */
+    public static void validate(@Nullable Options options) {
+        List<String> violations = findViolations(options);
+        if (!violations.isEmpty()) {
+            throw new InvalidOptionsException(
+                    "Invalid GrowthBook options: " + String.join("; ", violations), violations);
+        }
+    }
+
+    /**
+     * Collects every validation problem without throwing.
+     *
+     * @param options client options to inspect; {@code null} yields an empty list
+     * @return an immutable list of human-readable problem descriptions, empty when valid
+     */
+    public static List<String> findViolations(@Nullable Options options) {
+        if (options == null) {
+            return Collections.emptyList();
+        }
+
+        List<String> violations = new ArrayList<>();
+        checkApiHost(options.getApiHost(), violations);
+        checkClientKey(options.getClientKey(), violations);
+        checkRefreshInterval(options.getSwrTtlSeconds(), violations);
+        checkBackgroundFetchInterval(options.getBackgroundFetchInterval(), violations);
+        checkRemoteEvalCacheTtl(options.getRemoteEvalCacheTtlSeconds(), violations);
+        checkCacheConfiguration(options, violations);
+        violations.addAll(RemoteEvalOptionsValidator.remoteEvalViolations(options));
+        return Collections.unmodifiableList(violations);
+    }
+
+    private static void checkApiHost(@Nullable String apiHost, List<String> violations) {
+        if (StringUtils.isBlank(apiHost)) {
+            violations.add("apiHost is required");
+            return;
+        }
+
+        String raw = apiHost.trim();
+        boolean hasScheme = raw.contains(SCHEME_SEPARATOR);
+
+        URI uri;
+        try {
+            uri = URI.create(hasScheme ? raw : HTTPS + SCHEME_SEPARATOR + raw);
+        } catch (IllegalArgumentException e) {
+            violations.add("apiHost is not a valid URL: " + apiHost);
+            return;
+        }
+
+        if (hasScheme) {
+            String scheme = uri.getScheme();
+            if (scheme == null || (!scheme.equalsIgnoreCase(HTTP) && !scheme.equalsIgnoreCase(HTTPS))) {
+                violations.add("apiHost must use http or https scheme: " + apiHost);
+                return;
+            }
+        }
+
+        if (StringUtils.isBlank(uri.getHost())) {
+            violations.add("apiHost is not a valid URL: " + apiHost);
+        }
+    }
+
+    private static void checkClientKey(@Nullable String clientKey, List<String> violations) {
+        if (StringUtils.isBlank(clientKey)) {
+            violations.add("clientKey is required");
+        }
+    }
+
+    private static void checkRefreshInterval(@Nullable Integer swrTtlSeconds, List<String> violations) {
+        if (swrTtlSeconds != null && swrTtlSeconds <= 0) {
+            violations.add("refresh interval (swrTtlSeconds) must be greater than 0, but was " + swrTtlSeconds);
+        }
+    }
+
+    private static void checkBackgroundFetchInterval(@Nullable Duration backgroundFetchInterval, List<String> violations) {
+        if (backgroundFetchInterval != null && backgroundFetchInterval.isNegative()) {
+            violations.add("backgroundFetchInterval must not be negative, but was " + backgroundFetchInterval);
+        }
+    }
+
+    private static void checkRemoteEvalCacheTtl(@Nullable Integer remoteEvalCacheTtlSeconds, List<String> violations) {
+        if (remoteEvalCacheTtlSeconds != null && remoteEvalCacheTtlSeconds <= 0) {
+            violations.add("remoteEvalCacheTtlSeconds must be greater than 0 when set, but was "
+                    + remoteEvalCacheTtlSeconds);
+        }
+    }
+
+    private static void checkCacheConfiguration(Options options, List<String> violations) {
+        CacheMode cacheMode = options.getCacheMode();
+        boolean cacheManagerSupplied = options.getCacheManager() != null;
+        boolean cacheDisabled = Boolean.TRUE.equals(options.getIsCacheDisabled())
+                || cacheMode == CacheMode.NONE;
+
+        if (cacheManagerSupplied && cacheDisabled) {
+            violations.add("a cacheManager was supplied but caching is disabled "
+                    + "(isCacheDisabled=true or CacheMode.NONE); remove one of them");
+        }
+
+        if (cacheMode == CacheMode.CUSTOM && !cacheManagerSupplied) {
+            violations.add("CacheMode.CUSTOM requires a cacheManager to be supplied");
+        }
+    }
+}

--- a/lib/src/main/java/growthbook/sdk/java/remoteeval/RemoteEvalOptionsValidator.java
+++ b/lib/src/main/java/growthbook/sdk/java/remoteeval/RemoteEvalOptionsValidator.java
@@ -1,19 +1,25 @@
 package growthbook.sdk.java.remoteeval;
 
+import growthbook.sdk.java.exception.InvalidOptionsException;
 import growthbook.sdk.java.model.GBContext;
 import growthbook.sdk.java.multiusermode.configurations.Options;
 import growthbook.sdk.java.repository.FeatureRefreshStrategy;
+import growthbook.sdk.java.util.StringUtils;
 
 import javax.annotation.Nullable;
 import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Locale;
 
 /**
  * Validates SDK options before enabling remote evaluation.
  */
 public final class RemoteEvalOptionsValidator {
-    private static final String DEFAULT_SCHEME = "https://";
+
     private static final String SCHEME_SEPARATOR = "://";
+    private static final String DEFAULT_SCHEME = "https://";
     private static final String GROWTHBOOK_CLOUD_DOMAIN = "growthbook.io";
 
     private RemoteEvalOptionsValidator() {
@@ -24,13 +30,7 @@ public final class RemoteEvalOptionsValidator {
             return;
         }
 
-        validateCommon(
-                options.getApiHost(),
-                options.getClientKey(),
-                options.getDecryptionKey(),
-                options.getStickyBucketService() != null,
-                options.getRefreshStrategy()
-        );
+        throwIfAny(collect(ValidationTarget.from(options), true));
     }
 
     public static void validate(GBContext context) {
@@ -38,45 +38,74 @@ public final class RemoteEvalOptionsValidator {
             return;
         }
 
-        validateCommon(
-                context.getApiHost(),
-                context.getClientKey(),
-                context.getEncryptionKey(),
-                context.getStickyBucketService() != null,
-                null
-        );
+        throwIfAny(collect(ValidationTarget.from(context), true));
     }
 
-    private static void validateCommon(
-            @Nullable String apiHost,
-            @Nullable String clientKey,
-            @Nullable String decryptionKey,
-            boolean hasStickyBucketService,
-            @Nullable FeatureRefreshStrategy refreshStrategy
-    ) {
-        if (isBlank(apiHost)) {
-            throw new IllegalArgumentException("apiHost is required when remoteEval is enabled");
+    /**
+     * Returns the remote-eval specific incompatibilities for the supplied options.
+     *
+     * <p>Intended for callers that already validate {@code apiHost}/{@code clientKey} presence
+     * generally (e.g. {@code OptionsValidator}); this method therefore excludes those checks to
+     * avoid duplicate messages and reports only constraints unique to remote evaluation.
+     *
+     * @param options client options to inspect; {@code null} or non remote-eval yields an empty list
+     * @return an immutable list of human-readable problem descriptions, empty when valid
+     */
+    public static List<String> remoteEvalViolations(@Nullable Options options) {
+        if (options == null || !options.isRemoteEvalEnabled()) {
+            return Collections.emptyList();
         }
-        if (isBlank(clientKey)) {
-            throw new IllegalArgumentException("clientKey is required when remoteEval is enabled");
+
+        return Collections.unmodifiableList(collect(ValidationTarget.from(options), false));
+    }
+
+    private static List<String> collect(ValidationTarget target, boolean includeApiConfiguration) {
+        List<String> violations = new ArrayList<>();
+        if (includeApiConfiguration) {
+            collectApiConfiguration(target, violations);
         }
-        if (!isBlank(decryptionKey)) {
-            throw new IllegalArgumentException("decryptionKey is not supported when remoteEval is enabled");
+        collectUnsupportedOptions(target, violations);
+        collectGrowthBookCloudHost(target.apiHost, violations);
+        return violations;
+    }
+
+    private static void throwIfAny(List<String> violations) {
+        if (!violations.isEmpty()) {
+            throw new InvalidOptionsException(
+                    "Invalid GrowthBook options: " + String.join("; ", violations), violations);
         }
-        if (hasStickyBucketService) {
-            throw new IllegalArgumentException("stickyBucketService is not supported when remoteEval is enabled");
+    }
+
+    private static void collectApiConfiguration(ValidationTarget target, List<String> violations) {
+        if (StringUtils.isBlank(target.apiHost)) {
+            violations.add("apiHost is required when remoteEval is enabled");
         }
-        if (refreshStrategy == FeatureRefreshStrategy.STALE_WHILE_REVALIDATE) {
-            throw new IllegalArgumentException("stale-while-revalidate is not supported when remoteEval is enabled");
+        if (StringUtils.isBlank(target.clientKey)) {
+            violations.add("clientKey is required when remoteEval is enabled");
         }
+    }
+
+    private static void collectUnsupportedOptions(ValidationTarget target, List<String> violations) {
+        if (!StringUtils.isBlank(target.decryptionKey)) {
+            violations.add("decryptionKey is not supported when remoteEval is enabled");
+        }
+        if (target.hasStickyBucketService) {
+            violations.add("stickyBucketService is not supported when remoteEval is enabled");
+        }
+        if (target.refreshStrategy == FeatureRefreshStrategy.STALE_WHILE_REVALIDATE) {
+            violations.add("stale-while-revalidate is not supported when remoteEval is enabled");
+        }
+    }
+
+    private static void collectGrowthBookCloudHost(@Nullable String apiHost, List<String> violations) {
         if (isGrowthBookCloudHost(apiHost)) {
-            throw new IllegalArgumentException("remoteEval requires a self-hosted GrowthBook proxy or edge API host");
+            violations.add("remoteEval requires a self-hosted GrowthBook proxy or edge API host");
         }
     }
 
-    private static boolean isGrowthBookCloudHost(String apiHost) {
+    private static boolean isGrowthBookCloudHost(@Nullable String apiHost) {
         try {
-            String raw = apiHost == null ? "" : apiHost.trim();
+            String raw = StringUtils.normalize(apiHost).trim();
             String normalized = raw.contains(SCHEME_SEPARATOR) ? raw : DEFAULT_SCHEME + raw;
             String host = URI.create(normalized).getHost();
             if (host == null) {
@@ -90,7 +119,54 @@ public final class RemoteEvalOptionsValidator {
         }
     }
 
-    private static boolean isBlank(@Nullable String value) {
-        return value == null || value.trim().isEmpty();
+    private static final class ValidationTarget {
+
+        @Nullable
+        private final String apiHost;
+
+        @Nullable
+        private final String clientKey;
+
+        @Nullable
+        private final String decryptionKey;
+
+        private final boolean hasStickyBucketService;
+
+        @Nullable
+        private final FeatureRefreshStrategy refreshStrategy;
+
+        private ValidationTarget(
+                @Nullable String apiHost,
+                @Nullable String clientKey,
+                @Nullable String decryptionKey,
+                boolean hasStickyBucketService,
+                @Nullable FeatureRefreshStrategy refreshStrategy
+        ) {
+            this.apiHost = apiHost;
+            this.clientKey = clientKey;
+            this.decryptionKey = decryptionKey;
+            this.hasStickyBucketService = hasStickyBucketService;
+            this.refreshStrategy = refreshStrategy;
+        }
+
+        private static ValidationTarget from(Options options) {
+            return new ValidationTarget(
+                    options.getApiHost(),
+                    options.getClientKey(),
+                    options.getDecryptionKey(),
+                    options.getStickyBucketService() != null,
+                    options.getRefreshStrategy()
+            );
+        }
+
+        private static ValidationTarget from(GBContext context) {
+            return new ValidationTarget(
+                    context.getApiHost(),
+                    context.getClientKey(),
+                    context.getEncryptionKey(),
+                    context.getStickyBucketService() != null,
+                    null
+            );
+        }
     }
 }

--- a/lib/src/main/java/growthbook/sdk/java/util/StringUtils.java
+++ b/lib/src/main/java/growthbook/sdk/java/util/StringUtils.java
@@ -10,6 +10,10 @@ import lombok.experimental.UtilityClass;
 @UtilityClass
 public class StringUtils {
 
+    public static String normalize(@Nullable String value) {
+        return value == null ? "" : value;
+    }
+
     public static boolean isBlank(@Nullable String value) {
         return value == null || value.trim().isEmpty();
     }

--- a/lib/src/test/java/growthbook/sdk/java/multiusermode/configurations/OptionsValidatorTest.java
+++ b/lib/src/test/java/growthbook/sdk/java/multiusermode/configurations/OptionsValidatorTest.java
@@ -1,0 +1,209 @@
+package growthbook.sdk.java.multiusermode.configurations;
+
+import growthbook.sdk.java.exception.InvalidOptionsException;
+import growthbook.sdk.java.repository.FeatureRefreshStrategy;
+import growthbook.sdk.java.sandbox.CacheMode;
+import growthbook.sdk.java.sandbox.GbCacheManager;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.time.Duration;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class OptionsValidatorTest {
+
+    private static Options.OptionsBuilder validOptions() {
+        return Options.builder()
+                .apiHost("https://cdn.growthbook.io")
+                .clientKey("sdk-abc123");
+    }
+
+    @Test
+    @DisplayName("Verify: accepts a fully valid set of options")
+    void acceptsValidOptions() {
+        assertDoesNotThrow(() -> OptionsValidator.validate(validOptions().build()));
+    }
+
+    @Test
+    @DisplayName("Verify: accepts an apiHost without an explicit scheme")
+    void acceptsApiHostWithoutScheme() {
+        assertDoesNotThrow(() -> OptionsValidator.validate(
+                validOptions().apiHost("cdn.growthbook.io").build()));
+    }
+
+    @Test
+    @DisplayName("Verify: accepts a localhost apiHost with port")
+    void acceptsLocalhostApiHost() {
+        assertDoesNotThrow(() -> OptionsValidator.validate(
+                validOptions().apiHost("http://localhost:8080").build()));
+    }
+
+    @Test
+    @DisplayName("Verify: treats null options as a no-op")
+    void nullOptionsIsNoOp() {
+        assertDoesNotThrow(() -> OptionsValidator.validate(null));
+    }
+
+    @Test
+    @DisplayName("Verify: rejects a missing apiHost")
+    void rejectsMissingApiHost() {
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> OptionsValidator.validate(Options.builder().clientKey("sdk-abc123").build()));
+        assertTrue(ex.getMessage().contains("apiHost"));
+    }
+
+    @Test
+    @DisplayName("Verify: rejects a blank apiHost")
+    void rejectsBlankApiHost() {
+        assertThrows(IllegalArgumentException.class,
+                () -> OptionsValidator.validate(validOptions().apiHost("   ").build()));
+    }
+
+    @Test
+    @DisplayName("Verify: rejects an apiHost with a non-http(s) scheme")
+    void rejectsNonHttpApiHostScheme() {
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> OptionsValidator.validate(validOptions().apiHost("ftp://cdn.growthbook.io").build()));
+        assertTrue(ex.getMessage().contains("http or https"));
+    }
+
+    @Test
+    @DisplayName("Verify: rejects a malformed apiHost with no host")
+    void rejectsMalformedApiHost() {
+        assertThrows(IllegalArgumentException.class,
+                () -> OptionsValidator.validate(validOptions().apiHost("https://").build()));
+    }
+
+    @Test
+    @DisplayName("Verify: rejects a missing clientKey")
+    void rejectsMissingClientKey() {
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> OptionsValidator.validate(Options.builder().apiHost("https://cdn.growthbook.io").build()));
+        assertTrue(ex.getMessage().contains("clientKey"));
+    }
+
+    @Test
+    @DisplayName("Verify: rejects a non-positive refresh interval")
+    void rejectsNonPositiveRefreshInterval() {
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> OptionsValidator.validate(validOptions().swrTtlSeconds(0).build()));
+        assertTrue(ex.getMessage().contains("refresh interval"));
+    }
+
+    @Test
+    @DisplayName("Verify: rejects a negative backgroundFetchInterval")
+    void rejectsNegativeBackgroundFetchInterval() {
+        assertThrows(IllegalArgumentException.class,
+                () -> OptionsValidator.validate(
+                        validOptions().backgroundFetchInterval(Duration.ofSeconds(-1)).build()));
+    }
+
+    @Test
+    @DisplayName("Verify: rejects a non-positive remoteEvalCacheTtlSeconds")
+    void rejectsNonPositiveRemoteEvalCacheTtl() {
+        assertThrows(IllegalArgumentException.class,
+                () -> OptionsValidator.validate(validOptions().remoteEvalCacheTtlSeconds(0).build()));
+    }
+
+    @Test
+    @DisplayName("Verify: rejects a cacheManager when CacheMode.NONE disables caching")
+    void rejectsCacheManagerWhenCacheDisabled() {
+        GbCacheManager cacheManager = Mockito.mock(GbCacheManager.class);
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> OptionsValidator.validate(
+                        validOptions().cacheManager(cacheManager).cacheMode(CacheMode.NONE).build()));
+        assertTrue(ex.getMessage().contains("caching is disabled"));
+    }
+
+    @Test
+    @DisplayName("Verify: rejects a cacheManager when the isCacheDisabled flag is set")
+    void rejectsCacheManagerWhenIsCacheDisabledFlagSet() {
+        GbCacheManager cacheManager = Mockito.mock(GbCacheManager.class);
+        assertThrows(IllegalArgumentException.class,
+                () -> OptionsValidator.validate(
+                        validOptions().cacheManager(cacheManager).isCacheDisabled(true).build()));
+    }
+
+    @Test
+    @DisplayName("Verify: rejects CacheMode.CUSTOM without a cacheManager")
+    void rejectsCustomCacheModeWithoutManager() {
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> OptionsValidator.validate(validOptions().cacheMode(CacheMode.CUSTOM).build()));
+        assertTrue(ex.getMessage().contains("CacheMode.CUSTOM"));
+    }
+
+    @Test
+    @DisplayName("Verify: accepts CacheMode.CUSTOM when a cacheManager is supplied")
+    void acceptsCustomCacheModeWithManager() {
+        GbCacheManager cacheManager = Mockito.mock(GbCacheManager.class);
+        assertDoesNotThrow(() -> OptionsValidator.validate(
+                validOptions().cacheMode(CacheMode.CUSTOM).cacheManager(cacheManager).build()));
+    }
+
+    @Test
+    @DisplayName("Verify: reports every violation at once instead of failing on the first")
+    void reportsAllViolationsTogether() {
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> OptionsValidator.validate(Options.builder().swrTtlSeconds(0).build()));
+        assertTrue(ex.getMessage().contains("apiHost"), ex.getMessage());
+        assertTrue(ex.getMessage().contains("clientKey"), ex.getMessage());
+        assertTrue(ex.getMessage().contains("refresh interval"), ex.getMessage());
+    }
+
+    @Test
+    @DisplayName("Verify: findViolations returns an empty list for valid options")
+    void findViolationsReturnsEmptyForValidOptions() {
+        assertTrue(OptionsValidator.findViolations(validOptions().build()).isEmpty());
+    }
+
+    @Test
+    @DisplayName("Verify: findViolations lists each problem without throwing")
+    void findViolationsListsEachProblem() {
+        List<String> violations = OptionsValidator.findViolations(
+                Options.builder().swrTtlSeconds(0).build());
+        assertEquals(3, violations.size(), violations.toString());
+    }
+
+    @Test
+    @DisplayName("Verify: findViolations returns an empty list for null options")
+    void findViolationsHandlesNull() {
+        assertTrue(OptionsValidator.findViolations(null).isEmpty());
+    }
+
+    @Test
+    @DisplayName("Verify: throws InvalidOptionsException carrying the structured violations")
+    void throwsInvalidOptionsExceptionWithViolations() {
+        InvalidOptionsException ex = assertThrows(InvalidOptionsException.class,
+                () -> OptionsValidator.validate(Options.builder().swrTtlSeconds(0).build()));
+        assertEquals(3, ex.getViolations().size(), ex.getViolations().toString());
+    }
+
+    @Test
+    @DisplayName("Verify: aggregates remote-eval incompatibilities with general violations")
+    void aggregatesRemoteEvalViolations() {
+        GbCacheManager cacheManager = Mockito.mock(GbCacheManager.class);
+        List<String> violations = OptionsValidator.findViolations(validOptions()
+                .remoteEval(true)
+                .decryptionKey("secret")
+                .refreshStrategy(FeatureRefreshStrategy.STALE_WHILE_REVALIDATE)
+                .build());
+
+        assertTrue(violations.stream().anyMatch(v -> v.contains("decryptionKey")), violations.toString());
+        assertTrue(violations.stream().anyMatch(v -> v.contains("stale-while-revalidate")), violations.toString());
+        assertTrue(violations.stream().noneMatch(v -> v.equals("apiHost is required")), violations.toString());
+    }
+
+    @Test
+    @DisplayName("Verify: does not add remote-eval violations when remote eval is disabled")
+    void skipsRemoteEvalViolationsWhenDisabled() {
+        assertDoesNotThrow(() -> OptionsValidator.validate(
+                validOptions().decryptionKey("secret").build()));
+    }
+}


### PR DESCRIPTION
  ## Summary
  
  Adds start-up **configuration validation** for the multi-user `GrowthBookClient`.
  Invalid or contradictory options now fail at `initialize()` with a single, clear,
  aggregated message instead of surfacing later as an opaque feature-fetch failure.

  ## What changed

  - **`OptionsValidator`** (new) — validates `Options` and is invoked at the very
    start of `GrowthBookClient.initialize()`. Checks:
    - `apiHost` — present and a syntactically valid `http(s)` URL (no network call)
    - `clientKey` — present
    - `swrTtlSeconds` (refresh interval) — positive when set
    - `backgroundFetchInterval` — non-negative when set
    - `remoteEvalCacheTtlSeconds` — positive when set
    - cache config conflicts — `cacheManager` supplied while caching is disabled;
      `CacheMode.CUSTOM` without a `cacheManager`
    - remote-eval incompatibilities (delegated, see below)
  - **`InvalidOptionsException`** (new) — extends `IllegalArgumentException` and
    carries the full `List<String> getViolations()` for structured consumers
    (upcoming diagnostics / health checks).
  - **`RemoteEvalOptionsValidator`** (refactor) — converted to a collecting model;
    `validate(...)` now aggregates instead of failing on the first problem, and a
    new `remoteEvalViolations(Options)` lets `OptionsValidator` merge remote-eval
    constraints through **one** validation entry point (no duplicate
    `apiHost`/`clientKey` messages).
  - **Errors are aggregated** — all problems are reported together, so a caller
    fixing several misconfigured options sees every issue at once.

  ## Behaviour & compatibility
  
  - `GrowthBookClient.initialize()` keeps its `boolean` contract: validation
    failures are logged and return `false` (the exception is caught internally).
  - `InvalidOptionsException` **is** an `IllegalArgumentException`, so existing
    callers/tests that catch `IllegalArgumentException` are unaffected.
  - The remote-eval check in `RemoteEvalCoordinator` is retained as defense-in-depth;
    the single-context `GrowthBook` path keeps using `RemoteEvalOptionsValidator.validate(GBContext)`.
  - No new runtime dependencies. No public API removed.
