### PR TITLE
fix: enable SSE reconnect in multi-user client

### DIFF
--- a/lib/src/main/java/growthbook/sdk/java/multiusermode/GrowthBookClient.java
+++ b/lib/src/main/java/growthbook/sdk/java/multiusermode/GrowthBookClient.java
@@ -223,8 +223,6 @@ public class GrowthBookClient {
 
     private void initializeFeaturesRepository(GBFeaturesRepository repositorySnapshot) {
         try {
-            // Honor the configured SSE reconnect behavior; the no-arg initialize() hardwires
-            // retryOnFailure=false, which would disable SSE reconnection.
             repositorySnapshot.initialize(this.options.isSseReconnectOnFailure());
         } catch (FeatureFetchException e) {
             throw new GrowthBookClientInitializationException(

--- a/lib/src/main/java/growthbook/sdk/java/multiusermode/GrowthBookClient.java
+++ b/lib/src/main/java/growthbook/sdk/java/multiusermode/GrowthBookClient.java
@@ -223,7 +223,9 @@ public class GrowthBookClient {
 
     private void initializeFeaturesRepository(GBFeaturesRepository repositorySnapshot) {
         try {
-            repositorySnapshot.initialize();
+            // Honor the configured SSE reconnect behavior; the no-arg initialize() hardwires
+            // retryOnFailure=false, which would disable SSE reconnection.
+            repositorySnapshot.initialize(this.options.isSseReconnectOnFailure());
         } catch (FeatureFetchException e) {
             throw new GrowthBookClientInitializationException(
                     "Failed to initialize features repository", e);

--- a/lib/src/main/java/growthbook/sdk/java/multiusermode/configurations/Options.java
+++ b/lib/src/main/java/growthbook/sdk/java/multiusermode/configurations/Options.java
@@ -83,6 +83,7 @@ public class Options {
                 null,
                 null,
                 null,
+                null,
                 null
         );
     }
@@ -114,7 +115,8 @@ public class Options {
                    @Nullable Integer remoteEvalCacheSize,
                    @Nullable Integer remoteEvalCacheTtlSeconds,
                    @Nullable Duration backgroundFetchInterval,
-                   @Nullable FeatureFetchRetryPolicy retryPolicy
+                   @Nullable FeatureFetchRetryPolicy retryPolicy,
+                   @Nullable Boolean sseReconnectOnFailure
     ) {
         this.enabled = enabled == null || enabled;
         this.isQaMode = isQaMode != null && isQaMode;
@@ -143,6 +145,7 @@ public class Options {
         this.remoteEvalCacheTtlSeconds = remoteEvalCacheTtlSeconds;
         this.backgroundFetchInterval = backgroundFetchInterval;
         this.retryPolicy = retryPolicy;
+        this.sseReconnectOnFailure = sseReconnectOnFailure;
     }
 
     /**
@@ -299,6 +302,17 @@ public class Options {
      */
     @Nullable
     private FeatureFetchRetryPolicy retryPolicy;
+
+    /**
+     * Whether the multi-user client reconnects the SSE stream after an abnormal failure or a
+     * server close. Reconnect attempts are bounded by {@link #retryPolicy}. Defaults to {@code true}.
+     */
+    @Nullable
+    private Boolean sseReconnectOnFailure;
+
+    public boolean isSseReconnectOnFailure() {
+        return sseReconnectOnFailure == null || sseReconnectOnFailure;
+    }
 
     @Nullable
     public String getCacheDirectory() {

--- a/lib/src/test/java/growthbook/sdk/java/multiusermode/GrowthBookClientDiagnosticsTest.java
+++ b/lib/src/test/java/growthbook/sdk/java/multiusermode/GrowthBookClientDiagnosticsTest.java
@@ -27,6 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
@@ -323,7 +324,7 @@ class GrowthBookClientDiagnosticsTest {
         String unsafeErrorMessage = "network unavailable for "
                 + "https://user:pass@custom.growthbook.io/api/features/custom_key?token=secret using test_key";
         doThrow(new FeatureFetchException(FeatureFetchException.FeatureFetchErrorCode.NO_RESPONSE_ERROR, unsafeErrorMessage))
-                .when(mockRepository).initialize();
+                .when(mockRepository).initialize(anyBoolean());
         mockBuilder = createMockBuilder(mockRepository);
 
         try (MockedStatic<GBFeaturesRepository> mockedStatic = mockStatic(GBFeaturesRepository.class)) {

--- a/lib/src/test/java/growthbook/sdk/java/multiusermode/GrowthBookClientTest.java
+++ b/lib/src/test/java/growthbook/sdk/java/multiusermode/GrowthBookClientTest.java
@@ -88,9 +88,6 @@ class GrowthBookClientTest {
 
     @Test
     void initialize_sseReconnectDisabled_passesReconnectFlagFalseToRepository() throws FeatureFetchException {
-        // Regression: the client must pass Options.isSseReconnectOnFailure() into
-        // repository.initialize(Boolean). The no-arg initialize() hardwires retryOnFailure=false,
-        // which would disable SSE reconnection regardless of configuration.
         mockRepository = createMockRepository();
         mockBuilder = createMockBuilder(mockRepository);
 

--- a/lib/src/test/java/growthbook/sdk/java/multiusermode/GrowthBookClientTest.java
+++ b/lib/src/test/java/growthbook/sdk/java/multiusermode/GrowthBookClientTest.java
@@ -41,6 +41,7 @@ import static growthbook.sdk.java.multiusermode.GrowthBookClientTestFixtures.cre
 import static growthbook.sdk.java.multiusermode.GrowthBookClientTestFixtures.createMockRepository;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.*;
 
 class GrowthBookClientTest {
@@ -63,7 +64,7 @@ class GrowthBookClientTest {
             GrowthBookClient client = new GrowthBookClient(options);
             assertTrue(client.initialize());
 
-            verify(mockRepository).initialize();
+            verify(mockRepository).initialize(true);
 
             // Capture the callbacks for inspection
             ArgumentCaptor<FeatureRefreshCallback> callbackCaptor =
@@ -86,12 +87,39 @@ class GrowthBookClientTest {
     }
 
     @Test
+    void initialize_sseReconnectDisabled_passesReconnectFlagFalseToRepository() throws FeatureFetchException {
+        // Regression: the client must pass Options.isSseReconnectOnFailure() into
+        // repository.initialize(Boolean). The no-arg initialize() hardwires retryOnFailure=false,
+        // which would disable SSE reconnection regardless of configuration.
+        mockRepository = createMockRepository();
+        mockBuilder = createMockBuilder(mockRepository);
+
+        try (MockedStatic<GBFeaturesRepository> mockedStatic = mockStatic(GBFeaturesRepository.class)) {
+            mockedStatic.when(GBFeaturesRepository::builder).thenReturn(mockBuilder);
+
+            Options options = Options.builder()
+                    .apiHost("https://custom.growthbook.io")
+                    .clientKey("custom_key")
+                    .decryptionKey("test_key")
+                    .refreshStrategy(FeatureRefreshStrategy.STALE_WHILE_REVALIDATE)
+                    .sseReconnectOnFailure(false)
+                    .build();
+
+            GrowthBookClient client = new GrowthBookClient(options);
+            assertTrue(client.initialize());
+
+            verify(mockRepository).initialize(false);
+            verify(mockRepository, never()).initialize(true);
+        }
+    }
+
+    @Test
     void initialize_repositoryThrows_returnsFalse() throws FeatureFetchException {
         // Configures a mock repository that simulates initialization failure
         mockRepository = mock(GBFeaturesRepository.class);
         when(mockRepository.getInitialized()).thenReturn(false);
         doThrow(new FeatureFetchException(FeatureFetchException
-                .FeatureFetchErrorCode.NO_RESPONSE_ERROR)).when(mockRepository).initialize();
+                .FeatureFetchErrorCode.NO_RESPONSE_ERROR)).when(mockRepository).initialize(anyBoolean());
 
         // create the mock builder instance
         mockBuilder = createMockBuilder(mockRepository);
@@ -109,7 +137,7 @@ class GrowthBookClientTest {
             assertFalse(result);
 
             // 6. Verify initialize was called and threw exception
-            verify(mockRepository).initialize();
+            verify(mockRepository).initialize(anyBoolean());
         }
     }
 


### PR DESCRIPTION

  ## Problem

  In multi-user mode, `GrowthBookClient` always called the no-arg
  `repository.initialize()` (in `initializeFeaturesRepository()`), which delegates to
  `initialize(false)`. That hardwires `retryOnFailure = false`, so
  `scheduleSseReconnect(...)` early-returns and the SSE reconnect machinery is unreachable.

  As a result, a `GrowthBookClient` using `FeatureRefreshStrategy.SERVER_SENT_EVENTS`
  permanently stops receiving feature updates after the first abnormal stream failure
  (connection reset, proxy/pod restart, mid-stream IOException) — silently:

  - no reconnect attempt;
  - no polling fallback (`schedulePolling()` early-returns for SSE);
  - no observability — `FeatureRefreshCallback.onError(...)` never fires.

  Both `onFailure` and `onClose` route through `scheduleSseReconnect`, so multi-user + SSE
  also stops reconnecting on a *graceful* close. `Options.retryPolicy` (exponential
  backoff) was configurable but never actually engaged.

  ## Fix
  
  Expose the flag on `Options` and thread it through the single choke point:

  - `Options.sseReconnectOnFailure` — new option, **defaults to `true`**, with
    `isSseReconnectOnFailure()` returning `true` unless explicitly disabled. Added as the
    last constructor parameter to preserve the existing positional constructor signature.
  - `GrowthBookClient.initializeFeaturesRepository()` now calls
    `repository.initialize(options.isSseReconnectOnFailure())` instead of the no-arg form.

  Reconnect is on by default (bounded by `retryPolicy`), and callers can opt out with
  `Options.builder().sseReconnectOnFailure(false)`. The single-user
  `GBFeaturesRepository.initialize()` default (`false`) is unchanged to avoid a broader
  public-API behavior change.

  ## Tests
  backoff) was configurable but never actually engaged.

  ## Fix

  Expose the flag on `Options` and thread it through the single choke point:

  - `Options.sseReconnectOnFailure` — new option, **defaults to `true`**, with
    `isSseReconnectOnFailure()` returning `true` unless explicitly disabled. Added as the
    last constructor parameter to preserve the existing positional constructor signature.
  - `GrowthBookClient.initializeFeaturesRepository()` now calls
    `repository.initialize(options.isSseReconnectOnFailure())` instead of the no-arg form.

  Reconnect is on by default (bounded by `retryPolicy`), and callers can opt out with
  `Options.builder().sseReconnectOnFailure(false)`. The single-user
  `GBFeaturesRepository.initialize()` default (`false`) is unchanged to avoid a broader
  public-API behavior change.
