### PR TITLE
ci: replace macOS runner with Linux in build matrix

### DIFF
--- a/.github/workflows/ci_linux_windows.yml
+++ b/.github/workflows/ci_linux_windows.yml
@@ -1,4 +1,4 @@
-name: CI (macOS, Windows)
+name: CI (Linux, Windows)
 on:
   push:
     branches:
@@ -12,7 +12,7 @@ jobs:
   build_all:
     strategy:
       matrix:
-        os: [ macos-latest, windows-latest ]
+        os: [ ubuntu-latest, windows-latest ]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
The cross-platform CI workflow now runs on ubuntu-latest and windows-latest instead of macos-latest and windows-latest. The workflow file is renamed from ci_macos_windows.yml to ci_linux_windows.yml to match.