### PR TITLE
feat: Typed feature access

### DIFF
--- a/lib/src/main/java/growthbook/sdk/java/GrowthBook.java
+++ b/lib/src/main/java/growthbook/sdk/java/GrowthBook.java
@@ -16,6 +16,7 @@ import growthbook.sdk.java.exception.FeatureFetchException;
 import growthbook.sdk.java.model.AssignedExperiment;
 import growthbook.sdk.java.model.Experiment;
 import growthbook.sdk.java.model.ExperimentResult;
+import growthbook.sdk.java.model.FeatureKey;
 import growthbook.sdk.java.model.FeatureResult;
 import growthbook.sdk.java.model.GBContext;
 import growthbook.sdk.java.model.RequestBodyForRemoteEval;
@@ -599,6 +600,74 @@ public class GrowthBook implements IGrowthBook {
             return defaultValue;
         }
     }
+
+    /**
+     * Evaluate a feature using a type-safe {@link FeatureKey} instead of a raw string key.
+     * The key carries both the feature identifier and its value type, so a mistyped key
+     * becomes a compile-time error rather than a silent runtime miss.
+     *
+     * <p>As with {@link #evalFeature(String, Class)}, the returned result's
+     * {@link FeatureResult#getValue()} is the raw evaluated value (a boxed primitive, or a
+     * {@code Map}/{@code List} for object and array features); it is <em>not</em> deserialized
+     * into the key's value type. To obtain a deserialized instance of a complex type, use
+     * {@link #getFeatureValue(FeatureKey, Object)}.
+     *
+     * @param featureKey  typed feature key, e.g. {@code Features.NEW_HOME}
+     * @param <T> feature value type carried by the key
+     * @return the feature result
+     */
+    @Nullable
+    @Override
+    public <T> FeatureResult<T> getFeature(FeatureKey<T> featureKey) {
+        return evalFeature(featureKey.getKey(), featureKey.getValueType());
+    }
+
+    @Override
+    public Boolean isOn(FeatureKey<?> featureKey) {
+        return isOn(featureKey.getKey());
+    }
+
+    @Override
+    public Boolean isOff(FeatureKey<?> featureKey) {
+        return isOff(featureKey.getKey());
+    }
+
+    @Override
+    public <T> T getFeatureValue(FeatureKey<T> featureKey, T defaultValue) {
+        return getFeatureValue(featureKey.getKey(), defaultValue, featureKey.getValueType());
+    }
+
+    @Override
+    public Boolean getBooleanFeature(FeatureKey<Boolean> featureKey) {
+        return getBooleanFeature(featureKey, false);
+    }
+
+    @Override
+    public Boolean getBooleanFeature(FeatureKey<Boolean> featureKey, Boolean defaultValue) {
+        return getFeatureValue(featureKey.getKey(), defaultValue);
+    }
+
+    @Override
+    public String getStringFeature(FeatureKey<String> featureKey, String defaultValue) {
+        return getFeatureValue(featureKey.getKey(), defaultValue);
+    }
+
+    @Override
+    public Integer getIntegerFeature(FeatureKey<Integer> featureKey, Integer defaultValue) {
+        return getFeatureValue(featureKey.getKey(), defaultValue);
+    }
+
+    @Override
+    public Double getDoubleFeature(FeatureKey<Double> featureKey, Double defaultValue) {
+        return getFeatureValue(featureKey.getKey(), defaultValue);
+    }
+
+    @Override
+    public Float getFloatFeature(FeatureKey<Float> featureKey, Float defaultValue) {
+        return getFeatureValue(featureKey.getKey(), defaultValue);
+    }
+
+    // endregion Typed feature access
 
     /**
      * Reinitialized the list of ExperimentRunCallbacks.

--- a/lib/src/main/java/growthbook/sdk/java/IGrowthBook.java
+++ b/lib/src/main/java/growthbook/sdk/java/IGrowthBook.java
@@ -3,6 +3,7 @@ package growthbook.sdk.java;
 import growthbook.sdk.java.callback.ExperimentRunCallback;
 import growthbook.sdk.java.model.Experiment;
 import growthbook.sdk.java.model.ExperimentResult;
+import growthbook.sdk.java.model.FeatureKey;
 import growthbook.sdk.java.model.FeatureResult;
 import growthbook.sdk.java.stickyBucketing.StickyBucketService;
 import javax.annotation.Nullable;
@@ -118,6 +119,99 @@ interface IGrowthBook {
      * @return ValueType instance
      */
     <ValueType> ValueType getFeatureValue(String featureKey, ValueType defaultValue, Class<ValueType> gsonDeserializableClass);
+
+    /**
+     * Evaluate a feature using a type-safe {@link FeatureKey} instead of a raw string key.
+     * The key carries both the feature identifier and its value type.
+     *
+     * <p>The returned result's {@link FeatureResult#getValue()} is the raw evaluated value; it is
+     * <em>not</em> deserialized into the key's value type. To obtain a deserialized instance of a
+     * complex type, use {@link #getFeatureValue(FeatureKey, Object)}.
+     *
+     * @param featureKey  typed feature key, e.g. {@code Features.NEW_HOME}
+     * @param <ValueType> feature value type carried by the key
+     * @return the feature result
+     */
+    <ValueType> FeatureResult<ValueType> getFeature(FeatureKey<ValueType> featureKey);
+
+    /**
+     * Returns true if the feature identified by the typed key evaluates to a truthy value.
+     *
+     * @param featureKey typed feature key
+     * @return true if the value is truthy
+     */
+    Boolean isOn(FeatureKey<?> featureKey);
+
+    /**
+     * Returns true if the feature identified by the typed key evaluates to a falsy value.
+     *
+     * @param featureKey typed feature key
+     * @return true if the value is falsy
+     */
+    Boolean isOff(FeatureKey<?> featureKey);
+
+    /**
+     * Get the feature value using a typed key, inferring the deserialization class from the key.
+     *
+     * @param featureKey   typed feature key
+     * @param defaultValue value to return when the feature is missing or invalid
+     * @param <ValueType>  feature value type carried by the key
+     * @return the found value or defaultValue
+     */
+    <ValueType> ValueType getFeatureValue(FeatureKey<ValueType> featureKey, ValueType defaultValue);
+
+    /**
+     * Get a boolean feature value, defaulting to {@code false} when missing or falsy.
+     *
+     * @param featureKey typed boolean feature key
+     * @return the found value or {@code false}
+     */
+    Boolean getBooleanFeature(FeatureKey<Boolean> featureKey);
+
+    /**
+     * Get a boolean feature value.
+     *
+     * @param featureKey   typed boolean feature key
+     * @param defaultValue value to return when the feature is missing or invalid
+     * @return the found value or defaultValue
+     */
+    Boolean getBooleanFeature(FeatureKey<Boolean> featureKey, Boolean defaultValue);
+
+    /**
+     * Get a string feature value.
+     *
+     * @param featureKey   typed string feature key
+     * @param defaultValue value to return when the feature is missing or invalid
+     * @return the found value or defaultValue
+     */
+    String getStringFeature(FeatureKey<String> featureKey, String defaultValue);
+
+    /**
+     * Get an integer feature value.
+     *
+     * @param featureKey   typed integer feature key
+     * @param defaultValue value to return when the feature is missing or invalid
+     * @return the found value or defaultValue
+     */
+    Integer getIntegerFeature(FeatureKey<Integer> featureKey, Integer defaultValue);
+
+    /**
+     * Get a double feature value.
+     *
+     * @param featureKey   typed double feature key
+     * @param defaultValue value to return when the feature is missing or invalid
+     * @return the found value or defaultValue
+     */
+    Double getDoubleFeature(FeatureKey<Double> featureKey, Double defaultValue);
+
+    /**
+     * Get a float feature value.
+     *
+     * @param featureKey   typed float feature key
+     * @param defaultValue value to return when the feature is missing or invalid
+     * @return the found value or defaultValue
+     */
+    Float getFloatFeature(FeatureKey<Float> featureKey, Float defaultValue);
 
     // endregion Features
 

--- a/lib/src/main/java/growthbook/sdk/java/model/FeatureKey.java
+++ b/lib/src/main/java/growthbook/sdk/java/model/FeatureKey.java
@@ -1,0 +1,41 @@
+package growthbook.sdk.java.model;
+
+/**
+ * A type-safe reference to a feature flag.
+ *
+ * <p>Instead of passing raw string keys such as {@code growthBook.isOn("new-home")}, callers
+ * declare their feature keys once and reference them through this interface:
+ *
+ * <pre>{@code
+ * public final class Features {
+ *     public static final FeatureKey<Boolean> NEW_HOME = TypedKey.ofBoolean("new-home");
+ *     public static final FeatureKey<String>  THEME    = TypedKey.ofString("theme");
+ *     private Features() {}
+ * }
+ *
+ * growthBook.getFeature(Features.NEW_HOME);       // FeatureResult<Boolean>
+ * growthBook.getBooleanFeature(Features.NEW_HOME);
+ * }</pre>
+ *
+ * <p>The key carries both the feature identifier and its value type, so a mistyped string key
+ * becomes a compile-time error rather than a silent runtime miss.
+ *
+ * @param <T> the value type the feature evaluates to
+ * @see TypedKey
+ */
+public interface FeatureKey<T> {
+
+    /**
+     * The feature identifier as configured in GrowthBook, e.g. {@code "new-home"}.
+     *
+     * @return the raw feature key
+     */
+    String getKey();
+
+    /**
+     * The Gson-deserializable class of the feature value, e.g. {@code Boolean.class}.
+     *
+     * @return the value type
+     */
+    Class<T> getValueType();
+}

--- a/lib/src/main/java/growthbook/sdk/java/model/TypedKey.java
+++ b/lib/src/main/java/growthbook/sdk/java/model/TypedKey.java
@@ -1,0 +1,125 @@
+package growthbook.sdk.java.model;
+
+import java.util.Objects;
+
+/**
+ * Default immutable implementation of {@link FeatureKey}.
+ *
+ * <p>Declare feature keys as constants and reference them wherever a feature is evaluated:
+ *
+ * <pre>{@code
+ * public final class Features {
+ *     public static final TypedKey<Boolean> NEW_HOME  = TypedKey.ofBoolean("new-home");
+ *     public static final TypedKey<String>  THEME     = TypedKey.ofString("theme");
+ *     public static final TypedKey<Integer> MAX_ITEMS = TypedKey.ofInteger("max-items");
+ *     public static final TypedKey<MyConfig> CONFIG   = TypedKey.of("my-config", MyConfig.class);
+ *     private Features() {}
+ * }
+ * }</pre>
+ *
+ * @param <T> the value type the feature evaluates to
+ */
+public final class TypedKey<T> implements FeatureKey<T> {
+
+    private final String key;
+    private final Class<T> valueType;
+
+    private TypedKey(String key, Class<T> valueType) {
+        this.key = Objects.requireNonNull(key, "feature key must not be null");
+        this.valueType = Objects.requireNonNull(valueType, "feature value type must not be null");
+    }
+
+    /**
+     * Creates a typed key for an arbitrary Gson-deserializable value type.
+     *
+     * @param key       the feature identifier
+     * @param valueType the value type class, e.g. {@code MyConfig.class}
+     * @param <T> the value type
+     * @return a new typed key
+     */
+    public static <T> TypedKey<T> of(String key, Class<T> valueType) {
+        return new TypedKey<>(key, valueType);
+    }
+
+    /**
+     * Creates a typed key for a boolean feature.
+     *
+     * @param key the feature identifier
+     * @return a new typed key
+     */
+    public static TypedKey<Boolean> ofBoolean(String key) {
+        return of(key, Boolean.class);
+    }
+
+    /**
+     * Creates a typed key for a string feature.
+     *
+     * @param key the feature identifier
+     * @return a new typed key
+     */
+    public static TypedKey<String> ofString(String key) {
+        return of(key, String.class);
+    }
+
+    /**
+     * Creates a typed key for an integer feature.
+     *
+     * @param key the feature identifier
+     * @return a new typed key
+     */
+    public static TypedKey<Integer> ofInteger(String key) {
+        return of(key, Integer.class);
+    }
+
+    /**
+     * Creates a typed key for a double feature.
+     *
+     * @param key the feature identifier
+     * @return a new typed key
+     */
+    public static TypedKey<Double> ofDouble(String key) {
+        return of(key, Double.class);
+    }
+
+    /**
+     * Creates a typed key for a float feature.
+     *
+     * @param key the feature identifier
+     * @return a new typed key
+     */
+    public static TypedKey<Float> ofFloat(String key) {
+        return of(key, Float.class);
+    }
+
+    @Override
+    public String getKey() {
+        return key;
+    }
+
+    @Override
+    public Class<T> getValueType() {
+        return valueType;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof TypedKey)) {
+            return false;
+        }
+        TypedKey<?> other = (TypedKey<?>) o;
+        return key.equals(other.key) && valueType.equals(other.valueType);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(key, valueType);
+    }
+
+    @Override
+    public String toString() {
+        return "TypedKey{key='" + key + "', valueType=" + valueType.getSimpleName() + "}";
+    }
+}

--- a/lib/src/main/java/growthbook/sdk/java/multiusermode/GrowthBookClient.java
+++ b/lib/src/main/java/growthbook/sdk/java/multiusermode/GrowthBookClient.java
@@ -11,6 +11,7 @@ import growthbook.sdk.java.exception.GrowthBookClientInitializationException;
 import growthbook.sdk.java.model.AssignedExperiment;
 import growthbook.sdk.java.model.Experiment;
 import growthbook.sdk.java.model.ExperimentResult;
+import growthbook.sdk.java.model.FeatureKey;
 import growthbook.sdk.java.model.FeatureResult;
 import growthbook.sdk.java.model.RequestBodyForRemoteEval;
 import growthbook.sdk.java.multiusermode.configurations.EvaluationContext;
@@ -281,6 +282,130 @@ public class GrowthBookClient {
             log.error(e.getMessage(), e);
             return defaultValue;
         }
+    }
+
+    /**
+     * Evaluate a feature for a user using a type-safe {@link FeatureKey} instead of a raw string key.
+     *
+     * <p>As with {@link #evalFeature(String, Class, UserContext)}, the returned result's
+     * {@link FeatureResult#getValue()} is the raw evaluated value (a boxed primitive, or a
+     * {@code Map}/{@code List} for object and array features); it is <em>not</em> deserialized
+     * into the key's value type. To obtain a deserialized instance of a complex type, use
+     * {@link #getFeatureValue(FeatureKey, Object, UserContext)}.
+     *
+     * @param featureKey  typed feature key, e.g. {@code Features.NEW_HOME}
+     * @param userContext user context
+     * @param <T>         feature value type carried by the key
+     * @return the feature result
+     */
+    public <T> FeatureResult<T> getFeature(FeatureKey<T> featureKey, UserContext userContext) {
+        return evalFeature(featureKey.getKey(), featureKey.getValueType(), userContext);
+    }
+
+    /**
+     * Checks whether the feature identified by the typed key evaluates to on for a user.
+     *
+     * @param featureKey  typed feature key
+     * @param userContext user context
+     * @return true when the feature is on
+     */
+    public Boolean isOn(FeatureKey<?> featureKey, UserContext userContext) {
+        return isOn(featureKey.getKey(), userContext);
+    }
+
+    /**
+     * Checks whether the feature identified by the typed key evaluates to off for a user.
+     *
+     * @param featureKey  typed feature key
+     * @param userContext user context
+     * @return true when the feature is off
+     */
+    public Boolean isOff(FeatureKey<?> featureKey, UserContext userContext) {
+        return isOff(featureKey.getKey(), userContext);
+    }
+
+    /**
+     * Get a feature value using a typed key, inferring the deserialization class from the key.
+     *
+     * @param featureKey   typed feature key
+     * @param defaultValue value to return when the feature is missing or invalid
+     * @param userContext  user context
+     * @param <T>          feature value type carried by the key
+     * @return the found value or defaultValue
+     */
+    public <T> T getFeatureValue(FeatureKey<T> featureKey, T defaultValue, UserContext userContext) {
+        return getFeatureValue(featureKey.getKey(), defaultValue, featureKey.getValueType(), userContext);
+    }
+
+    /**
+     * Get a boolean feature value, defaulting to {@code false} when missing or falsy.
+     *
+     * @param featureKey  typed boolean feature key
+     * @param userContext user context
+     * @return the found value or {@code false}
+     */
+    public Boolean getBooleanFeature(FeatureKey<Boolean> featureKey, UserContext userContext) {
+        return getFeatureValue(featureKey, false, userContext);
+    }
+
+    /**
+     * Get a boolean feature value.
+     *
+     * @param featureKey   typed boolean feature key
+     * @param defaultValue value to return when the feature is missing or invalid
+     * @param userContext  user context
+     * @return the found value or defaultValue
+     */
+    public Boolean getBooleanFeature(FeatureKey<Boolean> featureKey, Boolean defaultValue, UserContext userContext) {
+        return getFeatureValue(featureKey, defaultValue, userContext);
+    }
+
+    /**
+     * Get a string feature value.
+     *
+     * @param featureKey   typed string feature key
+     * @param defaultValue value to return when the feature is missing or invalid
+     * @param userContext  user context
+     * @return the found value or defaultValue
+     */
+    public String getStringFeature(FeatureKey<String> featureKey, String defaultValue, UserContext userContext) {
+        return getFeatureValue(featureKey, defaultValue, userContext);
+    }
+
+    /**
+     * Get an integer feature value.
+     *
+     * @param featureKey   typed integer feature key
+     * @param defaultValue value to return when the feature is missing or invalid
+     * @param userContext  user context
+     * @return the found value or defaultValue
+     */
+    public Integer getIntegerFeature(FeatureKey<Integer> featureKey, Integer defaultValue, UserContext userContext) {
+        return getFeatureValue(featureKey, defaultValue, userContext);
+    }
+
+    /**
+     * Get a double feature value.
+     *
+     * @param featureKey   typed double feature key
+     * @param defaultValue value to return when the feature is missing or invalid
+     * @param userContext  user context
+     * @return the found value or defaultValue
+     */
+    public Double getDoubleFeature(FeatureKey<Double> featureKey, Double defaultValue, UserContext userContext) {
+        return getFeatureValue(featureKey, defaultValue, userContext);
+    }
+
+    /**
+     * Get a float feature value.
+     *
+     * @param featureKey   typed float feature key
+     * @param defaultValue value to return when the feature is missing or invalid
+     * @param userContext  user context
+     * @return the found value or defaultValue
+     */
+    public Float getFloatFeature(FeatureKey<Float> featureKey, Float defaultValue, UserContext userContext) {
+        return getFeatureValue(featureKey, defaultValue, userContext);
     }
 
     public <ValueType> ExperimentResult<ValueType> run(Experiment<ValueType> experiment, UserContext userContext) {

--- a/lib/src/test/java/growthbook/sdk/java/TypedFeatureAccessTest.java
+++ b/lib/src/test/java/growthbook/sdk/java/TypedFeatureAccessTest.java
@@ -1,0 +1,219 @@
+package growthbook.sdk.java;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import growthbook.sdk.java.model.FeatureResult;
+import growthbook.sdk.java.model.FeatureResultSource;
+import growthbook.sdk.java.model.GBContext;
+import growthbook.sdk.java.model.TypedKey;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class TypedFeatureAccessTest {
+
+    @Test
+    @DisplayName("TypedKey exposes the raw key and value type")
+    void typedKey_exposesKeyAndType() {
+        assertEquals("new-home", Features.NEW_HOME.getKey());
+        assertEquals(Boolean.class, Features.NEW_HOME.getValueType());
+        assertEquals(String.class, Features.THEME.getValueType());
+    }
+
+    @Test
+    @DisplayName("TypedKey.of rejects null arguments")
+    void typedKey_rejectsNulls() {
+        assertThrows(NullPointerException.class, () -> TypedKey.of(null, Boolean.class));
+        assertThrows(NullPointerException.class, () -> TypedKey.of("x", null));
+    }
+
+    @Test
+    @DisplayName("TypedKey equality is based on key and value type")
+    void typedKey_equality() {
+        TypedKey<Boolean> key = TypedKey.ofBoolean("new-home");
+
+        assertEquals(TypedKey.ofBoolean("new-home"), TypedKey.ofBoolean("new-home"));
+        assertEquals(TypedKey.ofBoolean("new-home").hashCode(), TypedKey.ofBoolean("new-home").hashCode());
+        assertNotEquals(TypedKey.ofBoolean("new-home"), TypedKey.ofBoolean("other"));
+        assertNotEquals(null, key);
+    }
+
+    @Test
+    @DisplayName("TypedKey.toString includes the key and value type")
+    void typedKey_toString() {
+        String text = Features.NEW_HOME.toString();
+
+        assertTrue(text.contains("new-home"), text);
+        assertTrue(text.contains("Boolean"), text);
+    }
+
+    @Test
+    @DisplayName("getFeature returns a typed FeatureResult")
+    void getFeature_returnsTypedResult() {
+        FeatureResult<Boolean> result = growthBook().getFeature(Features.NEW_HOME);
+
+        assertNotNull(result);
+        assertEquals(Boolean.TRUE, result.getValue());
+        assertEquals(FeatureResultSource.DEFAULT_VALUE, result.getSource());
+        assertTrue(result.isOn());
+    }
+
+    @Test
+    @DisplayName("getFeature on an unknown key returns an unknownFeature result rather than null")
+    void getFeature_unknownKey_returnsUnknownFeatureResult() {
+        FeatureResult<Boolean> result = growthBook().getFeature(TypedKey.ofBoolean("missing"));
+
+        assertNotNull(result);
+        assertNull(result.getValue());
+        assertEquals(FeatureResultSource.UNKNOWN_FEATURE, result.getSource());
+        assertFalse(result.isOn());
+        assertTrue(result.isOff());
+    }
+
+    @Test
+    @DisplayName("getFeatureValue deserializes a complex value type, falling back on unknown keys")
+    void getFeatureValue_complexType() {
+        GrowthBook subject = growthBook();
+        HomeConfig fallback = new HomeConfig("fallback", 0);
+
+        HomeConfig config = subject.getFeatureValue(Features.HOME_CONFIG, fallback);
+        assertEquals("Welcome", config.getTitle());
+        assertEquals(5, config.getLimit());
+
+        HomeConfig missing = subject.getFeatureValue(TypedKey.of("missing", HomeConfig.class), fallback);
+        assertEquals(fallback, missing);
+    }
+
+    @Test
+    @DisplayName("A feature whose value is falsy reports off")
+    void offFeature_reportsOff() {
+        GrowthBook subject = growthBook();
+
+        assertFalse(subject.isOn(Features.DARK_MODE));
+        assertTrue(subject.isOff(Features.DARK_MODE));
+        assertFalse(subject.getBooleanFeature(Features.DARK_MODE));
+        assertFalse(subject.getBooleanFeature(Features.DARK_MODE, true));
+    }
+
+    @Test
+    @DisplayName("isOn / isOff accept a typed key")
+    void isOnIsOff_acceptTypedKey() {
+        GrowthBook subject = growthBook();
+
+        assertTrue(subject.isOn(Features.NEW_HOME));
+        assertFalse(subject.isOff(Features.NEW_HOME));
+    }
+
+    @Test
+    @DisplayName("getBooleanFeature returns the value, defaulting to false when unknown")
+    void getBooleanFeature() {
+        GrowthBook subject = growthBook();
+
+        assertTrue(subject.getBooleanFeature(Features.NEW_HOME));
+        assertTrue(subject.getBooleanFeature(Features.NEW_HOME, false));
+        assertFalse(subject.getBooleanFeature(TypedKey.ofBoolean("missing")));
+        assertTrue(subject.getBooleanFeature(TypedKey.ofBoolean("missing"), true));
+    }
+
+    @Test
+    @DisplayName("Typed getters read string, integer, double and float values")
+    void typedGetters_readValues() {
+        GrowthBook subject = growthBook();
+
+        assertEquals("dark", subject.getStringFeature(Features.THEME, "light"));
+        assertEquals(Integer.valueOf(25), subject.getIntegerFeature(Features.MAX_ITEMS, 10));
+        assertEquals(Double.valueOf(1.5), subject.getDoubleFeature(Features.RATIO, 0.0));
+        assertEquals(Float.valueOf(2.5f), subject.getFloatFeature(Features.WEIGHT, 0.0f));
+    }
+
+    @Test
+    @DisplayName("Typed getters fall back to the default for unknown keys")
+    void typedGetters_fallBackToDefault() {
+        GrowthBook subject = growthBook();
+
+        assertEquals("light", subject.getStringFeature(TypedKey.ofString("missing"), "light"));
+        assertEquals(Integer.valueOf(10), subject.getIntegerFeature(TypedKey.ofInteger("missing"), 10));
+        assertEquals(Double.valueOf(9.9), subject.getDoubleFeature(TypedKey.ofDouble("missing"), 9.9));
+        assertEquals(Float.valueOf(9.9f), subject.getFloatFeature(TypedKey.ofFloat("missing"), 9.9f));
+    }
+
+    @Test
+    @DisplayName("getFeatureValue infers the deserialization class from the key")
+    void getFeatureValue_infersClassFromKey() {
+        GrowthBook subject = growthBook();
+
+        assertEquals("dark", subject.getFeatureValue(Features.THEME, "light"));
+        assertEquals(Integer.valueOf(25), subject.getFeatureValue(Features.MAX_ITEMS, 0));
+    }
+
+    static final class Features {
+
+        static final TypedKey<String> THEME = TypedKey.ofString("theme");
+        static final TypedKey<Double> RATIO = TypedKey.ofDouble("ratio");
+        static final TypedKey<Float> WEIGHT = TypedKey.ofFloat("weight");
+        static final TypedKey<Boolean> NEW_HOME = TypedKey.ofBoolean("new-home");
+        static final TypedKey<Boolean> DARK_MODE = TypedKey.ofBoolean("dark-mode");
+        static final TypedKey<Integer> MAX_ITEMS = TypedKey.ofInteger("max-items");
+        static final TypedKey<HomeConfig> HOME_CONFIG = TypedKey.of("home-config", HomeConfig.class);
+
+        private Features() {
+        }
+    }
+
+    static final class HomeConfig {
+        private final String title;
+        private final int limit;
+
+        HomeConfig(String title, int limit) {
+            this.title = title;
+            this.limit = limit;
+        }
+
+        String getTitle() {
+            return title;
+        }
+
+        int getLimit() {
+            return limit;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof HomeConfig)) {
+                return false;
+            }
+            HomeConfig other = (HomeConfig) o;
+            return limit == other.limit && java.util.Objects.equals(title, other.title);
+        }
+
+        @Override
+        public int hashCode() {
+            return java.util.Objects.hash(title, limit);
+        }
+    }
+
+    private static final String FEATURES_JSON = "{"
+        + "\"new-home\":{\"defaultValue\":true},"
+        + "\"dark-mode\":{\"defaultValue\":false},"
+        + "\"theme\":{\"defaultValue\":\"dark\"},"
+        + "\"max-items\":{\"defaultValue\":25},"
+        + "\"ratio\":{\"defaultValue\":1.5},"
+        + "\"weight\":{\"defaultValue\":2.5},"
+        + "\"home-config\":{\"defaultValue\":{\"title\":\"Welcome\",\"limit\":5}}"
+        + "}";
+
+    private GrowthBook growthBook() {
+        GBContext context = GBContext.builder()
+            .featuresJson(FEATURES_JSON)
+            .build();
+        return new GrowthBook(context);
+    }
+}

--- a/lib/src/test/java/growthbook/sdk/java/multiusermode/GrowthBookClientTest.java
+++ b/lib/src/test/java/growthbook/sdk/java/multiusermode/GrowthBookClientTest.java
@@ -1,12 +1,16 @@
 package growthbook.sdk.java.multiusermode;
 
+import com.sun.net.httpserver.HttpServer;
 import growthbook.sdk.java.callback.ExperimentRunCallback;
 import growthbook.sdk.java.callback.FeatureRefreshCallback;
 import growthbook.sdk.java.exception.FeatureFetchException;
 import growthbook.sdk.java.model.Experiment;
 import growthbook.sdk.java.model.Feature;
+import growthbook.sdk.java.model.FeatureKey;
 import growthbook.sdk.java.model.FeatureResult;
+import growthbook.sdk.java.model.HttpHeaders;
 import growthbook.sdk.java.model.RequestBodyForRemoteEval;
+import growthbook.sdk.java.model.TypedKey;
 import growthbook.sdk.java.multiusermode.configurations.GlobalContext;
 import growthbook.sdk.java.multiusermode.configurations.Options;
 import growthbook.sdk.java.multiusermode.configurations.UserContext;
@@ -21,7 +25,12 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 
+import java.io.IOException;
+import java.io.OutputStream;
 import java.lang.reflect.Field;
+import java.net.HttpURLConnection;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -522,6 +531,86 @@ class GrowthBookClientTest {
             assertFalse(off);
             assertTrue(floatFeatureResult.isOn());
         }
+    }
+
+    @Test
+    void test_typedFeatureAccess_evaluatesWithTypedKeys() throws Exception {
+        HttpServer server = startFeatureServer(
+                HttpURLConnection.HTTP_OK,
+                "{\"features\":{"
+                        + "\"new-home\":{\"defaultValue\":true},"
+                        + "\"theme\":{\"defaultValue\":\"dark\"},"
+                        + "\"max-items\":{\"defaultValue\":25},"
+                        + "\"ratio\":{\"defaultValue\":1.5},"
+                        // whole-number JSON: exercises the numeric coercion path for float/double
+                        + "\"weight\":{\"defaultValue\":2}"
+                        + "}}"
+        );
+        GrowthBookClient client = null;
+        try {
+            Options options = Options.builder()
+                    .apiHost(apiHost(server))
+                    .clientKey(TEST_CLIENT_KEY)
+                    .isCacheDisabled(true)
+                    .build();
+            client = new GrowthBookClient(options);
+            assertTrue(client.initialize());
+
+            UserContext userContext = UserContext.builder().attributesJson("{\"id\":\"1\"}").build();
+
+            FeatureKey<Boolean> newHome = TypedKey.ofBoolean("new-home");
+            FeatureKey<String> theme = TypedKey.ofString("theme");
+            FeatureKey<Integer> maxItems = TypedKey.ofInteger("max-items");
+            FeatureKey<Double> ratio = TypedKey.ofDouble("ratio");
+            FeatureKey<Float> weight = TypedKey.ofFloat("weight");
+
+            FeatureResult<Boolean> result = client.getFeature(newHome, userContext);
+            assertNotNull(result);
+            assertTrue(result.isOn());
+
+            assertTrue(client.isOn(newHome, userContext));
+            assertFalse(client.isOff(newHome, userContext));
+            assertTrue(client.getBooleanFeature(newHome, userContext));
+            assertEquals("dark", client.getStringFeature(theme, "light", userContext));
+            assertEquals(Integer.valueOf(25), client.getIntegerFeature(maxItems, 10, userContext));
+            assertEquals(Integer.valueOf(25), client.getFeatureValue(maxItems, 0, userContext));
+            assertEquals(Double.valueOf(1.5), client.getDoubleFeature(ratio, 0.0, userContext));
+            assertEquals(Float.valueOf(2.0f), client.getFloatFeature(weight, 0.0f, userContext));
+
+            // Unknown key falls back to the supplied default.
+            assertFalse(client.getBooleanFeature(TypedKey.ofBoolean("missing"), userContext));
+            assertEquals("light", client.getStringFeature(TypedKey.ofString("missing"), "light", userContext));
+        } finally {
+            if (client != null) {
+                client.shutdown();
+            }
+            server.stop(0);
+        }
+    }
+
+    private static final String TEST_CLIENT_KEY = "sdk-test";
+
+    private static HttpServer startFeatureServer(int statusCode, String body) throws IOException {
+        HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/api/features/" + TEST_CLIENT_KEY, exchange -> {
+            byte[] responseBytes = body == null ? new byte[0] : body.getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().add(HttpHeaders.X_SSE_SUPPORT.getHeader(), "enabled");
+            if (statusCode == HttpURLConnection.HTTP_NOT_MODIFIED) {
+                exchange.sendResponseHeaders(statusCode, -1);
+            } else {
+                exchange.sendResponseHeaders(statusCode, responseBytes.length);
+                try (OutputStream responseBody = exchange.getResponseBody()) {
+                    responseBody.write(responseBytes);
+                }
+            }
+            exchange.close();
+        });
+        server.start();
+        return server;
+    }
+
+    private static String apiHost(HttpServer server) {
+        return "http://127.0.0.1:" + server.getAddress().getPort();
     }
 
     private GBFeaturesRepository createMockRepository() {


### PR DESCRIPTION
# Typed feature access (`FeatureKey` / `TypedKey`)

## Summary

Adds a type-safe way to reference feature flags so raw string keys stop leaking into call sites. Instead of:

```java
growthBook.isOn("new-home");
```

applications declare their flags once and reference them through a typed key:

```java
public final class Features {
    public static final TypedKey<Boolean> NEW_HOME  = TypedKey.ofBoolean("new-home");
    public static final TypedKey<String>  THEME     = TypedKey.ofString("theme");
    public static final TypedKey<Integer> MAX_ITEMS = TypedKey.ofInteger("max-items");
    private Features() {}
}

growthBook.getFeature(Features.NEW_HOME);        // FeatureResult<Boolean>
growthBook.getBooleanFeature(Features.NEW_HOME);
growthBook.getStringFeature(Features.THEME, "light");
growthBook.getIntegerFeature(Features.MAX_ITEMS, 10);
```

A mistyped key becomes a **compile-time error** rather than a silent runtime miss, and the value type is checked by the compiler (you can't call `getBooleanFeature` on a `String` key). The change is purely additive — every existing `String`-based method is untouched.

## Design

- **`FeatureKey<T>`** — an interface carrying both the feature identifier (`getKey()`) and its value type (`getValueType()`). Applications can implement it directly, or use the provided implementation.
- **`TypedKey<T>`** — an immutable implementation with factories: `of(key, Class)` for arbitrary Gson-deserializable types, plus `ofBoolean` / `ofString` / `ofInteger` / `ofDouble` / `ofFloat` shortcuts. Null-checked at construction; `equals`/`hashCode`/`toString` based on key + value type.
- **New overloads on both entry points** — every typed method mirrors an existing `String`-based one and simply delegates through `featureKey.getKey()` / `featureKey.getValueType()`, so all existing evaluation and type-conversion logic is reused:
  - `getFeature(FeatureKey<T>)` → `FeatureResult<T>`
  - `isOn(FeatureKey<?>)`, `isOff(FeatureKey<?>)`
  - `getFeatureValue(FeatureKey<T>, T defaultValue)` — infers the deserialization class from the key, so no separate `Class<T>` argument is needed
  - `getBooleanFeature` (with and without a default; default `false`), `getStringFeature`, `getIntegerFeature`, `getDoubleFeature`, `getFloatFeature`
- **`GrowthBook`** implements these via the shared package-private `IGrowthBook` interface (methods added there too). **`GrowthBookClient`** exposes the same set with a trailing `UserContext` parameter, each delegating through the typed `getFeatureValue` so the key's value type is the single source of truth.

## Behavior note

`getFeature(key)` mirrors `evalFeature`: `FeatureResult.getValue()` returns the **raw** evaluated value (a boxed primitive, or a `Map`/`List` for object and array features) — it is *not* deserialized into the key's value type. To get a deserialized instance of a complex type, use `getFeatureValue(FeatureKey<T>, T)`, which performs the Gson round-trip. This is documented on the methods.

## Testing

- **`TypedFeatureAccessTest`** (13 tests, single-context `GrowthBook`): `TypedKey` key/type exposure, null rejection, `equals`/`toString`; `getFeature` for present and unknown keys (`UNKNOWN_FEATURE` source, `isOff`); `isOn`/`isOff`; `getBooleanFeature` with/without default; all typed getters (string/int/double/float) reading values and falling back on unknown keys; complex-type deserialization via `getFeatureValue(TypedKey.of(key, MyConfig.class), …)`; a falsy feature reporting off.
- **`GrowthBookClientTest`** (multi-user path, real HTTP server): typed `getFeature`/`isOn`/`isOff`/`getBooleanFeature`/`getStringFeature`/`getIntegerFeature`/`getFeatureValue` plus numeric coercion for `getDoubleFeature`/`getFloatFeature` (including a whole-number JSON value `2` → `2.0f`) and unknown-key fallbacks.
- Full `./gradlew :lib:test` is green.
