### PR TITLE
feat: add Map-based attributes overload to UserContextBuilder

### DIFF
--- a/lib/src/main/java/growthbook/sdk/java/multiusermode/configurations/UserContext.java
+++ b/lib/src/main/java/growthbook/sdk/java/multiusermode/configurations/UserContext.java
@@ -2,6 +2,7 @@ package growthbook.sdk.java.multiusermode.configurations;
 
 import com.google.gson.JsonObject;
 import growthbook.sdk.java.util.ForcedVariationsUtils;
+import growthbook.sdk.java.util.GrowthBookJsonUtils;
 import growthbook.sdk.java.model.StickyAssignmentsDocument;
 import growthbook.sdk.java.multiusermode.util.TransformationUtil;
 import lombok.Setter;
@@ -124,6 +125,26 @@ public class UserContext {
 
         public UserContextBuilder attributes(JsonObject attributes) {
             this.attributes = attributes;
+            return this;
+        }
+
+        /**
+         * Set attributes from a plain {@link Map}, converting it into the internal
+         * {@link JsonObject} using the SDK's shared Gson instance. This lets calling
+         * code pass attributes without touching the Gson/JSON layer, e.g.
+         * <pre>{@code
+         * UserContext.builder()
+         *     .attributes(Map.of("userId", userId, "country", country))
+         *     .build();
+         * }</pre>
+         *
+         * @param attributes attributes as key-value pairs, or {@code null} for none
+         * @return this builder
+         */
+        public UserContextBuilder attributes(Map<String, ?> attributes) {
+            this.attributes = attributes == null
+                    ? new JsonObject()
+                    : GrowthBookJsonUtils.getInstance().gson.toJsonTree(attributes).getAsJsonObject();
             return this;
         }
 

--- a/lib/src/test/java/growthbook/sdk/java/multiusermode/configurations/UserContextTest.java
+++ b/lib/src/test/java/growthbook/sdk/java/multiusermode/configurations/UserContextTest.java
@@ -1,0 +1,71 @@
+package growthbook.sdk.java.multiusermode.configurations;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.google.gson.JsonObject;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class UserContextTest {
+
+    @Test
+    void attributes_fromMap_convertsToJsonObject() {
+        Map<String, Object> attributes = new LinkedHashMap<>();
+        attributes.put("userId", "user-123");
+        attributes.put("country", "US");
+        attributes.put("loggedIn", true);
+        attributes.put("age", 42);
+
+        UserContext context = UserContext.builder()
+                .attributes(attributes)
+                .build();
+
+        JsonObject result = context.getAttributes();
+        assertEquals("user-123", result.get("userId").getAsString());
+        assertEquals("US", result.get("country").getAsString());
+        assertTrue(result.get("loggedIn").getAsBoolean());
+        assertEquals(42, result.get("age").getAsInt());
+    }
+
+    @Test
+    void attributes_fromNullMap_yieldsEmptyJsonObject() {
+        Map<String, ?> attributes = null;
+
+        UserContext context = UserContext.builder()
+                .attributes(attributes)
+                .build();
+
+        assertEquals(0, context.getAttributes().size());
+    }
+
+    @Test
+    void attributes_fromStringValuedMap_isAccepted() {
+        // Map.of(...) infers Map<String, String>; the wildcard overload must accept it.
+        Map<String, String> attributes = new HashMap<>();
+        attributes.put("userId", "user-123");
+        attributes.put("country", "US");
+
+        UserContext context = UserContext.builder()
+                .attributes(attributes)
+                .build();
+
+        JsonObject result = context.getAttributes();
+        assertEquals("user-123", result.get("userId").getAsString());
+        assertEquals("US", result.get("country").getAsString());
+    }
+
+    @Test
+    void attributes_fromJsonObject_stillWorks() {
+        JsonObject attributes = new JsonObject();
+        attributes.addProperty("userId", "user-123");
+
+        UserContext context = UserContext.builder()
+                .attributes(attributes)
+                .build();
+
+        assertEquals("user-123", context.getAttributes().get("userId").getAsString());
+    }
+}


### PR DESCRIPTION
## Summary
  
  `UserContext.UserContextBuilder` previously only accepted attributes as a
  `com.google.gson.JsonObject` or a raw JSON `String` (`attributesJson`). Both
  leak the Gson/JSON layer into calling code, where attributes are almost always
  already available as a plain `Map`.
  
  This PR adds a `Map`-based overload so attributes can be passed directly:
  
  ```java
  UserContext ctx = UserContext.builder()
          .attributes(Map.of(
                  "userId", userId,
                  "country", country
          ))
          .build();

  The map is converted into the internal JsonObject using the SDK's shared
  Gson instance. This mirrors how the JS/TS SDK works, where attributes is a
  plain object (Record<string, any>) with no JSON layer exposed to callers.

  Changes
  
  - Add UserContextBuilder.attributes(Map<String, ?>) overload. The
  Map<String, ?> wildcard ensures Map.of("userId", userId, "country", country)
  (inferred as Map<String, String>) is accepted.
  - Add UserContextTest covering Map→JsonObject conversion (mixed value types),
  null map handling, the Map<String, String> wildcard case, and that the
  existing JsonObject overload still works.
