### PR TITLE
fix: apply 200 response payload when x-sse-support header is absent

### DIFF
--- a/lib/src/main/java/growthbook/sdk/java/repository/NativeJavaGbFeatureRepository.java
+++ b/lib/src/main/java/growthbook/sdk/java/repository/NativeJavaGbFeatureRepository.java
@@ -458,12 +458,6 @@ public class NativeJavaGbFeatureRepository implements IGBFeaturesRepository {
             }
 
             if (responseCode == HttpURLConnection.HTTP_OK) {
-                if (this.featuresEndpoint.matches(FEATURES_ENDPOINT_PATTERN)) {
-                    String newEtag = connection.getHeaderField("ETag");
-                    if (newEtag != null) {
-                        eTagCache.put(this.featuresEndpoint, newEtag);
-                    }
-                }
                 reader = new BufferedReader(new InputStreamReader(connection.getInputStream()));
                 StringBuilder responseBuilder = new StringBuilder();
                 String lines;
@@ -473,11 +467,14 @@ public class NativeJavaGbFeatureRepository implements IGBFeaturesRepository {
                 reader.close();
                 String responseBody = responseBuilder.toString();
                 String sseSupportHeader = connection.getHeaderField(HttpHeaders.X_SSE_SUPPORT.getHeader());
-                if (sseSupportHeader == null) {
-                    throw new FeatureFetchException(FeatureFetchException.FeatureFetchErrorCode.UNKNOWN);
-                }
                 this.sseAllowed.set(ENABLED.equals(sseSupportHeader));
                 this.onSuccess(responseBody, false);
+                if (this.featuresEndpoint.matches(FEATURES_ENDPOINT_PATTERN)) {
+                    String newEtag = connection.getHeaderField("ETag");
+                    if (newEtag != null) {
+                        eTagCache.put(this.featuresEndpoint, newEtag);
+                    }
+                }
                 return;
             }
 

--- a/lib/src/test/java/growthbook/sdk/java/NativeJavaGbFeatureRepositoryTest.java
+++ b/lib/src/test/java/growthbook/sdk/java/NativeJavaGbFeatureRepositoryTest.java
@@ -397,4 +397,75 @@ class NativeJavaGbFeatureRepositoryTest {
 
         wireMock.verify(2, getRequestedFor(urlPathMatching("/api/features/.*")));
     }
+
+    @Test
+    void initialize_appliesPayload_whenSseSupportHeaderAbsent() throws Exception {
+        wireMock.stubFor(get(urlPathMatching("/api/features/.*"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"features\":{\"dark-mode\":{\"defaultValue\":true}}}")));
+
+        NativeJavaGbFeatureRepository repo = NativeJavaGbFeatureRepository.builder()
+                .apiHost("http://localhost:" + wireMock.port())
+                .clientKey("sdk-test123")
+                .refreshStrategy(FeatureRefreshStrategy.STALE_WHILE_REVALIDATE)
+                .isCacheDisabled(true)
+                .build();
+
+        repo.initialize();
+
+        assertTrue(repo.getInitialized().get());
+        assertEquals("{\"dark-mode\":{\"defaultValue\":true}}", repo.getFeaturesJson());
+    }
+
+    @Test
+    void initialize_fallsBackToSWR_whenSseSupportHeaderAbsent() throws Exception {
+        wireMock.stubFor(get(urlPathMatching("/api/features/.*"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withBody("{\"features\":{}}")));
+
+        NativeJavaGbFeatureRepository repo = NativeJavaGbFeatureRepository.builder()
+                .apiHost("http://localhost:" + wireMock.port())
+                .clientKey("sdk-test123")
+                .refreshStrategy(FeatureRefreshStrategy.SERVER_SENT_EVENTS)
+                .isCacheDisabled(true)
+                .build();
+
+        repo.initialize();
+
+        assertEquals(FeatureRefreshStrategy.STALE_WHILE_REVALIDATE, repo.getRefreshStrategy());
+    }
+
+    @Test
+    void fetchFeatures_doesNotCacheEtag_whenPayloadProcessingFails() throws Exception {
+        wireMock.stubFor(get(urlPathMatching("/api/features/.*"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("X-Sse-Support", "disabled")
+                        .withHeader("ETag", "W/\"stale-etag\"")
+                        .withBody("null")));
+
+        NativeJavaGbFeatureRepository repo = NativeJavaGbFeatureRepository.builder()
+                .apiHost("http://localhost:" + wireMock.port())
+                .clientKey("sdk-test123")
+                .isCacheDisabled(true)
+                .build();
+
+        assertThrows(Exception.class, repo::fetchFeatures);
+
+        wireMock.stubFor(get(urlPathMatching("/api/features/.*"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("X-Sse-Support", "disabled")
+                        .withHeader("ETag", "W/\"fresh-etag\"")
+                        .withBody("{\"features\":{\"dark-mode\":{\"defaultValue\":true}}}")));
+
+        repo.fetchFeatures();
+
+        assertEquals("{\"dark-mode\":{\"defaultValue\":true}}", repo.getFeaturesJson());
+        wireMock.verify(0, getRequestedFor(urlPathMatching("/api/features/.*"))
+                .withHeader("If-None-Match", matching(".*")));
+    }
 }


### PR DESCRIPTION
Fixes #230

## Problem

`NativeJavaGbFeatureRepository.fetchFeaturesOnce()` cached the response `ETag` **before** validating/applying the payload, and threw `FeatureFetchException(UNKNOWN)` whenever a 200 response lacked the `x-sse-support` header — discarding the payload it had just fetched. The combination permanently wedges the repository: every subsequent conditional GET carries the already-current ETag, receives an honest `304`, and the SDK keeps serving stale (or empty) features until the process restarts. `https://api.growthbook.io` serves 200s without the header, so the repository cannot be used against it at all; any proxy/CDN edge that drops the header wedges it too.

Per the [Build Your Own SDK spec](https://docs.growthbook.io/lib/build-your-own) the header is optional and only gates `/sub/` streaming; the JS/Go/Python SDKs and `GBFeaturesRepository` in this repo all treat it that way already.

## Changes

- `fetchFeaturesOnce()`: a missing `x-sse-support` header no longer throws; it results in `sseAllowed = false`, which the existing SSE path already turns into the documented stale-while-revalidate fallback.
- `fetchFeaturesOnce()`: the ETag is cached only **after** `onSuccess()` has applied the payload, so a failed apply can never poison the conditional-GET cache.

## Tests

- `initialize_appliesPayload_whenSseSupportHeaderAbsent` — 200 without the header must be applied.
- `initialize_fallsBackToSWR_whenSseSupportHeaderAbsent` — SSE strategy downgrades instead of failing when the header is absent.
- `fetchFeatures_doesNotCacheEtag_whenPayloadProcessingFails` — a 200 whose body fails to process must not leave its ETag behind (next request must be unconditional).

All three fail on current `main`; with the fix the full `:lib:test` suite is green (435 tests, 0 failures).