### PR TITLE
feat: async sticky bucket service with non-blocking reads and fire-and-forget writes

### DIFF
--- a/lib/src/main/java/growthbook/sdk/java/evaluators/ExperimentEvaluator.java
+++ b/lib/src/main/java/growthbook/sdk/java/evaluators/ExperimentEvaluator.java
@@ -20,6 +20,7 @@ import growthbook.sdk.java.model.VariationMeta;
 import growthbook.sdk.java.multiusermode.configurations.EvaluationContext;
 import growthbook.sdk.java.multiusermode.usage.TrackingCallbackWithUser;
 import growthbook.sdk.java.plugin.PluginRegistry;
+import growthbook.sdk.java.stickyBucketing.StickyBucketDocWriter;
 import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.Nullable;
@@ -299,8 +300,12 @@ public class ExperimentEvaluator implements IExperimentEvaluator {
                         docModel.getStickyAssignmentsDocument()
                 );
 
-                // save doc
-                if (context.getOptions().getStickyBucketService() != null) {
+                // save doc: through the owning client's writer seam when set
+                // (fire-and-forget persistence), else the legacy direct call.
+                StickyBucketDocWriter docWriter = context.getStickyBucketDocWriter();
+                if (docWriter != null) {
+                    docWriter.write(docModel.getStickyAssignmentsDocument());
+                } else if (context.getOptions().getStickyBucketService() != null) {
                     context.getOptions().getStickyBucketService().saveAssignments(docModel.getStickyAssignmentsDocument());
                 }
             }
@@ -460,7 +465,7 @@ public class ExperimentEvaluator implements IExperimentEvaluator {
 
     private <ValueType> boolean isStickyBucketingEnabledForExperiment(EvaluationContext context,
                                                                       Experiment<ValueType> experiment) {
-        return context.getOptions().getStickyBucketService() != null
+        return context.getOptions().isStickyBucketingConfigured()
                 && !Boolean.TRUE.equals(experiment.getDisableStickyBucketing());
     }
 

--- a/lib/src/main/java/growthbook/sdk/java/multiusermode/GrowthBookClient.java
+++ b/lib/src/main/java/growthbook/sdk/java/multiusermode/GrowthBookClient.java
@@ -39,6 +39,8 @@ import growthbook.sdk.java.sandbox.CacheManagerFactory;
 import growthbook.sdk.java.sandbox.CacheMode;
 import growthbook.sdk.java.sandbox.GbCacheManager;
 import growthbook.sdk.java.model.StickyAssignmentsDocument;
+import growthbook.sdk.java.stickyBucketing.AsyncStickyBucketService;
+import growthbook.sdk.java.stickyBucketing.SyncOffloadStickyBucketAdapter;
 import growthbook.sdk.java.util.GrowthBookJsonUtils;
 import lombok.extern.slf4j.Slf4j;
 
@@ -46,11 +48,20 @@ import javax.annotation.Nullable;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
@@ -74,6 +85,15 @@ public class GrowthBookClient {
     private final DiagnosticsProvider diagnosticsProvider;
     private final PluginRegistry pluginRegistry;
 
+    /** Owns all sticky bucket I/O; null when no sticky bucket service is configured. */
+    @Nullable
+    private final StickyBucketManager stickyBucketManager;
+    /** The pool this client created for itself (and must shut down); null when the caller supplied one. */
+    @Nullable
+    private final ExecutorService ownedAsyncExecutor;
+
+    private static final AtomicLong ASYNC_THREAD_COUNTER = new AtomicLong();
+
     public GrowthBookClient() {
         this(Options.builder().build());
     }
@@ -89,8 +109,52 @@ public class GrowthBookClient {
         this.experimentEvaluatorEvaluator = new ExperimentEvaluator();
         this.diagnosticsProvider = new GrowthBookClientDiagnosticsProvider(this.options, clientStateView());
 
+        if (this.options.isStickyBucketingConfigured()) {
+            Executor executor = this.options.getAsyncExecutor();
+            if (executor == null) {
+                this.ownedAsyncExecutor = newOwnedAsyncExecutor();
+                executor = this.ownedAsyncExecutor;
+            } else {
+                this.ownedAsyncExecutor = null;
+            }
+            AsyncStickyBucketService asyncService = this.options.getAsyncStickyBucketService() != null
+                    ? this.options.getAsyncStickyBucketService()
+                    : new SyncOffloadStickyBucketAdapter(this.options.getStickyBucketService(), executor);
+            this.stickyBucketManager = new StickyBucketManager(
+                    asyncService,
+                    this.options.getStickyBucketCacheTtlSeconds(),
+                    this.options.getStickyBucketCacheSize());
+        } else {
+            this.ownedAsyncExecutor = null;
+            this.stickyBucketManager = null;
+        }
+
         this.pluginRegistry = new PluginRegistry(this.options.getPlugins());
         this.pluginRegistry.initAll();
+    }
+
+    /**
+     * Bounded daemon pool for blocking I/O offload — sized for I/O, not CPU.
+     * Fixed core==max (a ThreadPoolExecutor never grows past core until its
+     * queue is FULL, so a small core with a deep queue serializes I/O) with
+     * idle timeout so a quiet client holds zero threads. Default AbortPolicy:
+     * CallerRunsPolicy would run blocking store I/O on the request thread at
+     * saturation — exactly what this pool exists to prevent — and silently
+     * discards tasks after shutdown, leaving futures that never complete.
+     */
+    private static ExecutorService newOwnedAsyncExecutor() {
+        int threads = Math.max(8, 2 * Runtime.getRuntime().availableProcessors());
+        ThreadPoolExecutor pool = new ThreadPoolExecutor(
+                threads, threads,
+                60L, TimeUnit.SECONDS,
+                new LinkedBlockingQueue<>(1024),
+                runnable -> {
+                    Thread thread = new Thread(runnable, "growthbook-async-" + ASYNC_THREAD_COUNTER.incrementAndGet());
+                    thread.setDaemon(true);
+                    return thread;
+                });
+        pool.allowCoreThreadTimeOut(true);
+        return pool;
     }
 
     private GrowthBookClientDiagnosticsProvider.ClientState clientStateView() {
@@ -511,6 +575,24 @@ public class GrowthBookClient {
 
     public synchronized void shutdown() {
         this.clientShutdown.set(true);
+        // Drain sticky bucket saves FIRST, while the offload executor is fully
+        // alive — shutting the executor down before the flush would discard
+        // trailing saves and leave the flush waiting on futures nobody completes.
+        if (this.stickyBucketManager != null) {
+            this.stickyBucketManager.startDraining();
+            this.stickyBucketManager.close(5_000);
+        }
+        if (this.ownedAsyncExecutor != null) {
+            this.ownedAsyncExecutor.shutdown();
+            try {
+                if (!this.ownedAsyncExecutor.awaitTermination(1, TimeUnit.SECONDS)) {
+                    this.ownedAsyncExecutor.shutdownNow();
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                this.ownedAsyncExecutor.shutdownNow();
+            }
+        }
         GBFeaturesRepository repositorySnapshot = this.repository.getAndSet(null);
         this.globalContext.set(null);
         if (repositorySnapshot != null) {
@@ -662,7 +744,61 @@ public class GrowthBookClient {
         if (this.options.isRemoteEvalEnabled()) {
             return getRemoteEvalContext(updatedUserContext);
         }
-        return withPluginRegistry(new EvaluationContext(getLocalGlobalContext(), updatedUserContext, new EvaluationContext.StackContext(), this.options));
+        EvaluationContext evaluationContext = withPluginRegistry(
+                new EvaluationContext(getLocalGlobalContext(), updatedUserContext, new EvaluationContext.StackContext(), this.options));
+        if (this.stickyBucketManager != null) {
+            // Fire-and-forget persistence (JS/Python parity): evaluation never waits
+            // on the store; the manager merges, serializes per key, and tracks the
+            // save for flushStickyBucketSaves()/shutdown().
+            evaluationContext.setStickyBucketDocWriter(this.stickyBucketManager::recordAndSave);
+        }
+        return evaluationContext;
+    }
+
+    /**
+     * Waits for every pending sticky bucket save to be persisted. Evaluation
+     * writes assignments fire-and-forget; long-running services never need this,
+     * but short-lived processes (serverless functions, batch jobs) should await
+     * it — or call {@link #shutdown()}, which flushes automatically — before
+     * exiting to guarantee durability.
+     *
+     * @return a future completing when all pending saves have been attempted;
+     *         already complete when no sticky bucket service is configured
+     */
+    public CompletableFuture<Void> flushStickyBucketSaves() {
+        if (this.stickyBucketManager == null) {
+            return CompletableFuture.completedFuture(null);
+        }
+        return this.stickyBucketManager.flush();
+    }
+
+    /**
+     * Prefetch sticky bucket assignments for a user context, so subsequent
+     * evaluations with that same context perform no sticky bucket I/O at all
+     * (the JavaScript SDK's {@code applyStickyBuckets} pattern: fetch once per
+     * request, evaluate any number of flags). The supplied context's
+     * {@code stickyBucketAssignmentDocs} is populated in place and the same
+     * instance is returned.
+     *
+     * <p>The returned future is caller-owned: cancelling it detaches this
+     * caller's stage only and never aborts the underlying store lookup or
+     * affects concurrent callers coalesced onto the same fetch.
+     *
+     * @param userContext the request-scoped user context to prefetch for
+     * @return a future completing with the same context, docs populated
+     */
+    public CompletableFuture<UserContext> prefetchStickyBuckets(UserContext userContext) {
+        UserContext context = userContext == null ? UserContext.builder().build() : userContext;
+        if (this.stickyBucketManager == null || context.getStickyBucketAssignmentDocs() != null) {
+            return CompletableFuture.completedFuture(context);
+        }
+        UserContext merged = toUserContextWithMergedAttributesOnly(context);
+        Map<String, String> attributes = stickyIdentifierAttributesFor(merged.getAttributes());
+        return this.stickyBucketManager.fetchAssignments(attributes)
+                .thenApply(docs -> {
+                    context.setStickyBucketAssignmentDocs(docs);
+                    return context;
+                });
     }
 
     private EvaluationContext getRemoteEvalContext(UserContext userContext) {
@@ -682,7 +818,8 @@ public class GrowthBookClient {
         return context;
     }
 
-    private UserContext toUserContextWithMergedAttributes(UserContext userContext) {
+    /** Attribute merge only — no sticky bucket I/O. */
+    private UserContext toUserContextWithMergedAttributesOnly(UserContext userContext) {
         UserContext currentUserContext = userContext == null ? UserContext.builder().build() : userContext;
         JsonObject merged = new JsonObject();
         if (this.options.getGlobalAttributes() != null) {
@@ -695,24 +832,105 @@ public class GrowthBookClient {
                 merged.add(e.getKey(), e.getValue());
             }
         }
-        UserContext updatedUserContext = currentUserContext.withAttributes(merged);
+        return currentUserContext.withAttributes(merged);
+    }
 
-        // If a sticky bucket service is configured and the caller hasn't preloaded docs,
-        // fetch docs for this user's attributes now (one call per request).
-        if (this.options.getStickyBucketService() != null
+    private UserContext toUserContextWithMergedAttributes(UserContext userContext) {
+        UserContext updatedUserContext = toUserContextWithMergedAttributesOnly(userContext);
+        JsonObject merged = updatedUserContext.getAttributes();
+
+        // If a sticky bucket service is configured and the caller hasn't preloaded
+        // docs (directly or via prefetchStickyBuckets), fetch them now — scoped to
+        // the identifier attributes actually used by experiments, coalesced with
+        // concurrent fetches for the same user, and overlaid with this process's
+        // own writes. The docs map is fresh per evaluation: the evaluator mutates
+        // it in place and it must never be shared between evaluations.
+        if (this.stickyBucketManager != null
                 && updatedUserContext.getStickyBucketAssignmentDocs() == null) {
-            Map<String, String> attrStrings = new HashMap<>();
-            for (Map.Entry<String, JsonElement> e : merged.entrySet()) {
-                if (e.getValue() != null && e.getValue().isJsonPrimitive()) {
-                    attrStrings.put(e.getKey(), e.getValue().getAsString());
-                }
-            }
-            Map<String, StickyAssignmentsDocument> docs =
-                    this.options.getStickyBucketService().getAllAssignments(attrStrings);
-            updatedUserContext.setStickyBucketAssignmentDocs(docs);
+            Map<String, String> attrStrings = stickyIdentifierAttributesFor(merged);
+            updatedUserContext.setStickyBucketAssignmentDocs(fetchStickyDocsBlocking(attrStrings));
         }
 
         return updatedUserContext;
+    }
+
+    /**
+     * The identifier attribute name → value pairs to fetch sticky documents for:
+     * {@code Options.stickyBucketIdentifierAttributes} when configured, else
+     * derived from the current feature snapshot's experiment rules (memoized on
+     * the {@link GlobalContext}, which is rebuilt on every feature refresh).
+     */
+    private Map<String, String> stickyIdentifierAttributesFor(JsonObject mergedAttributes) {
+        Set<String> identifiers = resolveStickyIdentifierAttributes();
+        Map<String, String> attributes = new HashMap<>(Math.max(4, identifiers.size() * 2));
+        for (String name : identifiers) {
+            JsonElement value = mergedAttributes.get(name);
+            if (value != null && value.isJsonPrimitive()) {
+                attributes.put(name, value.getAsString());
+            }
+        }
+        return attributes;
+    }
+
+    private Set<String> resolveStickyIdentifierAttributes() {
+        List<String> configured = this.options.getStickyBucketIdentifierAttributes();
+        if (configured != null && !configured.isEmpty()) {
+            return new HashSet<>(configured);
+        }
+        GlobalContext currentGlobalContext = getLocalGlobalContext();
+        Set<String> derived = currentGlobalContext.getDerivedStickyIdentifierAttributes();
+        if (derived == null) {
+            derived = deriveStickyIdentifierAttributes(currentGlobalContext.getFeatures());
+            // Benign race: derivation is idempotent for one snapshot.
+            currentGlobalContext.setDerivedStickyIdentifierAttributes(derived);
+        }
+        return derived;
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private static Set<String> deriveStickyIdentifierAttributes(
+            @Nullable Map<String, growthbook.sdk.java.model.Feature<?>> features) {
+        Set<String> attributes = new HashSet<>();
+        if (features == null) {
+            return attributes;
+        }
+        for (growthbook.sdk.java.model.Feature<?> feature : features.values()) {
+            if (feature == null || feature.getRules() == null) {
+                continue;
+            }
+            for (growthbook.sdk.java.model.FeatureRule rule
+                    : (List<growthbook.sdk.java.model.FeatureRule>) (List) feature.getRules()) {
+                if (rule.getVariations() != null && !rule.getVariations().isEmpty()) {
+                    attributes.add(rule.getHashAttribute() != null ? rule.getHashAttribute() : "id");
+                    if (rule.getFallbackAttribute() != null) {
+                        attributes.add(rule.getFallbackAttribute());
+                    }
+                }
+            }
+        }
+        return attributes;
+    }
+
+    /**
+     * Sync bridge into the manager's coalesced fetch. Uses {@code get()} rather
+     * than {@code join()}: Java 8's {@code join()} is uninterruptible, and a
+     * hung store must not make request threads immune to interruption. Fetch
+     * failures propagate (JS/Python parity — the SDK never silently evaluates
+     * without sticky data when a service is configured).
+     */
+    private Map<String, StickyAssignmentsDocument> fetchStickyDocsBlocking(Map<String, String> attributes) {
+        try {
+            return this.stickyBucketManager.fetchAssignments(attributes).get();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("Interrupted while fetching sticky bucket assignments", e);
+        } catch (ExecutionException e) {
+            Throwable cause = e.getCause() == null ? e : e.getCause();
+            if (cause instanceof RuntimeException) {
+                throw (RuntimeException) cause;
+            }
+            throw new RuntimeException("Sticky bucket assignment fetch failed", cause);
+        }
     }
 
     private RemoteEvalResponse getRemoteEvalResponse(UserContext userContext) throws FeatureFetchException {

--- a/lib/src/main/java/growthbook/sdk/java/multiusermode/StickyBucketManager.java
+++ b/lib/src/main/java/growthbook/sdk/java/multiusermode/StickyBucketManager.java
@@ -1,0 +1,441 @@
+package growthbook.sdk.java.multiusermode;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import growthbook.sdk.java.model.StickyAssignmentsDocument;
+import growthbook.sdk.java.stickyBucketing.AsyncStickyBucketService;
+import lombok.extern.slf4j.Slf4j;
+
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * Owns all sticky bucket I/O for one {@link GrowthBookClient}: coalesced
+ * non-blocking reads, fire-and-forget writes serialized per document key, and
+ * the authoritative in-process record of every document this process has
+ * written. Package-private on purpose — its invariants (merge direction,
+ * dirty/in-flight save states, overlay rules) are implementation detail, not
+ * public API; consumers reach it through the client's methods only.
+ *
+ * <p>Invariants (ported from the Python SDK 2.4.0 design, growthbook-python
+ * #128/#129):
+ * <ul>
+ *   <li><b>Authoritative overlay:</b> every fetched or cached snapshot has this
+ *       process's own documents merged over it (local wins per experiment key),
+ *       so a slow or stale store read can never roll back an assignment.</li>
+ *   <li><b>Per-key save serialization:</b> at most one save per document key is
+ *       in flight; a write during flight marks the key dirty and the completion
+ *       re-saves the latest merged document, so completion order can never
+ *       regress the stored document.</li>
+ *   <li><b>Coalesced reads:</b> concurrent fetches for the same attribute map
+ *       share one store call; a waiter cancelling its own future cannot affect
+ *       the shared fetch (reserve-then-start: waiters only ever see dependent
+ *       stages of the reserved future).</li>
+ *   <li><b>Bounded memory:</b> the authoritative map is pruned to
+ *       {@value #STICKY_DOCS_MAX} entries (least-recently-saved first); dirty or
+ *       in-flight documents are never evicted, nor is any document whose save
+ *       completed after the oldest currently in-flight fetch started (an
+ *       overlay against that fetch's result still needs it).</li>
+ * </ul>
+ *
+ * <p>Threading: no {@code synchronized} (virtual-thread friendly) and no side
+ * effects inside {@code ConcurrentHashMap} compute lambdas (bin locks are
+ * hidden monitors; a synchronously-completing service would otherwise re-enter
+ * them). Store calls are launched outside all locks.
+ */
+@Slf4j
+final class StickyBucketManager {
+
+    static final int STICKY_DOCS_MAX = 1000;
+
+    private final AsyncStickyBucketService service;
+
+    /** Authoritative record of every document this process has written, keyed attributeName||attributeValue. */
+    private final ConcurrentHashMap<String, StickyAssignmentsDocument> authoritativeDocs = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, SaveState> saveStates = new ConcurrentHashMap<>();
+
+    /** In-flight coalesced fetches. Keys are immutable attribute-map copies —
+     * content-based equality, collision-proof (a joined-string fingerprint is
+     * ambiguous for attribute values containing the separator). */
+    private final ConcurrentHashMap<Map<String, String>, FetchEntry> inflightFetches = new ConcurrentHashMap<>();
+
+    /** Monotonic sequence ordering fetch starts and save completions, for the eviction guard. */
+    private final AtomicLong sequence = new AtomicLong();
+
+    /** Opt-in bounded read cache of successful raw fetches (overlay is applied per read, never cached). */
+    @Nullable
+    private final Cache<Map<String, String>, Map<String, StickyAssignmentsDocument>> readCache;
+
+    private volatile boolean draining = false;
+
+    StickyBucketManager(AsyncStickyBucketService service,
+                        @Nullable Long cacheTtlSeconds,
+                        @Nullable Integer cacheSize) {
+        this.service = service;
+        boolean cacheEnabled = cacheTtlSeconds != null && cacheTtlSeconds > 0
+                && (cacheSize == null || cacheSize > 0);
+        this.readCache = cacheEnabled
+                ? CacheBuilder.newBuilder()
+                .maximumSize(cacheSize == null ? 1000 : cacheSize)
+                .expireAfterWrite(cacheTtlSeconds, TimeUnit.SECONDS)
+                .build()
+                : null;
+    }
+
+    private static final class FetchEntry {
+        final CompletableFuture<Map<String, StickyAssignmentsDocument>> future = new CompletableFuture<>();
+        final long startSequence;
+
+        FetchEntry(long startSequence) {
+            this.startSequence = startSequence;
+        }
+    }
+
+    private static final class SaveState {
+        final ReentrantLock lock = new ReentrantLock();
+        boolean inFlight;
+        boolean dirty;
+        CompletableFuture<Void> quiescent = CompletableFuture.completedFuture(null);
+        long lastSaveCompletedSequence;
+    }
+
+    // ------------------------------------------------------------------ reads
+
+    /**
+     * Fetch the sticky bucket documents for these identifier attributes, with
+     * this process's own writes overlaid. Failures propagate (a rejecting
+     * store completes the future exceptionally — matching the JS and Python
+     * SDKs, which never silently evaluate without sticky data).
+     */
+    CompletableFuture<Map<String, StickyAssignmentsDocument>> fetchAssignments(Map<String, String> attributes) {
+        if (attributes.isEmpty()) {
+            return CompletableFuture.completedFuture(overlay(attributes, Collections.emptyMap()));
+        }
+        Map<String, String> key = Collections.unmodifiableMap(new HashMap<>(attributes));
+
+        if (readCache != null) {
+            Map<String, StickyAssignmentsDocument> cached = readCache.getIfPresent(key);
+            if (cached != null) {
+                // Re-apply local writes: another snapshot for the same identifier
+                // may have assigned since this entry was cached.
+                return CompletableFuture.completedFuture(overlay(key, cached));
+            }
+        }
+
+        while (true) {
+            FetchEntry existing = inflightFetches.get(key);
+            if (existing != null) {
+                // Dependent stage: a waiter's cancel() cannot reach the shared future.
+                return existing.future.thenApply(fetched -> overlay(key, fetched));
+            }
+            FetchEntry created = new FetchEntry(sequence.incrementAndGet());
+            if (inflightFetches.putIfAbsent(key, created) == null) {
+                startFetch(key, created);
+                return created.future.thenApply(fetched -> overlay(key, fetched));
+            }
+        }
+    }
+
+    private void startFetch(Map<String, String> key, FetchEntry entry) {
+        if (draining) {
+            inflightFetches.remove(key, entry);
+            entry.future.completeExceptionally(new IllegalStateException("client is shutting down"));
+            return;
+        }
+        CompletionStage<Map<String, StickyAssignmentsDocument>> stage;
+        try {
+            stage = service.getAllAssignments(key);
+        } catch (RuntimeException e) {
+            // Includes RejectedExecutionException from an offload executor at
+            // saturation: surface it, don't silently evaluate without sticky data.
+            inflightFetches.remove(key, entry);
+            entry.future.completeExceptionally(e);
+            return;
+        }
+        if (stage == null) {
+            inflightFetches.remove(key, entry);
+            entry.future.complete(Collections.emptyMap());
+            return;
+        }
+        stage.whenComplete((fetched, error) -> {
+            // Remove BEFORE completing so a dependent stage that immediately
+            // re-fetches starts a fresh store call instead of re-joining this one.
+            inflightFetches.remove(key, entry);
+            if (error != null) {
+                entry.future.completeExceptionally(error);
+                return;
+            }
+            Map<String, StickyAssignmentsDocument> result =
+                    fetched == null ? Collections.emptyMap() : fetched;
+            if (readCache != null) {
+                readCache.put(key, result); // successful raw fetches only
+            }
+            entry.future.complete(result);
+        });
+    }
+
+    /**
+     * Merge this process's authoritative documents (local wins per experiment
+     * key) over a fetched/cached snapshot, for the document keys this attribute
+     * map can address. Returns a fresh mutable map — the evaluator mutates the
+     * per-eval docs map in place for in-eval read-your-writes, and that map must
+     * never be shared between evaluations.
+     */
+    private Map<String, StickyAssignmentsDocument> overlay(Map<String, String> attributes,
+                                                           Map<String, StickyAssignmentsDocument> fetched) {
+        Map<String, StickyAssignmentsDocument> merged = new HashMap<>(Math.max(8, fetched.size() * 2));
+        merged.putAll(fetched);
+        for (Map.Entry<String, String> attribute : attributes.entrySet()) {
+            String docKey = attribute.getKey() + "||" + attribute.getValue();
+            StickyAssignmentsDocument local = authoritativeDocs.get(docKey);
+            if (local != null) {
+                merged.put(docKey, mergeDocs(merged.get(docKey), local));
+            }
+        }
+        return merged;
+    }
+
+    /** Per-experiment-key merge; {@code wins}'s entries take precedence. Always returns a fresh document. */
+    private static StickyAssignmentsDocument mergeDocs(@Nullable StickyAssignmentsDocument base,
+                                                       StickyAssignmentsDocument wins) {
+        Map<String, String> assignments = new HashMap<>();
+        if (base != null && base.getAssignments() != null) {
+            assignments.putAll(base.getAssignments());
+        }
+        if (wins.getAssignments() != null) {
+            assignments.putAll(wins.getAssignments());
+        }
+        return new StickyAssignmentsDocument(wins.getAttributeName(), wins.getAttributeValue(), assignments);
+    }
+
+    // ----------------------------------------------------------------- writes
+
+    /**
+     * Record a newly assigned document in the authoritative map and persist it,
+     * fire-and-forget. The document actually written to the store is re-read
+     * from the authoritative map at save time, so a trailing save always writes
+     * the latest merged state. Store failures are logged, not retried (JS/Python
+     * parity); an executor rejection leaves the key dirty so the next write or
+     * {@link #flush()} re-attempts it — nothing is lost either way, the
+     * authoritative map still holds the document.
+     */
+    CompletableFuture<Void> recordAndSave(StickyAssignmentsDocument doc) {
+        String key = doc.getAttributeName() + "||" + doc.getAttributeValue();
+        authoritativeDocs.merge(key, doc, (existing, incoming) -> mergeDocs(existing, incoming));
+
+        SaveState state = saveStates.computeIfAbsent(key, k -> new SaveState()); // pure creation only
+        boolean start = false;
+        CompletableFuture<Void> waiter;
+        state.lock.lock();
+        try {
+            if (state.inFlight) {
+                state.dirty = true;
+            } else {
+                state.inFlight = true;
+                state.dirty = false; // the save snapshots the latest merged doc anyway
+                state.quiescent = new CompletableFuture<>();
+                start = true;
+            }
+            waiter = state.quiescent;
+        } finally {
+            state.lock.unlock();
+        }
+        if (start) {
+            driveSave(key, state); // outside the map AND the state lock
+        }
+        return waiter.thenApply(v -> v); // dependent copy: caller cancel() can't detach other writers
+    }
+
+    private void driveSave(String key, SaveState state) {
+        StickyAssignmentsDocument snapshot = authoritativeDocs.get(key);
+        CompletableFuture<Void> saveFuture;
+        boolean rejected = false;
+        try {
+            CompletionStage<Void> stage = snapshot == null ? null : service.saveAssignments(snapshot);
+            saveFuture = stage == null
+                    ? CompletableFuture.completedFuture(null)
+                    : stage.toCompletableFuture();
+        } catch (RuntimeException e) {
+            // Typically RejectedExecutionException from an offload executor at
+            // saturation or during drain: keep the key dirty for a later re-kick.
+            log.warn("Sticky bucket save could not be scheduled for {}; will retry on next write or flush", key, e);
+            rejected = true;
+            saveFuture = CompletableFuture.completedFuture(null);
+        }
+
+        final boolean keepDirty = rejected;
+        saveFuture.whenComplete((ignored, error) -> {
+            if (error != null) {
+                log.warn("Sticky bucket save failed for {}", key, error);
+            }
+            boolean again;
+            CompletableFuture<Void> quiescent = null;
+            state.lock.lock();
+            try {
+                if (keepDirty) {
+                    state.dirty = true;
+                }
+                again = state.dirty && !keepDirty;
+                if (again) {
+                    state.dirty = false;
+                } else {
+                    state.inFlight = false;
+                    state.lastSaveCompletedSequence = sequence.incrementAndGet();
+                    quiescent = state.quiescent;
+                }
+            } finally {
+                state.lock.unlock();
+            }
+            if (again) {
+                driveSave(key, state);
+            } else {
+                quiescent.complete(null);
+                pruneAuthoritativeDocs();
+            }
+        });
+    }
+
+    // ------------------------------------------------------------- lifecycle
+
+    /**
+     * Completes when every pending or dirty save has been attempted. Loops
+     * because a trailing save can be scheduled while a round is awaited;
+     * bounded so a persistently rejecting executor cannot spin it forever.
+     */
+    CompletableFuture<Void> flush() {
+        return flush(20);
+    }
+
+    private CompletableFuture<Void> flush(int roundsLeft) {
+        if (roundsLeft <= 0) {
+            log.warn("Sticky bucket flush gave up after repeated rounds; some saves may remain unflushed");
+            return CompletableFuture.completedFuture(null);
+        }
+        List<CompletableFuture<Void>> pending = new ArrayList<>();
+        for (Map.Entry<String, SaveState> entry : saveStates.entrySet()) {
+            SaveState state = entry.getValue();
+            boolean kick = false;
+            CompletableFuture<Void> waiter = null;
+            state.lock.lock();
+            try {
+                if (state.inFlight) {
+                    waiter = state.quiescent;
+                } else if (state.dirty) {
+                    state.dirty = false;
+                    state.inFlight = true;
+                    state.quiescent = new CompletableFuture<>();
+                    waiter = state.quiescent;
+                    kick = true;
+                }
+            } finally {
+                state.lock.unlock();
+            }
+            if (kick) {
+                driveSave(entry.getKey(), state);
+            }
+            if (waiter != null) {
+                pending.add(waiter);
+            }
+        }
+        if (pending.isEmpty()) {
+            return CompletableFuture.completedFuture(null);
+        }
+        return CompletableFuture.allOf(pending.toArray(new CompletableFuture[0]))
+                .thenCompose(ignored -> flush(roundsLeft - 1));
+    }
+
+    /** Stop accepting new fetches; writes still merge into the authoritative map. */
+    void startDraining() {
+        this.draining = true;
+    }
+
+    /** Blocking, bounded flush for {@code shutdown()}. Never throws. */
+    void close(long timeoutMillis) {
+        try {
+            flush().get(timeoutMillis, TimeUnit.MILLISECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            log.warn("Interrupted while flushing sticky bucket saves during shutdown");
+        } catch (TimeoutException e) {
+            log.warn("Timed out after {}ms flushing sticky bucket saves during shutdown", timeoutMillis);
+        } catch (ExecutionException e) {
+            log.warn("Sticky bucket save flush failed during shutdown", e.getCause());
+        }
+    }
+
+    // -------------------------------------------------------------- eviction
+
+    private void pruneAuthoritativeDocs() {
+        if (authoritativeDocs.size() <= STICKY_DOCS_MAX) {
+            return;
+        }
+        long oldestInflightFetchStart = Long.MAX_VALUE;
+        for (FetchEntry entry : inflightFetches.values()) {
+            oldestInflightFetchStart = Math.min(oldestInflightFetchStart, entry.startSequence);
+        }
+
+        List<Map.Entry<String, SaveState>> candidates = new ArrayList<>();
+        for (Map.Entry<String, SaveState> entry : saveStates.entrySet()) {
+            SaveState state = entry.getValue();
+            state.lock.lock();
+            try {
+                if (!state.inFlight && !state.dirty
+                        && state.lastSaveCompletedSequence < oldestInflightFetchStart) {
+                    candidates.add(entry);
+                }
+            } finally {
+                state.lock.unlock();
+            }
+        }
+        candidates.sort(Comparator.comparingLong(e -> e.getValue().lastSaveCompletedSequence));
+
+        int excess = authoritativeDocs.size() - STICKY_DOCS_MAX;
+        for (Map.Entry<String, SaveState> entry : candidates) {
+            if (excess <= 0) {
+                break;
+            }
+            SaveState state = entry.getValue();
+            state.lock.lock();
+            try {
+                if (state.inFlight || state.dirty) {
+                    continue; // became active since the scan — never evict unsaved local truth
+                }
+                if (authoritativeDocs.remove(entry.getKey()) != null) {
+                    excess--;
+                }
+                saveStates.remove(entry.getKey(), state);
+            } finally {
+                state.lock.unlock();
+            }
+        }
+    }
+
+    // ------------------------------------------------------------------ test seams
+
+    int authoritativeDocCount() {
+        return authoritativeDocs.size();
+    }
+
+    @Nullable
+    StickyAssignmentsDocument authoritativeDoc(String key) {
+        return authoritativeDocs.get(key);
+    }
+
+    Set<Map<String, String>> inflightFetchKeys() {
+        return inflightFetches.keySet();
+    }
+}

--- a/lib/src/main/java/growthbook/sdk/java/multiusermode/configurations/EvaluationContext.java
+++ b/lib/src/main/java/growthbook/sdk/java/multiusermode/configurations/EvaluationContext.java
@@ -2,7 +2,10 @@ package growthbook.sdk.java.multiusermode.configurations;
 
 import growthbook.sdk.java.model.FeatureResult;
 import growthbook.sdk.java.plugin.PluginRegistry;
+import growthbook.sdk.java.stickyBucketing.StickyBucketDocWriter;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.Nullable;
@@ -24,9 +27,24 @@ public class EvaluationContext {
      * Plugins registered with the owning GrowthBook instance. Carried per
      * evaluation context (not on the shared {@link Options}) so that separate
      * SDK instances built from the same {@code Options} stay isolated.
+     * Excluded from equals/hashCode/toString: identity-equality object, and its
+     * toString is noise in debug logs.
      */
     @Nullable
+    @EqualsAndHashCode.Exclude
+    @ToString.Exclude
     private PluginRegistry pluginRegistry;
+
+    /**
+     * Persistence seam for newly assigned sticky bucket documents, set by the
+     * owning multi-user client. When null the evaluator calls the configured
+     * synchronous service directly (legacy path, unchanged). Excluded from
+     * equals/hashCode/toString: lambdas have identity equality.
+     */
+    @Nullable
+    @EqualsAndHashCode.Exclude
+    @ToString.Exclude
+    private StickyBucketDocWriter stickyBucketDocWriter;
 
     public EvaluationContext(GlobalContext global, UserContext user, StackContext stack, Options options) {
         this.global = global;

--- a/lib/src/main/java/growthbook/sdk/java/multiusermode/configurations/GlobalContext.java
+++ b/lib/src/main/java/growthbook/sdk/java/multiusermode/configurations/GlobalContext.java
@@ -6,12 +6,16 @@ import growthbook.sdk.java.model.Feature;
 import growthbook.sdk.java.util.ForcedVariationsUtils;
 import lombok.Builder;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 @Data
 @Slf4j
@@ -70,4 +74,18 @@ public class GlobalContext {
     @Getter
     @Nullable
     private Map<String, Object> forcedFeatureValues;
+
+    /**
+     * Lazily derived sticky-bucket identifier attributes for this feature
+     * snapshot (hashAttribute/fallbackAttribute across experiment rules).
+     * Memoized here because a new GlobalContext is built on every feature
+     * refresh, so invalidation is free. A cache, not state — excluded from
+     * equals/hashCode/toString.
+     */
+    @Getter
+    @Setter
+    @Nullable
+    @EqualsAndHashCode.Exclude
+    @ToString.Exclude
+    private volatile Set<String> derivedStickyIdentifierAttributes;
 }

--- a/lib/src/main/java/growthbook/sdk/java/multiusermode/configurations/Options.java
+++ b/lib/src/main/java/growthbook/sdk/java/multiusermode/configurations/Options.java
@@ -15,6 +15,7 @@ import growthbook.sdk.java.repository.FeatureRefreshStrategy;
 import growthbook.sdk.java.retry.FeatureFetchRetryPolicy;
 import growthbook.sdk.java.sandbox.GbCacheManager;
 import growthbook.sdk.java.sandbox.CacheMode;
+import growthbook.sdk.java.stickyBucketing.AsyncStickyBucketService;
 import growthbook.sdk.java.stickyBucketing.InMemoryStickyBucketServiceImpl;
 import growthbook.sdk.java.stickyBucketing.StickyBucketService;
 import growthbook.sdk.java.util.ForcedVariationsUtils;
@@ -27,6 +28,7 @@ import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Executor;
 
 @Data
 @Slf4j
@@ -86,6 +88,10 @@ public class Options {
                 null,
                 null,
                 null,
+                null,
+                null,
+                null,
+                null,
                 null
         );
     }
@@ -118,7 +124,11 @@ public class Options {
                    @Nullable Integer remoteEvalCacheTtlSeconds,
                    @Nullable Duration backgroundFetchInterval,
                    @Nullable FeatureFetchRetryPolicy retryPolicy,
-                   @Nullable List<GrowthBookPlugin> plugins
+                   @Nullable List<GrowthBookPlugin> plugins,
+                   @Nullable AsyncStickyBucketService asyncStickyBucketService,
+                   @Nullable Executor asyncExecutor,
+                   @Nullable Long stickyBucketCacheTtlSeconds,
+                   @Nullable Integer stickyBucketCacheSize
     ) {
         this.enabled = enabled == null || enabled;
         this.isQaMode = isQaMode != null && isQaMode;
@@ -148,6 +158,10 @@ public class Options {
         this.backgroundFetchInterval = backgroundFetchInterval;
         this.retryPolicy = retryPolicy;
         this.plugins = plugins;
+        this.asyncStickyBucketService = asyncStickyBucketService;
+        this.asyncExecutor = asyncExecutor;
+        this.stickyBucketCacheTtlSeconds = stickyBucketCacheTtlSeconds;
+        this.stickyBucketCacheSize = stickyBucketCacheSize == null ? 1000 : stickyBucketCacheSize;
     }
 
     /**
@@ -316,6 +330,42 @@ public class Options {
     @Nullable
     private FeatureFetchRetryPolicy retryPolicy;
 
+    /**
+     * Non-blocking sticky bucket service for the multi-user client. Mutually
+     * exclusive with {@link #stickyBucketService} — configure exactly one.
+     * See {@link AsyncStickyBucketService} for the contract.
+     */
+    @Nullable
+    private AsyncStickyBucketService asyncStickyBucketService;
+
+    /**
+     * Executor for the client's asynchronous work: offloading blocking
+     * {@link StickyBucketService} calls and composing async evaluations. When
+     * null, the client creates its own bounded daemon pool and shuts it down in
+     * {@code shutdown()}; a caller-supplied executor is never shut down by the
+     * SDK. On JDK 21+, pass {@code Executors.newVirtualThreadPerTaskExecutor()}
+     * so blocking offloads scale with the store instead of a fixed pool.
+     */
+    @Nullable
+    private Executor asyncExecutor;
+
+    /**
+     * Opt-in TTL, in seconds, for caching sticky bucket reads per user
+     * attributes. Null or non-positive (the default) disables caching:
+     * assignments are fetched per evaluation, so assignment changes made by
+     * other processes are picked up promptly. Enabling trades that freshness
+     * for fewer store lookups on hot users.
+     */
+    @Nullable
+    private Long stickyBucketCacheTtlSeconds;
+
+    /**
+     * Maximum entries in the opt-in sticky bucket read cache (default 1000).
+     * Non-positive disables caching. Only meaningful when
+     * {@link #stickyBucketCacheTtlSeconds} is set.
+     */
+    private Integer stickyBucketCacheSize;
+
     @Nullable
     public String getCacheDirectory() {
         return cacheDirectory;
@@ -330,6 +380,15 @@ public class Options {
         // Thread-safe backing map: this Options instance configures the multi-user
         // GrowthBookClient, which evaluates (and therefore saves assignments) concurrently.
         this.setStickyBucketService(new InMemoryStickyBucketServiceImpl());
+    }
+
+    /**
+     * Whether either flavor of sticky bucket service is configured.
+     *
+     * @return true when a sync or async sticky bucket service is set
+     */
+    public boolean isStickyBucketingConfigured() {
+        return this.stickyBucketService != null || this.asyncStickyBucketService != null;
     }
 
     public void setGlobalAttributes(@Nullable String attributesJson) {

--- a/lib/src/main/java/growthbook/sdk/java/multiusermode/configurations/OptionsValidator.java
+++ b/lib/src/main/java/growthbook/sdk/java/multiusermode/configurations/OptionsValidator.java
@@ -74,8 +74,15 @@ public final class OptionsValidator {
         checkBackgroundFetchInterval(options.getBackgroundFetchInterval(), violations);
         checkRemoteEvalCacheTtl(options.getRemoteEvalCacheTtlSeconds(), violations);
         checkCacheConfiguration(options, violations);
+        checkStickyBucketConfiguration(options, violations);
         violations.addAll(RemoteEvalOptionsValidator.remoteEvalViolations(options));
         return Collections.unmodifiableList(violations);
+    }
+
+    private static void checkStickyBucketConfiguration(Options options, List<String> violations) {
+        if (options.getStickyBucketService() != null && options.getAsyncStickyBucketService() != null) {
+            violations.add("configure either stickyBucketService or asyncStickyBucketService, not both");
+        }
     }
 
     private static void checkApiHost(@Nullable String apiHost, List<String> violations) {

--- a/lib/src/main/java/growthbook/sdk/java/remoteeval/RemoteEvalOptionsValidator.java
+++ b/lib/src/main/java/growthbook/sdk/java/remoteeval/RemoteEvalOptionsValidator.java
@@ -154,7 +154,7 @@ public final class RemoteEvalOptionsValidator {
                     options.getApiHost(),
                     options.getClientKey(),
                     options.getDecryptionKey(),
-                    options.getStickyBucketService() != null,
+                    options.isStickyBucketingConfigured(),
                     options.getRefreshStrategy()
             );
         }

--- a/lib/src/main/java/growthbook/sdk/java/stickyBucketing/AsyncStickyBucketService.java
+++ b/lib/src/main/java/growthbook/sdk/java/stickyBucketing/AsyncStickyBucketService.java
@@ -1,0 +1,102 @@
+package growthbook.sdk.java.stickyBucketing;
+
+import growthbook.sdk.java.model.StickyAssignmentsDocument;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+/**
+ * Non-blocking sticky bucket persistence for the multi-user
+ * {@link growthbook.sdk.java.multiusermode.GrowthBookClient}: reads and writes
+ * never run on the evaluating thread's time. This is the async twin of
+ * {@link StickyBucketService}, mirroring the JavaScript SDK's Promise-based
+ * service interface and the Python SDK's {@code AbstractAsyncStickyBucketService}.
+ *
+ * <p>Implementations back this with a network store (Redis, DynamoDB, JDBC, ...)
+ * using their client's native async API. Methods return {@link CompletionStage}
+ * so natively-async clients (e.g. Lettuce's {@code RedisFuture}, Reactor's
+ * {@code Mono#toFuture()}) plug in without adaptation.
+ *
+ * <p><b>Contract:</b>
+ * <ul>
+ *   <li>Store keys use {@code attributeName + "||" + attributeValue}
+ *       ({@link #getKey}), byte-compatible with documents written by the other
+ *       GrowthBook SDKs against the same store.</li>
+ *   <li>{@link #getAssignments} completes with {@code null} when no document
+ *       exists for the key.</li>
+ *   <li>Completion may happen on the store client's own threads (e.g. a Netty
+ *       event loop) — the SDK hops off that thread before evaluating, and
+ *       implementations should not block inside completion callbacks.</li>
+ *   <li>Implementations must be thread-safe; the SDK calls them concurrently.</li>
+ * </ul>
+ *
+ * <p>Existing synchronous {@link StickyBucketService} implementations do not
+ * need porting — pass them as {@code Options.stickyBucketService} and the
+ * client offloads their blocking calls to its executor (see
+ * {@link SyncOffloadStickyBucketAdapter}).
+ */
+public interface AsyncStickyBucketService {
+
+    /**
+     * Look up one sticky bucket document.
+     *
+     * @param attributeName  the identifier attribute name (e.g. {@code id})
+     * @param attributeValue the identifier attribute value
+     * @return a stage completing with the document, or {@code null} if absent
+     */
+    CompletionStage<StickyAssignmentsDocument> getAssignments(String attributeName, String attributeValue);
+
+    /**
+     * Persist one sticky bucket document (upsert by
+     * {@code attributeName + "||" + attributeValue}).
+     *
+     * @param doc the document to persist
+     * @return a stage completing when the write is durable
+     */
+    CompletionStage<Void> saveAssignments(StickyAssignmentsDocument doc);
+
+    /**
+     * The store key for a document. Shared convention across all GrowthBook SDKs.
+     *
+     * @param attributeName  the identifier attribute name
+     * @param attributeValue the identifier attribute value
+     * @return {@code attributeName + "||" + attributeValue}
+     */
+    default String getKey(String attributeName, String attributeValue) {
+        return attributeName + "||" + attributeValue;
+    }
+
+    /**
+     * Look up the documents for all of a user's identifier attributes.
+     *
+     * <p>The default implementation fans out one {@link #getAssignments} call per
+     * attribute. Override it to batch all lookups into a single round trip
+     * (e.g. one Redis {@code MGET}) — this method is called once per sticky
+     * bucket fetch, so batching here is the highest-leverage optimization.
+     *
+     * @param attributes identifier attribute name → value
+     * @return a stage completing with found documents keyed by
+     *         {@link #getKey}; attributes with no document are omitted
+     */
+    default CompletionStage<Map<String, StickyAssignmentsDocument>> getAllAssignments(Map<String, String> attributes) {
+        List<CompletableFuture<StickyAssignmentsDocument>> lookups = new ArrayList<>(attributes.size());
+        for (Map.Entry<String, String> attribute : attributes.entrySet()) {
+            lookups.add(getAssignments(attribute.getKey(), attribute.getValue()).toCompletableFuture());
+        }
+        return CompletableFuture.allOf(lookups.toArray(new CompletableFuture[0]))
+                .thenApply(ignored -> {
+                    Map<String, StickyAssignmentsDocument> docs = new HashMap<>();
+                    for (CompletableFuture<StickyAssignmentsDocument> lookup : lookups) {
+                        StickyAssignmentsDocument doc = lookup.join();
+                        if (doc != null) {
+                            docs.put(getKey(doc.getAttributeName(), doc.getAttributeValue()), doc);
+                        }
+                    }
+                    return docs;
+                });
+    }
+}

--- a/lib/src/main/java/growthbook/sdk/java/stickyBucketing/StickyBucketDocWriter.java
+++ b/lib/src/main/java/growthbook/sdk/java/stickyBucketing/StickyBucketDocWriter.java
@@ -1,0 +1,24 @@
+package growthbook.sdk.java.stickyBucketing;
+
+import growthbook.sdk.java.model.StickyAssignmentsDocument;
+
+/**
+ * Seam through which evaluation hands newly assigned sticky bucket documents to
+ * the owning client for persistence. Whether the write blocks, is offloaded, or
+ * is fire-and-forget is the writer's choice — the evaluator stays synchronous
+ * and ignorant of I/O (the same seam as the Python SDK's
+ * {@code EvaluationContext.save_sticky_bucket_doc}).
+ *
+ * <p>When no writer is set on the evaluation context, the evaluator falls back
+ * to calling the configured {@link StickyBucketService#saveAssignments} directly
+ * — the legacy single-user path, unchanged.
+ */
+@FunctionalInterface
+public interface StickyBucketDocWriter {
+    /**
+     * Persist a newly assigned document. Must not throw into evaluation.
+     *
+     * @param doc the document to persist
+     */
+    void write(StickyAssignmentsDocument doc);
+}

--- a/lib/src/main/java/growthbook/sdk/java/stickyBucketing/SyncOffloadStickyBucketAdapter.java
+++ b/lib/src/main/java/growthbook/sdk/java/stickyBucketing/SyncOffloadStickyBucketAdapter.java
@@ -1,0 +1,51 @@
+package growthbook.sdk.java.stickyBucketing;
+
+import growthbook.sdk.java.model.StickyAssignmentsDocument;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Executor;
+
+/**
+ * Presents a blocking {@link StickyBucketService} as an
+ * {@link AsyncStickyBucketService} by running each call on the supplied
+ * executor. This is how the multi-user client keeps legacy synchronous
+ * services working without blocking the evaluating thread; it is public so
+ * applications composing their own pipelines can reuse it.
+ *
+ * <p>{@link #getAllAssignments} is offloaded as ONE task wrapping the
+ * delegate's own {@code getAllAssignments}, preserving batched implementations
+ * (e.g. a single Redis {@code MGET}) instead of exploding them into N calls.
+ */
+public final class SyncOffloadStickyBucketAdapter implements AsyncStickyBucketService {
+
+    private final StickyBucketService delegate;
+    private final Executor executor;
+
+    /**
+     * @param delegate the blocking service to adapt
+     * @param executor where the delegate's blocking calls run; sized for
+     *                 blocking I/O (never a CPU-sized pool)
+     */
+    public SyncOffloadStickyBucketAdapter(StickyBucketService delegate, Executor executor) {
+        this.delegate = Objects.requireNonNull(delegate, "delegate");
+        this.executor = Objects.requireNonNull(executor, "executor");
+    }
+
+    @Override
+    public CompletionStage<StickyAssignmentsDocument> getAssignments(String attributeName, String attributeValue) {
+        return CompletableFuture.supplyAsync(() -> delegate.getAssignments(attributeName, attributeValue), executor);
+    }
+
+    @Override
+    public CompletionStage<Void> saveAssignments(StickyAssignmentsDocument doc) {
+        return CompletableFuture.runAsync(() -> delegate.saveAssignments(doc), executor);
+    }
+
+    @Override
+    public CompletionStage<Map<String, StickyAssignmentsDocument>> getAllAssignments(Map<String, String> attributes) {
+        return CompletableFuture.supplyAsync(() -> delegate.getAllAssignments(attributes), executor);
+    }
+}

--- a/lib/src/test/java/growthbook/sdk/java/multiusermode/GrowthBookClientStickyBucketTest.java
+++ b/lib/src/test/java/growthbook/sdk/java/multiusermode/GrowthBookClientStickyBucketTest.java
@@ -1,0 +1,351 @@
+package growthbook.sdk.java.multiusermode;
+
+import growthbook.sdk.java.model.Experiment;
+import growthbook.sdk.java.model.ExperimentResult;
+import growthbook.sdk.java.model.StickyAssignmentsDocument;
+import growthbook.sdk.java.multiusermode.configurations.Options;
+import growthbook.sdk.java.multiusermode.configurations.OptionsValidator;
+import growthbook.sdk.java.multiusermode.configurations.UserContext;
+import growthbook.sdk.java.stickyBucketing.AsyncStickyBucketService;
+import growthbook.sdk.java.stickyBucketing.InMemoryStickyBucketServiceImpl;
+import growthbook.sdk.java.stickyBucketing.StickyBucketService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Client-level behavior of async sticky bucketing: identifier-scoped reads,
+ * sync-service offload off the caller thread with batched lookups,
+ * fire-and-forget writes with flush, prefetch, failure propagation, and
+ * executor ownership. Inline experiments are used so no feature fetch or
+ * network is involved; all gating is latch-based, no sleeps.
+ */
+class GrowthBookClientStickyBucketTest {
+
+    private static final long GATE_TIMEOUT_SECONDS = 10;
+
+    /** Async in-memory service with gates and counters. */
+    private static final class GatedAsyncStickyService implements AsyncStickyBucketService {
+        final Map<String, StickyAssignmentsDocument> store = new ConcurrentHashMap<>();
+        final List<Map<String, String>> fetchCalls = new CopyOnWriteArrayList<>();
+        final AtomicInteger saveCalls = new AtomicInteger();
+        volatile CountDownLatch saveGate = null; // when set, saves complete only after the gate opens
+        volatile boolean failFetches = false;
+
+        @Override
+        public CompletionStage<StickyAssignmentsDocument> getAssignments(String attributeName, String attributeValue) {
+            return CompletableFuture.completedFuture(store.get(getKey(attributeName, attributeValue)));
+        }
+
+        @Override
+        public CompletionStage<Void> saveAssignments(StickyAssignmentsDocument doc) {
+            saveCalls.incrementAndGet();
+            CountDownLatch gate = saveGate;
+            if (gate == null) {
+                store.put(getKey(doc.getAttributeName(), doc.getAttributeValue()), doc);
+                return CompletableFuture.completedFuture(null);
+            }
+            CompletableFuture<Void> pending = new CompletableFuture<>();
+            Thread completer = new Thread(() -> {
+                try {
+                    if (gate.await(GATE_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                        store.put(getKey(doc.getAttributeName(), doc.getAttributeValue()), doc);
+                        pending.complete(null);
+                    } else {
+                        pending.completeExceptionally(new IllegalStateException("save gate never opened"));
+                    }
+                } catch (InterruptedException e) {
+                    pending.completeExceptionally(e);
+                }
+            }, "gated-save-completer");
+            completer.setDaemon(true);
+            completer.start();
+            return pending;
+        }
+
+        @Override
+        public CompletionStage<Map<String, StickyAssignmentsDocument>> getAllAssignments(Map<String, String> attributes) {
+            fetchCalls.add(attributes);
+            if (failFetches) {
+                CompletableFuture<Map<String, StickyAssignmentsDocument>> failed = new CompletableFuture<>();
+                failed.completeExceptionally(new IllegalStateException("store unavailable"));
+                return failed;
+            }
+            Map<String, StickyAssignmentsDocument> result = new ConcurrentHashMap<>();
+            for (Map.Entry<String, String> attribute : attributes.entrySet()) {
+                StickyAssignmentsDocument doc = store.get(getKey(attribute.getKey(), attribute.getValue()));
+                if (doc != null) {
+                    result.put(getKey(doc.getAttributeName(), doc.getAttributeValue()), doc);
+                }
+            }
+            return CompletableFuture.completedFuture(result);
+        }
+    }
+
+    /** Sync service instrumented to record calling threads and batch counts. */
+    private static final class RecordingSyncStickyService implements StickyBucketService {
+        final InMemoryStickyBucketServiceImpl delegate = new InMemoryStickyBucketServiceImpl();
+        final List<String> fetchThreads = new CopyOnWriteArrayList<>();
+        final AtomicInteger batchedFetchCalls = new AtomicInteger();
+
+        @Override
+        public StickyAssignmentsDocument getAssignments(String attributeName, String attributeValue) {
+            return delegate.getAssignments(attributeName, attributeValue);
+        }
+
+        @Override
+        public void saveAssignments(StickyAssignmentsDocument doc) {
+            delegate.saveAssignments(doc);
+        }
+
+        @Override
+        public Map<String, StickyAssignmentsDocument> getAllAssignments(Map<String, String> attributes) {
+            batchedFetchCalls.incrementAndGet();
+            fetchThreads.add(Thread.currentThread().getName());
+            return delegate.getAllAssignments(attributes);
+        }
+    }
+
+    private static Experiment<String> experiment(String key) {
+        // meta keys are required for sticky lookups to map a persisted variation
+        // key back to an index — same behavior as the JS SDK (GrowthBook-served
+        // experiments always carry meta).
+        return Experiment.<String>builder()
+                .key(key)
+                .variations(new ArrayList<>(Arrays.asList("control", "treatment")))
+                .meta(new ArrayList<>(Arrays.asList(
+                        growthbook.sdk.java.model.VariationMeta.builder().key("control").build(),
+                        growthbook.sdk.java.model.VariationMeta.builder().key("treatment").build())))
+                .build();
+    }
+
+    private static UserContext user(String id, String extraAttr) {
+        return UserContext.builder()
+                .attributesJson("{\"id\":\"" + id + "\",\"" + extraAttr + "\":\"x\",\"premium\":true}")
+                .build();
+    }
+
+    private static Options stickyOptions(GatedAsyncStickyService service) {
+        return Options.builder()
+                .asyncStickyBucketService(service)
+                .stickyBucketIdentifierAttributes(Collections.singletonList("id"))
+                .build();
+    }
+
+    // ---------------------------------------------------------------- reads
+
+    @Test
+    @Timeout(30)
+    void fetchesAreScopedToIdentifierAttributes() {
+        GatedAsyncStickyService service = new GatedAsyncStickyService();
+        GrowthBookClient client = new GrowthBookClient(stickyOptions(service));
+        try {
+            client.run(experiment("exp-scope"), user("u1", "country"));
+
+            assertFalse(service.fetchCalls.isEmpty());
+            for (Map<String, String> call : service.fetchCalls) {
+                assertEquals(Collections.singleton("id"), call.keySet(),
+                        "only identifier attributes may be sent to the store");
+            }
+        } finally {
+            client.shutdown();
+        }
+    }
+
+    @Test
+    @Timeout(30)
+    void syncServiceIsOffloadedAndBatched() {
+        RecordingSyncStickyService service = new RecordingSyncStickyService();
+        GrowthBookClient client = new GrowthBookClient(Options.builder()
+                .stickyBucketService(service)
+                .stickyBucketIdentifierAttributes(Collections.singletonList("id"))
+                .build());
+        try {
+            client.run(experiment("exp-offload"), user("u1", "country"));
+
+            assertEquals(1, service.batchedFetchCalls.get(),
+                    "sync service must be offloaded as ONE batched getAllAssignments call");
+            for (String threadName : service.fetchThreads) {
+                assertTrue(threadName.startsWith("growthbook-async-"),
+                        "blocking sync service must run on the SDK pool, ran on: " + threadName);
+            }
+        } finally {
+            client.shutdown();
+        }
+    }
+
+    @Test
+    @Timeout(30)
+    void callerPreloadedDocsSkipTheFetch() {
+        GatedAsyncStickyService service = new GatedAsyncStickyService();
+        GrowthBookClient client = new GrowthBookClient(stickyOptions(service));
+        try {
+            UserContext preloaded = UserContext.builder()
+                    .attributesJson("{\"id\":\"u1\"}")
+                    .stickyBucketAssignmentDocs(new ConcurrentHashMap<>())
+                    .build();
+            client.run(experiment("exp-preload"), preloaded);
+
+            assertEquals(0, service.fetchCalls.size(), "preloaded docs must skip the store fetch");
+        } finally {
+            client.shutdown();
+        }
+    }
+
+    @Test
+    @Timeout(30)
+    void prefetchOnceThenManyEvaluationsFetchOnlyOnce() throws Exception {
+        GatedAsyncStickyService service = new GatedAsyncStickyService();
+        GrowthBookClient client = new GrowthBookClient(stickyOptions(service));
+        try {
+            UserContext requestContext = user("u1", "country");
+            UserContext prefetched = client.prefetchStickyBuckets(requestContext).get(5, TimeUnit.SECONDS);
+            assertNotNull(prefetched.getStickyBucketAssignmentDocs());
+
+            for (int i = 0; i < 10; i++) {
+                client.run(experiment("exp-" + i), prefetched);
+            }
+
+            assertEquals(1, service.fetchCalls.size(),
+                    "prefetch-per-request means N evaluations do zero further sticky I/O");
+        } finally {
+            client.shutdown();
+        }
+    }
+
+    @Test
+    @Timeout(30)
+    void fetchFailurePropagatesOnTheSyncPath() {
+        GatedAsyncStickyService service = new GatedAsyncStickyService();
+        service.failFetches = true;
+        GrowthBookClient client = new GrowthBookClient(stickyOptions(service));
+        try {
+            assertThrows(RuntimeException.class,
+                    () -> client.run(experiment("exp-fail"), user("u1", "country")),
+                    "a failing sticky store must not silently produce non-sticky assignments");
+        } finally {
+            client.shutdown();
+        }
+    }
+
+    // ---------------------------------------------------------------- writes
+
+    @Test
+    @Timeout(30)
+    void writesAreFireAndForgetAndFlushWaitsForThem() throws Exception {
+        GatedAsyncStickyService service = new GatedAsyncStickyService();
+        CountDownLatch saveGate = new CountDownLatch(1);
+        service.saveGate = saveGate;
+        GrowthBookClient client = new GrowthBookClient(stickyOptions(service));
+        try {
+            // Evaluation returns while the save is still gated — never blocks on persistence.
+            ExperimentResult<String> result = client.run(experiment("exp-write"), user("u1", "country"));
+            assertNotNull(result);
+            assertTrue(service.saveCalls.get() >= 1, "assignment must schedule a save");
+            assertTrue(service.store.isEmpty(), "evaluation must not wait for persistence");
+
+            CompletableFuture<Void> flush = client.flushStickyBucketSaves();
+            assertFalse(flush.isDone(), "flush must wait for the gated save");
+
+            saveGate.countDown();
+            flush.get(10, TimeUnit.SECONDS);
+            assertNotNull(service.store.get("id||u1"), "flushed save must be persisted");
+        } finally {
+            client.shutdown();
+        }
+    }
+
+    @Test
+    @Timeout(30)
+    void newAssignmentIsVisibleToLaterEvaluationsBeforePersistenceCompletes() {
+        GatedAsyncStickyService service = new GatedAsyncStickyService();
+        CountDownLatch saveGate = new CountDownLatch(1);
+        service.saveGate = saveGate;
+        GrowthBookClient client = new GrowthBookClient(stickyOptions(service));
+        try {
+            UserContext firstEval = user("u1", "country");
+            ExperimentResult<String> first = client.run(experiment("exp-ryw"), firstEval);
+
+            // Same user, fresh context, save still in flight: the authoritative
+            // overlay must serve the assignment (read-your-writes in-process).
+            ExperimentResult<String> second = client.run(experiment("exp-ryw"), user("u1", "country"));
+            assertEquals(first.getVariationId(), second.getVariationId());
+            assertTrue(Boolean.TRUE.equals(second.getStickyBucketUsed()),
+                    "second evaluation must be served by the sticky assignment, not re-hashed");
+        } finally {
+            saveGate.countDown();
+            client.shutdown();
+        }
+    }
+
+    // -------------------------------------------------------------- lifecycle
+
+    @Test
+    @Timeout(30)
+    void shutdownFlushesPendingSaves() {
+        GatedAsyncStickyService service = new GatedAsyncStickyService();
+        GrowthBookClient client = new GrowthBookClient(stickyOptions(service));
+        client.run(experiment("exp-shutdown"), user("u1", "country"));
+        client.shutdown();
+        assertNotNull(service.store.get("id||u1"), "shutdown must flush pending saves");
+    }
+
+    @Test
+    @Timeout(30)
+    void callerSuppliedExecutorIsNeverShutDown() throws Exception {
+        RecordingSyncStickyService service = new RecordingSyncStickyService();
+        java.util.concurrent.ExecutorService callerPool = java.util.concurrent.Executors.newSingleThreadExecutor(r -> {
+            Thread t = new Thread(r, "caller-pool");
+            t.setDaemon(true);
+            return t;
+        });
+        try {
+            GrowthBookClient client = new GrowthBookClient(Options.builder()
+                    .stickyBucketService(service)
+                    .stickyBucketIdentifierAttributes(Collections.singletonList("id"))
+                    .asyncExecutor(callerPool)
+                    .build());
+            client.run(experiment("exp-exec"), user("u1", "country"));
+            client.shutdown();
+
+            assertFalse(callerPool.isShutdown(), "the SDK must never shut down a caller-supplied executor");
+            // Still usable after client shutdown.
+            callerPool.submit(() -> { }).get(5, TimeUnit.SECONDS);
+        } finally {
+            callerPool.shutdownNow();
+        }
+    }
+
+    // ------------------------------------------------------------- validation
+
+    @Test
+    void configuringBothServiceFlavorsIsRejected() {
+        Options options = Options.builder()
+                .apiHost("https://cdn.growthbook.io")
+                .clientKey("sdk-key")
+                .stickyBucketService(new InMemoryStickyBucketServiceImpl())
+                .asyncStickyBucketService(new GatedAsyncStickyService())
+                .build();
+        List<String> violations = OptionsValidator.findViolations(options);
+        assertTrue(violations.stream().anyMatch(v -> v.contains("not both")),
+                "expected mutual-exclusion violation, got: " + violations);
+    }
+}

--- a/lib/src/test/java/growthbook/sdk/java/multiusermode/StickyBucketManagerTest.java
+++ b/lib/src/test/java/growthbook/sdk/java/multiusermode/StickyBucketManagerTest.java
@@ -1,0 +1,386 @@
+package growthbook.sdk.java.multiusermode;
+
+import growthbook.sdk.java.model.StickyAssignmentsDocument;
+import growthbook.sdk.java.stickyBucketing.AsyncStickyBucketService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for the sticky bucket manager's invariants: fetch coalescing,
+ * authoritative overlay (a stale read can never roll back a local write),
+ * per-key save serialization with trailing saves, rejection semantics, flush,
+ * bounded eviction that never drops unsaved documents, and the opt-in cache.
+ *
+ * <p>All tests drive a hand-completed service double — no executors, no sleeps.
+ */
+class StickyBucketManagerTest {
+
+    /** Service double whose futures are completed manually by the test. */
+    private static final class ScriptedService implements AsyncStickyBucketService {
+        final List<Map<String, String>> fetchCalls = new CopyOnWriteArrayList<>();
+        final List<CompletableFuture<Map<String, StickyAssignmentsDocument>>> pendingFetches = new CopyOnWriteArrayList<>();
+        final List<StickyAssignmentsDocument> savedDocs = new CopyOnWriteArrayList<>();
+        final List<CompletableFuture<Void>> pendingSaves = new CopyOnWriteArrayList<>();
+        final Map<String, StickyAssignmentsDocument> store = new ConcurrentHashMap<>();
+        volatile boolean completeFetchesImmediately = false;
+        volatile boolean completeSavesImmediately = false;
+        volatile RuntimeException throwOnFetch = null;
+        volatile RuntimeException throwOnSave = null;
+
+        @Override
+        public CompletionStage<StickyAssignmentsDocument> getAssignments(String attributeName, String attributeValue) {
+            return CompletableFuture.completedFuture(store.get(getKey(attributeName, attributeValue)));
+        }
+
+        @Override
+        public CompletionStage<Void> saveAssignments(StickyAssignmentsDocument doc) {
+            RuntimeException toThrow = throwOnSave;
+            if (toThrow != null) {
+                throwOnSave = null; // throw once
+                throw toThrow;
+            }
+            savedDocs.add(doc);
+            store.put(getKey(doc.getAttributeName(), doc.getAttributeValue()), doc);
+            if (completeSavesImmediately) {
+                return CompletableFuture.completedFuture(null);
+            }
+            CompletableFuture<Void> pending = new CompletableFuture<>();
+            pendingSaves.add(pending);
+            return pending;
+        }
+
+        @Override
+        public CompletionStage<Map<String, StickyAssignmentsDocument>> getAllAssignments(Map<String, String> attributes) {
+            if (throwOnFetch != null) {
+                throw throwOnFetch;
+            }
+            fetchCalls.add(attributes);
+            if (completeFetchesImmediately) {
+                Map<String, StickyAssignmentsDocument> result = new HashMap<>();
+                for (Map.Entry<String, String> attribute : attributes.entrySet()) {
+                    StickyAssignmentsDocument doc = store.get(getKey(attribute.getKey(), attribute.getValue()));
+                    if (doc != null) {
+                        result.put(getKey(doc.getAttributeName(), doc.getAttributeValue()), doc);
+                    }
+                }
+                return CompletableFuture.completedFuture(result);
+            }
+            CompletableFuture<Map<String, StickyAssignmentsDocument>> pending = new CompletableFuture<>();
+            pendingFetches.add(pending);
+            return pending;
+        }
+    }
+
+    private static StickyAssignmentsDocument doc(String value, String expKey, String variation) {
+        Map<String, String> assignments = new HashMap<>();
+        assignments.put(expKey, variation);
+        return new StickyAssignmentsDocument("id", value, assignments);
+    }
+
+    private static Map<String, String> attrs(String idValue) {
+        return Collections.singletonMap("id", idValue);
+    }
+
+    // ------------------------------------------------------------- coalescing
+
+    @Test
+    @Timeout(10)
+    void concurrentFetchesForSameAttributesShareOneStoreCall() throws Exception {
+        ScriptedService service = new ScriptedService();
+        StickyBucketManager manager = new StickyBucketManager(service, null, null);
+
+        CompletableFuture<Map<String, StickyAssignmentsDocument>> first = manager.fetchAssignments(attrs("u1"));
+        CompletableFuture<Map<String, StickyAssignmentsDocument>> second = manager.fetchAssignments(attrs("u1"));
+
+        assertEquals(1, service.fetchCalls.size(), "concurrent identical fetches must coalesce");
+
+        Map<String, StickyAssignmentsDocument> fetched = new HashMap<>();
+        fetched.put("id||u1", doc("u1", "exp__0", "1"));
+        service.pendingFetches.get(0).complete(fetched);
+
+        assertEquals("1", first.get(5, TimeUnit.SECONDS).get("id||u1").getAssignments().get("exp__0"));
+        assertEquals("1", second.get(5, TimeUnit.SECONDS).get("id||u1").getAssignments().get("exp__0"));
+    }
+
+    @Test
+    @Timeout(10)
+    void distinctAttributesFetchIndependently() {
+        ScriptedService service = new ScriptedService();
+        StickyBucketManager manager = new StickyBucketManager(service, null, null);
+
+        manager.fetchAssignments(attrs("u1"));
+        manager.fetchAssignments(attrs("u2"));
+
+        assertEquals(2, service.fetchCalls.size());
+    }
+
+    @Test
+    @Timeout(10)
+    void waiterCancellationDoesNotPoisonTheSharedFetch() throws Exception {
+        ScriptedService service = new ScriptedService();
+        StickyBucketManager manager = new StickyBucketManager(service, null, null);
+
+        CompletableFuture<Map<String, StickyAssignmentsDocument>> owner = manager.fetchAssignments(attrs("u1"));
+        CompletableFuture<Map<String, StickyAssignmentsDocument>> waiter = manager.fetchAssignments(attrs("u1"));
+
+        waiter.cancel(true);
+
+        service.pendingFetches.get(0).complete(Collections.emptyMap());
+        assertNotNull(owner.get(5, TimeUnit.SECONDS), "cancelling one caller's future must not affect others");
+    }
+
+    // ---------------------------------------------------------------- overlay
+
+    @Test
+    @Timeout(10)
+    void staleFetchCompletingAfterLocalWriteCannotRollItBack() throws Exception {
+        ScriptedService service = new ScriptedService();
+        service.completeSavesImmediately = true;
+        StickyBucketManager manager = new StickyBucketManager(service, null, null);
+
+        // A fetch is in flight against a store that does NOT yet contain the doc...
+        CompletableFuture<Map<String, StickyAssignmentsDocument>> stale = manager.fetchAssignments(attrs("u1"));
+        // ...while this process assigns and records a new document.
+        manager.recordAndSave(doc("u1", "exp__0", "treatment"));
+        // The stale store response arrives last.
+        service.pendingFetches.get(0).complete(Collections.emptyMap());
+
+        Map<String, StickyAssignmentsDocument> result = stale.get(5, TimeUnit.SECONDS);
+        assertNotNull(result.get("id||u1"), "authoritative overlay must re-apply the local write");
+        assertEquals("treatment", result.get("id||u1").getAssignments().get("exp__0"));
+    }
+
+    @Test
+    @Timeout(10)
+    void assignmentsFromDifferentSnapshotsForSameIdentifierAllSurvive() throws Exception {
+        // Port of the Python 2.4.0 P1 regression: same identifier reached through
+        // different attribute sets must never lose assignments to last-write-wins.
+        ScriptedService service = new ScriptedService();
+        service.completeFetchesImmediately = true;
+        service.completeSavesImmediately = true;
+        StickyBucketManager manager = new StickyBucketManager(service, null, null);
+
+        manager.recordAndSave(doc("u1", "exp_a__0", "a1")).get(5, TimeUnit.SECONDS);
+        manager.recordAndSave(doc("u1", "exp_b__0", "b1")).get(5, TimeUnit.SECONDS);
+
+        StickyAssignmentsDocument persisted = service.store.get("id||u1");
+        assertEquals("a1", persisted.getAssignments().get("exp_a__0"), "first assignment lost");
+        assertEquals("b1", persisted.getAssignments().get("exp_b__0"), "second assignment lost");
+    }
+
+    // -------------------------------------------------------- save semantics
+
+    @Test
+    @Timeout(10)
+    void savesAreSerializedPerKeyWithOneTrailingSave() throws Exception {
+        ScriptedService service = new ScriptedService();
+        StickyBucketManager manager = new StickyBucketManager(service, null, null);
+
+        // First save goes in flight (gated open).
+        manager.recordAndSave(doc("u1", "exp_a__0", "a"));
+        assertEquals(1, service.savedDocs.size());
+
+        // Two more writes while the save is in flight: dirty flag, no new store call.
+        manager.recordAndSave(doc("u1", "exp_b__0", "b"));
+        CompletableFuture<Void> lastWaiter = manager.recordAndSave(doc("u1", "exp_c__0", "c"));
+        assertEquals(1, service.savedDocs.size(), "in-flight save must serialize concurrent writes");
+
+        // Completing the first save triggers exactly ONE trailing save with the merged doc.
+        service.pendingSaves.get(0).complete(null);
+        assertEquals(2, service.savedDocs.size(), "dirty key gets one trailing save, not one per write");
+        StickyAssignmentsDocument trailing = service.savedDocs.get(1);
+        assertEquals("a", trailing.getAssignments().get("exp_a__0"));
+        assertEquals("b", trailing.getAssignments().get("exp_b__0"));
+        assertEquals("c", trailing.getAssignments().get("exp_c__0"));
+
+        service.pendingSaves.get(1).complete(null);
+        lastWaiter.get(5, TimeUnit.SECONDS);
+    }
+
+    @Test
+    @Timeout(10)
+    void rejectedSaveStaysDirtyAndFlushRetriesIt() throws Exception {
+        ScriptedService service = new ScriptedService();
+        service.completeSavesImmediately = true;
+        service.throwOnSave = new RejectedExecutionException("pool saturated");
+        StickyBucketManager manager = new StickyBucketManager(service, null, null);
+
+        manager.recordAndSave(doc("u1", "exp__0", "v"));
+        assertEquals(0, service.savedDocs.size(), "rejected save must not reach the store");
+
+        // The document is still local truth and flush re-attempts it.
+        manager.flush().get(5, TimeUnit.SECONDS);
+        assertEquals(1, service.savedDocs.size(), "flush must re-kick a rejected save");
+        assertEquals("v", service.store.get("id||u1").getAssignments().get("exp__0"));
+    }
+
+    @Test
+    @Timeout(10)
+    void failedSaveIsLoggedNotRetriedButDocRemainsAuthoritative() throws Exception {
+        ScriptedService service = new ScriptedService();
+        StickyBucketManager manager = new StickyBucketManager(service, null, null);
+
+        CompletableFuture<Void> waiter = manager.recordAndSave(doc("u1", "exp__0", "v"));
+        service.pendingSaves.get(0).completeExceptionally(new RuntimeException("store down"));
+        waiter.get(5, TimeUnit.SECONDS); // quiesces without retry (JS/Python parity)
+        assertEquals(1, service.savedDocs.size());
+
+        // The overlay still serves the local write.
+        service.completeFetchesImmediately = true;
+        Map<String, StickyAssignmentsDocument> result =
+                manager.fetchAssignments(attrs("u1")).get(5, TimeUnit.SECONDS);
+        assertEquals("v", result.get("id||u1").getAssignments().get("exp__0"));
+    }
+
+    @Test
+    @Timeout(10)
+    void flushWaitsForPendingSaves() throws Exception {
+        ScriptedService service = new ScriptedService();
+        StickyBucketManager manager = new StickyBucketManager(service, null, null);
+
+        manager.recordAndSave(doc("u1", "exp__0", "v"));
+        CompletableFuture<Void> flush = manager.flush();
+        assertFalse(flush.isDone(), "flush must wait for the in-flight save");
+
+        service.pendingSaves.get(0).complete(null);
+        flush.get(5, TimeUnit.SECONDS);
+    }
+
+    // -------------------------------------------------------------- failures
+
+    @Test
+    @Timeout(10)
+    void fetchFailurePropagates() {
+        ScriptedService service = new ScriptedService();
+        service.throwOnFetch = new RejectedExecutionException("pool saturated");
+        StickyBucketManager manager = new StickyBucketManager(service, null, null);
+
+        CompletableFuture<Map<String, StickyAssignmentsDocument>> fetch = manager.fetchAssignments(attrs("u1"));
+        ExecutionException error = assertThrows(ExecutionException.class, () -> fetch.get(5, TimeUnit.SECONDS));
+        assertTrue(error.getCause() instanceof RejectedExecutionException);
+    }
+
+    @Test
+    @Timeout(10)
+    void fetchRejectionDoesNotWedgeSubsequentFetches() throws Exception {
+        ScriptedService service = new ScriptedService();
+        service.throwOnFetch = new RejectedExecutionException("pool saturated");
+        StickyBucketManager manager = new StickyBucketManager(service, null, null);
+        assertThrows(ExecutionException.class,
+                () -> manager.fetchAssignments(attrs("u1")).get(5, TimeUnit.SECONDS));
+
+        service.throwOnFetch = null;
+        service.completeFetchesImmediately = true;
+        assertNotNull(manager.fetchAssignments(attrs("u1")).get(5, TimeUnit.SECONDS),
+                "a failed fetch must not leave a poisoned in-flight entry behind");
+    }
+
+    // -------------------------------------------------------------- eviction
+
+    @Test
+    @Timeout(30)
+    void evictionBoundsTheDocMapButNeverDropsUnsavedDocs() throws Exception {
+        ScriptedService service = new ScriptedService();
+        service.completeSavesImmediately = true;
+        StickyBucketManager manager = new StickyBucketManager(service, null, null);
+
+        // One document whose save is held in flight — unsaved local truth.
+        service.completeSavesImmediately = false;
+        manager.recordAndSave(doc("dirty-user", "exp__0", "keep-me"));
+        service.completeSavesImmediately = true;
+
+        // Blow past the bound with clean saves.
+        for (int i = 0; i < StickyBucketManager.STICKY_DOCS_MAX + 200; i++) {
+            manager.recordAndSave(doc("user-" + i, "exp__0", "v")).get(5, TimeUnit.SECONDS);
+        }
+
+        assertTrue(manager.authoritativeDocCount() <= StickyBucketManager.STICKY_DOCS_MAX + 1,
+                "authoritative doc map must be bounded, was " + manager.authoritativeDocCount());
+        assertNotNull(manager.authoritativeDoc("id||dirty-user"),
+                "a document with an in-flight (unsaved) save must never be evicted");
+
+        service.pendingSaves.get(0).complete(null);
+    }
+
+    // ------------------------------------------------------------------ cache
+
+    @Test
+    @Timeout(10)
+    void cacheDisabledByDefaultFetchesEveryTime() throws Exception {
+        ScriptedService service = new ScriptedService();
+        service.completeFetchesImmediately = true;
+        StickyBucketManager manager = new StickyBucketManager(service, null, null);
+
+        manager.fetchAssignments(attrs("u1")).get(5, TimeUnit.SECONDS);
+        manager.fetchAssignments(attrs("u1")).get(5, TimeUnit.SECONDS);
+
+        assertEquals(2, service.fetchCalls.size(), "per-eval fetch is the default; no implicit caching");
+    }
+
+    @Test
+    @Timeout(10)
+    void optInCacheServesRepeatFetchesAndStillOverlaysLocalWrites() throws Exception {
+        ScriptedService service = new ScriptedService();
+        service.completeFetchesImmediately = true;
+        service.completeSavesImmediately = true;
+        StickyBucketManager manager = new StickyBucketManager(service, 30L, 100);
+
+        manager.fetchAssignments(attrs("u1")).get(5, TimeUnit.SECONDS);
+        manager.fetchAssignments(attrs("u1")).get(5, TimeUnit.SECONDS);
+        assertEquals(1, service.fetchCalls.size(), "TTL cache must absorb the repeat fetch");
+
+        // A local write after caching must still be visible through the cache.
+        manager.recordAndSave(doc("u1", "exp__0", "post-cache")).get(5, TimeUnit.SECONDS);
+        Map<String, StickyAssignmentsDocument> cached = manager.fetchAssignments(attrs("u1")).get(5, TimeUnit.SECONDS);
+        assertEquals("post-cache", cached.get("id||u1").getAssignments().get("exp__0"),
+                "overlay must be applied per read, never baked into the cache");
+    }
+
+    @Test
+    @Timeout(10)
+    void nonPositiveCacheSizeDisablesCaching() throws Exception {
+        ScriptedService service = new ScriptedService();
+        service.completeFetchesImmediately = true;
+        StickyBucketManager manager = new StickyBucketManager(service, 30L, -1);
+
+        manager.fetchAssignments(attrs("u1")).get(5, TimeUnit.SECONDS);
+        manager.fetchAssignments(attrs("u1")).get(5, TimeUnit.SECONDS);
+        assertEquals(2, service.fetchCalls.size());
+    }
+
+    @Test
+    @Timeout(10)
+    void failedFetchesAreNeverCached() throws Exception {
+        ScriptedService service = new ScriptedService();
+        StickyBucketManager manager = new StickyBucketManager(service, 30L, 100);
+
+        CompletableFuture<Map<String, StickyAssignmentsDocument>> failing = manager.fetchAssignments(attrs("u1"));
+        service.pendingFetches.get(0).completeExceptionally(new RuntimeException("blip"));
+        assertThrows(ExecutionException.class, () -> failing.get(5, TimeUnit.SECONDS));
+
+        service.completeFetchesImmediately = true;
+        assertNotNull(manager.fetchAssignments(attrs("u1")).get(5, TimeUnit.SECONDS));
+        assertEquals(2, service.fetchCalls.size(), "the failure must not have been cached");
+    }
+}


### PR DESCRIPTION
# Async sticky bucket service: non-blocking reads, fire-and-forget writes

Stacked on #234 (concurrency groundwork).

## Summary

Add async sticky bucketing architecture to the multi-user `GrowthBookClient`: 
- a `CompletionStage`-based `AsyncStickyBucketService`, 
- identifier-scoped coalesced reads, 
- fire-and-forget writes backed by an authoritative in-process document map (read-your-writes; a stale store read can never roll back an assignment), 
- a public flush, 
- and a JS-style prefetch API. 

Evaluation stays synchronous and CPU-only (same as JS/Python) — I/O moves to the edges. Legacy single-user `GrowthBook` behavior is untouched.

## Behavior changes (multi-user client only; changelog-flagged)

- Sticky reads are identifier-scoped (previously every primitive attribute went to the store) and coalesced.
- Sticky saves are fire-and-forget with merge + per-key serialization (previously one blocking, unmerged `saveAssignments` inside evaluation). Durability story: `flushStickyBucketSaves()` / `shutdown()`.
- Sticky bucketing activates for either service flavor (`Options.isStickyBucketingConfigured()`).
