### PR TITLE
feat: CompletableFuture evaluation API, non-blocking initializeAsync, and Loom-safe monitors

### DIFF
--- a/lib/src/main/java/growthbook/sdk/java/multiusermode/GrowthBookClient.java
+++ b/lib/src/main/java/growthbook/sdk/java/multiusermode/GrowthBookClient.java
@@ -79,6 +79,9 @@ public class GrowthBookClient {
     private volatile RemoteEvalService remoteEvalService;
     private volatile RemoteEvalCache remoteEvalCache;
     private final AtomicBoolean remoteEvalReady = new AtomicBoolean(false);
+    private final AtomicReference<CompletableFuture<Boolean>> remoteEvalInit = new AtomicReference<>();
+    private final java.util.concurrent.locks.ReentrantLock remoteEvalInitLock =
+            new java.util.concurrent.locks.ReentrantLock();
     private final AtomicBoolean clientShutdown = new AtomicBoolean(false);
     private final AtomicReference<Throwable> lastInitializationError = new AtomicReference<>();
     private final AtomicLong lastInitializationErrorAtMillis = new AtomicLong(0);
@@ -573,8 +576,14 @@ public class GrowthBookClient {
         this.callbacks.add(callback);
     }
 
-    public synchronized void shutdown() {
-        this.clientShutdown.set(true);
+    public void shutdown() {
+        // CAS instead of synchronized: shutdown blocks for seconds (sticky flush,
+        // plugin close) and a monitor held that long pins virtual-thread carriers
+        // and stalls every synchronized method on this client. CAS also makes
+        // shutdown idempotent — a second caller returns immediately.
+        if (!this.clientShutdown.compareAndSet(false, true)) {
+            return;
+        }
         // Drain sticky bucket saves FIRST, while the offload executor is fully
         // alive — shutting the executor down before the flush would discard
         // trailing saves and leave the flush waiting on futures nobody completes.
@@ -614,17 +623,49 @@ public class GrowthBookClient {
         if (this.remoteEvalReady.get()) {
             return true;
         }
-        synchronized (this) {
+        // One-time-init future instead of synchronized(this): the initialization
+        // performs blocking HTTP (SSE invalidation setup), and a monitor held
+        // across network I/O pins virtual-thread carriers and blocks every other
+        // synchronized member. Exactly one caller initializes; concurrent callers
+        // wait on the future. A failed attempt resets so the next call retries
+        // (preserving the previous retry-on-every-call semantics).
+        while (true) {
             if (this.remoteEvalReady.get()) {
                 return true;
             }
-            RemoteEvalOptionsValidator.validate(this.options);
-            getRemoteEvalService();
-            getRemoteEvalCache();
-            initializeRemoteEvalSseInvalidationIfNeeded();
-            this.globalContext.compareAndSet(null, buildGlobalContext(Collections.emptyMap(), new JsonObject()));
-            this.remoteEvalReady.set(true);
-            return true;
+            CompletableFuture<Boolean> inflight = this.remoteEvalInit.get();
+            if (inflight == null) {
+                CompletableFuture<Boolean> created = new CompletableFuture<>();
+                if (!this.remoteEvalInit.compareAndSet(null, created)) {
+                    continue;
+                }
+                try {
+                    RemoteEvalOptionsValidator.validate(this.options);
+                    getRemoteEvalService();
+                    getRemoteEvalCache();
+                    initializeRemoteEvalSseInvalidationIfNeeded();
+                    this.globalContext.compareAndSet(null, buildGlobalContext(Collections.emptyMap(), new JsonObject()));
+                    this.remoteEvalReady.set(true);
+                    created.complete(true);
+                    return true;
+                } catch (RuntimeException e) {
+                    this.remoteEvalInit.compareAndSet(created, null);
+                    created.completeExceptionally(e);
+                    throw e;
+                }
+            }
+            try {
+                return inflight.get();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException("Interrupted while waiting for remote eval initialization", e);
+            } catch (ExecutionException e) {
+                Throwable cause = e.getCause() == null ? e : e.getCause();
+                if (cause instanceof RuntimeException) {
+                    throw (RuntimeException) cause;
+                }
+                throw new RuntimeException(cause);
+            }
         }
     }
 
@@ -959,25 +1000,46 @@ public class GrowthBookClient {
         return getRemoteEvalCache().get(cacheKey, requestBody);
     }
 
-    private synchronized RemoteEvalService getRemoteEvalService() {
-        if (this.remoteEvalService == null) {
-            this.remoteEvalService = new RemoteEvalService(this.options.getApiHost(), this.options.getClientKey());
+    // Double-checked on the volatile fields with a ReentrantLock slow path:
+    // getRemoteEvalCache() sits on the remote-eval evaluation hot path, and a
+    // synchronized method there contends every eval and pins virtual threads.
+    private RemoteEvalService getRemoteEvalService() {
+        RemoteEvalService service = this.remoteEvalService;
+        if (service != null) {
+            return service;
         }
-        return this.remoteEvalService;
+        this.remoteEvalInitLock.lock();
+        try {
+            if (this.remoteEvalService == null) {
+                this.remoteEvalService = new RemoteEvalService(this.options.getApiHost(), this.options.getClientKey());
+            }
+            return this.remoteEvalService;
+        } finally {
+            this.remoteEvalInitLock.unlock();
+        }
     }
 
-    private synchronized RemoteEvalCache getRemoteEvalCache() {
-        if (this.remoteEvalCache == null) {
-            this.remoteEvalCache = new RemoteEvalCache(
-                    getRemoteEvalService(),
-                    RemoteEvalRequestBuilder.normalizeCacheSize(this.options.getRemoteEvalCacheSize()),
-                    secondsToDuration(this.options.getSwrTtlSeconds() == null
-                            ? SDKConstants.DEFAULT_SWR_TTL_SECONDS
-                            : this.options.getSwrTtlSeconds()),
-                    secondsToDuration(this.options.getRemoteEvalCacheTtlSeconds())
-            );
+    private RemoteEvalCache getRemoteEvalCache() {
+        RemoteEvalCache cache = this.remoteEvalCache;
+        if (cache != null) {
+            return cache;
         }
-        return this.remoteEvalCache;
+        this.remoteEvalInitLock.lock();
+        try {
+            if (this.remoteEvalCache == null) {
+                this.remoteEvalCache = new RemoteEvalCache(
+                        getRemoteEvalService(),
+                        RemoteEvalRequestBuilder.normalizeCacheSize(this.options.getRemoteEvalCacheSize()),
+                        secondsToDuration(this.options.getSwrTtlSeconds() == null
+                                ? SDKConstants.DEFAULT_SWR_TTL_SECONDS
+                                : this.options.getSwrTtlSeconds()),
+                        secondsToDuration(this.options.getRemoteEvalCacheTtlSeconds())
+                );
+            }
+            return this.remoteEvalCache;
+        } finally {
+            this.remoteEvalInitLock.unlock();
+        }
     }
 
     private static Duration secondsToDuration(@Nullable Integer seconds) {

--- a/lib/src/main/java/growthbook/sdk/java/multiusermode/GrowthBookClient.java
+++ b/lib/src/main/java/growthbook/sdk/java/multiusermode/GrowthBookClient.java
@@ -94,6 +94,8 @@ public class GrowthBookClient {
     /** The pool this client created for itself (and must shut down); null when the caller supplied one. */
     @Nullable
     private final ExecutorService ownedAsyncExecutor;
+    /** Where the client's async work runs: the caller-supplied executor or the owned pool. */
+    private final Executor asyncExecutor;
 
     private static final AtomicLong ASYNC_THREAD_COUNTER = new AtomicLong();
 
@@ -112,23 +114,25 @@ public class GrowthBookClient {
         this.experimentEvaluatorEvaluator = new ExperimentEvaluator();
         this.diagnosticsProvider = new GrowthBookClientDiagnosticsProvider(this.options, clientStateView());
 
+        // Eager construction is free: a ThreadPoolExecutor spawns no threads until
+        // its first submit, and an idle-timeout pool holds zero threads when quiet.
+        if (this.options.getAsyncExecutor() != null) {
+            this.ownedAsyncExecutor = null;
+            this.asyncExecutor = this.options.getAsyncExecutor();
+        } else {
+            this.ownedAsyncExecutor = newOwnedAsyncExecutor();
+            this.asyncExecutor = this.ownedAsyncExecutor;
+        }
+
         if (this.options.isStickyBucketingConfigured()) {
-            Executor executor = this.options.getAsyncExecutor();
-            if (executor == null) {
-                this.ownedAsyncExecutor = newOwnedAsyncExecutor();
-                executor = this.ownedAsyncExecutor;
-            } else {
-                this.ownedAsyncExecutor = null;
-            }
             AsyncStickyBucketService asyncService = this.options.getAsyncStickyBucketService() != null
                     ? this.options.getAsyncStickyBucketService()
-                    : new SyncOffloadStickyBucketAdapter(this.options.getStickyBucketService(), executor);
+                    : new SyncOffloadStickyBucketAdapter(this.options.getStickyBucketService(), this.asyncExecutor);
             this.stickyBucketManager = new StickyBucketManager(
                     asyncService,
                     this.options.getStickyBucketCacheTtlSeconds(),
                     this.options.getStickyBucketCacheSize());
         } else {
-            this.ownedAsyncExecutor = null;
             this.stickyBucketManager = null;
         }
 
@@ -256,6 +260,67 @@ public class GrowthBookClient {
             log.error("Failed to initialize growthbook instance", e);
             return false;
         }
+    }
+
+    /**
+     * Async twin of {@link #initialize()}: the initial feature fetch uses
+     * OkHttp's async {@code enqueue()} and retry backoff is scheduled, not
+     * slept — no thread (caller or pool) is parked through network round trips
+     * or retry delays. Mirrors {@code initialize()}'s no-throw contract: the
+     * future completes with {@code false} on failure, never exceptionally.
+     *
+     * <p>Remote-eval mode keeps its blocking initialization internally and is
+     * offloaded wholesale to the client's executor.
+     *
+     * @return future completing with whether the client is ready
+     */
+    public CompletableFuture<Boolean> initializeAsync() {
+        try {
+            OptionsValidator.validate(this.options);
+        } catch (InvalidOptionsException e) {
+            log.error("Failed to initialize growthbook instance", e);
+            return CompletableFuture.completedFuture(false);
+        }
+
+        if (this.options.isRemoteEvalEnabled()) {
+            return CompletableFuture.supplyAsync(this::initialize, this.asyncExecutor);
+        }
+
+        GBFeaturesRepository repositoryToInitialize;
+        try {
+            repositoryToInitialize = prepareRepositoryForInitialization();
+        } catch (RuntimeException e) {
+            recordInitializationFailure(e);
+            log.error("Failed to initialize growthbook instance", e);
+            return CompletableFuture.completedFuture(false);
+        }
+        if (repositoryToInitialize == null) {
+            GBFeaturesRepository repositorySnapshot = this.repository.get();
+            return CompletableFuture.completedFuture(
+                    repositorySnapshot != null && repositorySnapshot.getInitialized());
+        }
+
+        return repositoryToInitialize.initializeAsync(false)
+                // Hop off the OkHttp dispatcher / retry-scheduler thread before
+                // context building and any user continuations.
+                .thenApplyAsync(ignored -> {
+                    replaceGlobalContextFrom(repositoryToInitialize);
+                    boolean isReady = this.repository.get() == repositoryToInitialize
+                            && repositoryToInitialize.getInitialized();
+                    if (isReady) {
+                        this.lastInitializationError.set(null);
+                        this.lastInitializationErrorAtMillis.set(0);
+                        log.info("GrowthBookClient initialized repository and registered feature refresh callbacks.");
+                    }
+                    return isReady;
+                }, this.asyncExecutor)
+                .exceptionally(e -> {
+                    Throwable cause = e.getCause() == null ? e : e.getCause();
+                    recordInitializationFailure(cause);
+                    clearFailedInitialization(repositoryToInitialize);
+                    log.error("Failed to initialize growthbook instance", cause);
+                    return false;
+                });
     }
 
     private void recordInitializationFailure(Throwable error) {
@@ -409,6 +474,146 @@ public class GrowthBookClient {
                                                             Class<ValueType> valueTypeClass,
                                                             UserContext userContext) {
         return featureEvaluator.evaluateFeature(key, getEvalContext(userContext), valueTypeClass);
+    }
+
+    // ------------------------------------------------------------------------
+    // Asynchronous evaluation API.
+    //
+    // Feature evaluation itself is synchronous and CPU-only (matching the
+    // JavaScript SDK); what these methods make non-blocking is the I/O at the
+    // edges — the sticky bucket read before evaluation and, for remote eval,
+    // the HTTP round trip. With no sticky bucket service configured the
+    // returned futures are already complete.
+    //
+    // Contract: returned futures are caller-owned. cancel() detaches the
+    // caller's stage only — it never aborts the underlying store or network
+    // operation and never affects other callers coalesced onto the same fetch.
+    // Completion runs on the client's executor (Options.asyncExecutor, or the
+    // client-owned pool), never on a store client's I/O thread. The remaining
+    // convenience overloads of the sync API compose from these, e.g.
+    // getFeatureAsync(key, user).thenApply(FeatureResult::getValue).
+    // Reactor wrap: Mono.defer(() -> Mono.fromFuture(client.evalFeatureAsync(...))).
+    // ------------------------------------------------------------------------
+
+    /**
+     * Async twin of {@link #evalFeature(String, Class, UserContext)}: evaluates
+     * without blocking the calling thread on sticky bucket or remote-eval I/O.
+     *
+     * @param key            feature key
+     * @param valueTypeClass value type token
+     * @param userContext    user context
+     * @param <ValueType>    feature value type
+     * @return future completing with the feature result; completes
+     *         exceptionally when a configured sticky bucket store fails
+     */
+    public <ValueType> CompletableFuture<FeatureResult<ValueType>> evalFeatureAsync(String key,
+                                                                                    Class<ValueType> valueTypeClass,
+                                                                                    UserContext userContext) {
+        return getEvalContextAsync(userContext)
+                .thenApply(evalContext -> featureEvaluator.evaluateFeature(key, evalContext, valueTypeClass));
+    }
+
+    /**
+     * Async twin of {@link #isOn(String, UserContext)}.
+     *
+     * @param featureKey  feature key
+     * @param userContext user context
+     * @return future completing with whether the feature is on
+     */
+    public CompletableFuture<Boolean> isOnAsync(String featureKey, UserContext userContext) {
+        return getEvalContextAsync(userContext)
+                .thenApply(evalContext -> featureEvaluator.evaluateFeature(featureKey, evalContext, Object.class).isOn());
+    }
+
+    /**
+     * Async twin of {@link #isOff(String, UserContext)}.
+     *
+     * @param featureKey  feature key
+     * @param userContext user context
+     * @return future completing with whether the feature is off
+     */
+    public CompletableFuture<Boolean> isOffAsync(String featureKey, UserContext userContext) {
+        return getEvalContextAsync(userContext)
+                .thenApply(evalContext -> featureEvaluator.evaluateFeature(featureKey, evalContext, Object.class).isOff());
+    }
+
+    /**
+     * Async twin of {@link #getFeatureValue(String, Object, Class, UserContext)}:
+     * same deserialization and default-value semantics.
+     *
+     * @param featureKey              feature key
+     * @param defaultValue            value when the feature is missing or evaluation fails
+     * @param gsonDeserializableClass value type token
+     * @param userContext             user context
+     * @param <ValueType>             feature value type
+     * @return future completing with the deserialized value or the default
+     */
+    public <ValueType> CompletableFuture<ValueType> getFeatureValueAsync(String featureKey,
+                                                                         ValueType defaultValue,
+                                                                         Class<ValueType> gsonDeserializableClass,
+                                                                         UserContext userContext) {
+        return getEvalContextAsync(userContext).thenApply(evalContext -> {
+            try {
+                Object maybeValue = featureEvaluator
+                        .evaluateFeature(featureKey, evalContext, gsonDeserializableClass).getValue();
+                if (maybeValue == null) {
+                    return defaultValue;
+                }
+                String stringValue = GrowthBookJsonUtils.getInstance().gson.toJson(maybeValue);
+                return GrowthBookJsonUtils.getInstance().gson.fromJson(stringValue, gsonDeserializableClass);
+            } catch (Exception e) {
+                log.error(e.getMessage(), e);
+                return defaultValue;
+            }
+        });
+    }
+
+    /**
+     * Async twin of {@link #getFeature(FeatureKey, UserContext)}.
+     *
+     * @param featureKey  typed feature key
+     * @param userContext user context
+     * @param <T>         feature value type carried by the key
+     * @return future completing with the feature result
+     */
+    public <T> CompletableFuture<FeatureResult<T>> getFeatureAsync(FeatureKey<T> featureKey, UserContext userContext) {
+        Objects.requireNonNull(featureKey, "featureKey");
+        return evalFeatureAsync(featureKey.getKey(), featureKey.getValueType(), userContext);
+    }
+
+    /**
+     * Async twin of {@link #getFeatureValue(FeatureKey, Object, UserContext)}.
+     *
+     * @param featureKey   typed feature key
+     * @param defaultValue value when the feature is missing or evaluation fails
+     * @param userContext  user context
+     * @param <T>          feature value type carried by the key
+     * @return future completing with the deserialized value or the default
+     */
+    public <T> CompletableFuture<T> getFeatureValueAsync(FeatureKey<T> featureKey,
+                                                         T defaultValue,
+                                                         UserContext userContext) {
+        Objects.requireNonNull(featureKey, "featureKey");
+        return getFeatureValueAsync(featureKey.getKey(), defaultValue, featureKey.getValueType(), userContext);
+    }
+
+    /**
+     * Async twin of {@link #run(Experiment, UserContext)} — evaluates the inline
+     * experiment and fires subscriptions, without blocking on sticky bucket I/O.
+     *
+     * @param experiment  inline experiment
+     * @param userContext user context
+     * @param <ValueType> variation value type
+     * @return future completing with the experiment result
+     */
+    public <ValueType> CompletableFuture<ExperimentResult<ValueType>> runAsync(Experiment<ValueType> experiment,
+                                                                               UserContext userContext) {
+        return getEvalContextAsync(userContext).thenApply(evalContext -> {
+            ExperimentResult<ValueType> result =
+                    experimentEvaluatorEvaluator.evaluateExperiment(experiment, evalContext, null);
+            fireSubscriptions(experiment, result);
+            return result;
+        });
     }
 
     public Boolean isOn(String featureKey, UserContext userContext) {
@@ -785,8 +990,12 @@ public class GrowthBookClient {
         if (this.options.isRemoteEvalEnabled()) {
             return getRemoteEvalContext(updatedUserContext);
         }
+        return buildLocalEvalContext(updatedUserContext);
+    }
+
+    private EvaluationContext buildLocalEvalContext(UserContext mergedUserContext) {
         EvaluationContext evaluationContext = withPluginRegistry(
-                new EvaluationContext(getLocalGlobalContext(), updatedUserContext, new EvaluationContext.StackContext(), this.options));
+                new EvaluationContext(getLocalGlobalContext(), mergedUserContext, new EvaluationContext.StackContext(), this.options));
         if (this.stickyBucketManager != null) {
             // Fire-and-forget persistence (JS/Python parity): evaluation never waits
             // on the store; the manager merges, serializes per key, and tracks the
@@ -794,6 +1003,28 @@ public class GrowthBookClient {
             evaluationContext.setStickyBucketDocWriter(this.stickyBucketManager::recordAndSave);
         }
         return evaluationContext;
+    }
+
+    private CompletableFuture<EvaluationContext> getEvalContextAsync(UserContext userContext) {
+        UserContext merged = toUserContextWithMergedAttributesOnly(userContext);
+        if (this.options.isRemoteEvalEnabled()) {
+            // Remote eval performs blocking HTTP on a cache miss: offload wholesale.
+            return CompletableFuture.supplyAsync(() -> getRemoteEvalContext(merged), this.asyncExecutor);
+        }
+        if (this.stickyBucketManager == null || merged.getStickyBucketAssignmentDocs() != null) {
+            return CompletableFuture.completedFuture(buildLocalEvalContext(merged));
+        }
+        Map<String, String> attributes = stickyIdentifierAttributesFor(merged.getAttributes());
+        // Exactly ONE executor hop, at the foreign-completion boundary: the sticky
+        // store's completion thread (a Lettuce/Netty event loop, an OkHttp
+        // dispatcher) must never run evaluation, the user's tracking callback, or
+        // caller continuations. The hop also serves as the defensive copy of the
+        // shared coalesced future — a caller's cancel() cannot reach it.
+        return this.stickyBucketManager.fetchAssignments(attributes)
+                .thenApplyAsync(docs -> {
+                    merged.setStickyBucketAssignmentDocs(docs);
+                    return buildLocalEvalContext(merged);
+                }, this.asyncExecutor);
     }
 
     /**

--- a/lib/src/main/java/growthbook/sdk/java/repository/GBFeaturesRepository.java
+++ b/lib/src/main/java/growthbook/sdk/java/repository/GBFeaturesRepository.java
@@ -54,6 +54,8 @@ import java.time.Instant;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -84,6 +86,11 @@ public class GBFeaturesRepository implements IGBFeaturesRepository {
     };
     private static final ThreadFactory POLL_THREAD_FACTORY = runnable -> {
         Thread thread = new Thread(runnable, "growthbook-feature-poll");
+        thread.setDaemon(true);
+        return thread;
+    };
+    private static final ThreadFactory FETCH_RETRY_THREAD_FACTORY = runnable -> {
+        Thread thread = new Thread(runnable, "growthbook-fetch-retry");
         thread.setDaemon(true);
         return thread;
     };
@@ -205,6 +212,19 @@ public class GBFeaturesRepository implements IGBFeaturesRepository {
 
     @Nullable
     private EventSource sseEventSource = null;
+
+    /** In-flight enqueue()-based feature fetch, retained so shutdown() can cancel it. */
+    @Nullable
+    private volatile Call inflightAsyncFetchCall;
+
+    /** Result futures of async fetches not yet completed — failed at shutdown so nothing ever hangs. */
+    private final java.util.Set<CompletableFuture<Void>> pendingAsyncFetches = ConcurrentHashMap.newKeySet();
+
+    /** Daemon timer for async fetch retry backoff (lazy; no Thread.sleep on any pool thread). */
+    @Nullable
+    private volatile ScheduledExecutorService asyncFetchRetryScheduler;
+    private final java.util.concurrent.locks.ReentrantLock asyncFetchRetrySchedulerLock =
+            new java.util.concurrent.locks.ReentrantLock();
 
     /**
      * The current features payload — raw JSON and parsed forms captured together
@@ -638,6 +658,140 @@ public class GBFeaturesRepository implements IGBFeaturesRepository {
         initialize(false);
     }
 
+    /**
+     * Non-blocking initialization for the stale-while-revalidate and SSE
+     * strategies: the initial feature fetch goes through OkHttp's async
+     * {@code enqueue()} and retry backoff is scheduled on a daemon timer — no
+     * caller thread is parked through network round-trips or retry delays.
+     * Completion may happen on an OkHttp dispatcher or retry-scheduler thread;
+     * callers must hop to their own executor before doing significant work.
+     *
+     * @param retryOnFailure passed through to the SSE reconnect logic
+     * @return a future completing when features are loaded (possibly from the
+     *         cache fallback) and background refresh is running, or completing
+     *         exceptionally when the fetch fails without a usable fallback
+     */
+    public CompletableFuture<Void> initializeAsync(Boolean retryOnFailure) {
+        if (this.initialized) {
+            return CompletableFuture.completedFuture(null);
+        }
+        if (this.refreshStrategy == FeatureRefreshStrategy.REMOTE_EVAL_STRATEGY) {
+            // Remote eval keeps its blocking initialization; callers offload it.
+            CompletableFuture<Void> unsupported = new CompletableFuture<>();
+            unsupported.completeExceptionally(new IllegalStateException(
+                    "initializeAsync does not support the remote-eval strategy; use initialize() on an executor"));
+            return unsupported;
+        }
+        return fetchFeaturesAsync().thenRun(() -> {
+            if (this.refreshStrategy == FeatureRefreshStrategy.SERVER_SENT_EVENTS) {
+                initializeSSE(retryOnFailure);
+            } else {
+                schedulePolling();
+            }
+            this.initialized = true;
+        });
+    }
+
+    /**
+     * Fetch features via OkHttp {@code enqueue()} with scheduled (never slept)
+     * retry backoff, honoring the same retry policy, cache-freshness skip, and
+     * cache-fallback failure handling as the blocking path.
+     */
+    CompletableFuture<Void> fetchFeaturesAsync() {
+        CompletableFuture<Void> result = new CompletableFuture<>();
+        if (shouldSkipRefresh(RefreshMode.DEFAULT)) {
+            log.debug("Skipping feature refresh because cached features are newer than the background fetch interval.");
+            result.complete(null);
+            return result;
+        }
+        pendingAsyncFetches.add(result);
+        result.whenComplete((v, e) -> pendingAsyncFetches.remove(result));
+        attemptAsyncFetch(result, 1);
+        return result;
+    }
+
+    private void attemptAsyncFetch(CompletableFuture<Void> result, int attempt) {
+        if (this.shuttingDown.get()) {
+            result.completeExceptionally(new IllegalStateException("repository is shut down"));
+            return;
+        }
+        Request request;
+        try {
+            request = buildFeatureFetchRequest(RefreshMode.DEFAULT);
+        } catch (RuntimeException e) {
+            result.completeExceptionally(e);
+            return;
+        }
+        Call call = this.okHttpClient.newCall(request);
+        this.inflightAsyncFetchCall = call;
+        call.enqueue(new Callback() {
+            @Override
+            public void onResponse(@NotNull Call completedCall, @NotNull Response response) {
+                GBFeaturesRepository.this.inflightAsyncFetchCall = null;
+                try (Response toClose = response) {
+                    String sseSupportHeader = toClose.header(HttpHeaders.X_SSE_SUPPORT.getHeader());
+                    GBFeaturesRepository.this.sseAllowed = Objects.equals(sseSupportHeader, ENABLED);
+                    onSuccess(toClose);
+                    result.complete(null);
+                } catch (FeatureFetchException e) {
+                    failOrScheduleRetry(result, attempt, e);
+                } catch (RuntimeException e) {
+                    result.completeExceptionally(e);
+                }
+            }
+
+            @Override
+            public void onFailure(@NotNull Call failedCall, @NotNull IOException e) {
+                GBFeaturesRepository.this.inflightAsyncFetchCall = null;
+                if (failedCall.isCanceled()) {
+                    result.completeExceptionally(new IllegalStateException("feature fetch cancelled", e));
+                    return;
+                }
+                failOrScheduleRetry(result, attempt, new RetryableFeatureFetchException(
+                        FeatureFetchException.FeatureFetchErrorCode.NO_RESPONSE_ERROR,
+                        e.getMessage(),
+                        e
+                ));
+            }
+        });
+    }
+
+    private void failOrScheduleRetry(CompletableFuture<Void> result, int attempt, FeatureFetchException failure) {
+        int maxAttempts = this.retryPolicy.getMaxAttempts();
+        if (failure instanceof RetryableFeatureFetchException && attempt < maxAttempts && !this.shuttingDown.get()) {
+            int nextAttempt = attempt + 1;
+            long delayMillis = this.retryPolicy.getDelayMillisBeforeAttempt(nextAttempt);
+            log.warn("Feature fetch failed. Retry attempt {}/{} in {}ms.", nextAttempt, maxAttempts, delayMillis);
+            asyncFetchRetryScheduler().schedule(
+                    () -> attemptAsyncFetch(result, nextAttempt), delayMillis, TimeUnit.MILLISECONDS);
+            return;
+        }
+        try {
+            handleFetchFailure(failure); // may satisfy from the cache fallback
+            result.complete(null);
+        } catch (FeatureFetchException e) {
+            result.completeExceptionally(e);
+        } catch (RuntimeException e) {
+            result.completeExceptionally(e);
+        }
+    }
+
+    private ScheduledExecutorService asyncFetchRetryScheduler() {
+        ScheduledExecutorService scheduler = this.asyncFetchRetryScheduler;
+        if (scheduler != null) {
+            return scheduler;
+        }
+        this.asyncFetchRetrySchedulerLock.lock();
+        try {
+            if (this.asyncFetchRetryScheduler == null) {
+                this.asyncFetchRetryScheduler = Executors.newSingleThreadScheduledExecutor(FETCH_RETRY_THREAD_FACTORY);
+            }
+            return this.asyncFetchRetryScheduler;
+        } finally {
+            this.asyncFetchRetrySchedulerLock.unlock();
+        }
+    }
+
     @Override
     public void initialize(Boolean retryOnFailure) throws FeatureFetchException {
         if (this.initialized) return;
@@ -873,7 +1027,7 @@ public class GBFeaturesRepository implements IGBFeaturesRepository {
         }
     }
 
-    private void fetchFeaturesOnce(RefreshMode refreshMode) throws FeatureFetchException {
+    private Request buildFeatureFetchRequest(RefreshMode refreshMode) {
         if (this.featuresEndpoint == null) {
             throw new IllegalArgumentException("features endpoint cannot be null");
         }
@@ -892,7 +1046,11 @@ public class GBFeaturesRepository implements IGBFeaturesRepository {
                 requestBuilder.header(HttpHeaders.CACHE_CONTROL.getHeader(), "max-age=" + this.swrTtlSeconds);
             }
         }
-        Request request = requestBuilder.build();
+        return requestBuilder.build();
+    }
+
+    private void fetchFeaturesOnce(RefreshMode refreshMode) throws FeatureFetchException {
+        Request request = buildFeatureFetchRequest(refreshMode);
 
         try (Response response = this.okHttpClient.newCall(request).execute()) {
             String sseSupportHeader = response.header(HttpHeaders.X_SSE_SUPPORT.getHeader());
@@ -1211,6 +1369,21 @@ public class GBFeaturesRepository implements IGBFeaturesRepository {
     public void shutdown() {
         this.shuttingDown.set(true);
         this.sseConnected.set(false);
+        // Cancel any in-flight async fetch and pending retries so an
+        // initializeAsync() future can never hang past shutdown.
+        Call asyncFetchCall = this.inflightAsyncFetchCall;
+        if (asyncFetchCall != null) {
+            asyncFetchCall.cancel();
+            this.inflightAsyncFetchCall = null;
+        }
+        ScheduledExecutorService retryScheduler = this.asyncFetchRetryScheduler;
+        if (retryScheduler != null) {
+            retryScheduler.shutdownNow();
+            this.asyncFetchRetryScheduler = null;
+        }
+        for (CompletableFuture<Void> pending : pendingAsyncFetches) {
+            pending.completeExceptionally(new IllegalStateException("repository is shut down"));
+        }
         this.featureRefreshScheduler.shutdown();
         // stop polling
         if (this.pollScheduler != null) {

--- a/lib/src/test/java/growthbook/sdk/java/multiusermode/GrowthBookClientAsyncApiTest.java
+++ b/lib/src/test/java/growthbook/sdk/java/multiusermode/GrowthBookClientAsyncApiTest.java
@@ -1,0 +1,299 @@
+package growthbook.sdk.java.multiusermode;
+
+import com.sun.net.httpserver.HttpServer;
+import growthbook.sdk.java.model.Experiment;
+import growthbook.sdk.java.model.ExperimentResult;
+import growthbook.sdk.java.model.FeatureResult;
+import growthbook.sdk.java.model.StickyAssignmentsDocument;
+import growthbook.sdk.java.model.VariationMeta;
+import growthbook.sdk.java.multiusermode.configurations.Options;
+import growthbook.sdk.java.multiusermode.configurations.UserContext;
+import growthbook.sdk.java.multiusermode.usage.TrackingCallbackWithUser;
+import growthbook.sdk.java.stickyBucketing.AsyncStickyBucketService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The CompletableFuture evaluation surface: parity with the sync API, the
+ * executor hop off store-completion threads, caller-cancel isolation, failure
+ * propagation, and hang-proof initializeAsync/shutdown interplay. Latch-gated,
+ * no sleeps.
+ */
+class GrowthBookClientAsyncApiTest {
+
+    private static final String CLIENT_KEY = "async_api_key";
+
+    /** Async service completing fetches on its own named thread. */
+    private static final class ForeignThreadStickyService implements AsyncStickyBucketService {
+        final Map<String, StickyAssignmentsDocument> store = new HashMap<>();
+        volatile CountDownLatch fetchGate = null;
+        volatile boolean failFetches = false;
+
+        @Override
+        public CompletionStage<StickyAssignmentsDocument> getAssignments(String attributeName, String attributeValue) {
+            return CompletableFuture.completedFuture(store.get(getKey(attributeName, attributeValue)));
+        }
+
+        @Override
+        public CompletionStage<Void> saveAssignments(StickyAssignmentsDocument doc) {
+            store.put(getKey(doc.getAttributeName(), doc.getAttributeValue()), doc);
+            return CompletableFuture.completedFuture(null);
+        }
+
+        @Override
+        public CompletionStage<Map<String, StickyAssignmentsDocument>> getAllAssignments(Map<String, String> attributes) {
+            CompletableFuture<Map<String, StickyAssignmentsDocument>> pending = new CompletableFuture<>();
+            CountDownLatch gate = fetchGate;
+            Thread completer = new Thread(() -> {
+                try {
+                    if (gate != null && !gate.await(10, TimeUnit.SECONDS)) {
+                        pending.completeExceptionally(new IllegalStateException("fetch gate never opened"));
+                        return;
+                    }
+                    if (failFetches) {
+                        pending.completeExceptionally(new IllegalStateException("store unavailable"));
+                    } else {
+                        pending.complete(new HashMap<>());
+                    }
+                } catch (InterruptedException e) {
+                    pending.completeExceptionally(e);
+                }
+            }, "store-io-thread");
+            completer.setDaemon(true);
+            completer.start();
+            return pending;
+        }
+    }
+
+    private static Options stickyOptions(AsyncStickyBucketService service, TrackingCallbackWithUser tracking) {
+        return Options.builder()
+                .asyncStickyBucketService(service)
+                .stickyBucketIdentifierAttributes(Collections.singletonList("id"))
+                .trackingCallBackWithUser(tracking)
+                .build();
+    }
+
+    private static Experiment<String> experiment(String key) {
+        return Experiment.<String>builder()
+                .key(key)
+                .variations(new ArrayList<>(Arrays.asList("control", "treatment")))
+                .meta(new ArrayList<>(Arrays.asList(
+                        VariationMeta.builder().key("control").build(),
+                        VariationMeta.builder().key("treatment").build())))
+                .build();
+    }
+
+    private static UserContext user(String id) {
+        return UserContext.builder().attributesJson("{\"id\":\"" + id + "\"}").build();
+    }
+
+    @Test
+    @Timeout(30)
+    void asyncEvaluationMatchesSyncResults() throws Exception {
+        ForeignThreadStickyService service = new ForeignThreadStickyService();
+        GrowthBookClient client = new GrowthBookClient(stickyOptions(service, null));
+        try {
+            ExperimentResult<String> sync = client.run(experiment("exp-parity"), user("u1"));
+            ExperimentResult<String> async = client.runAsync(experiment("exp-parity"), user("u1"))
+                    .get(10, TimeUnit.SECONDS);
+
+            assertEquals(sync.getInExperiment(), async.getInExperiment());
+            assertEquals(sync.getVariationId(), async.getVariationId());
+            assertEquals(sync.getValue(), async.getValue());
+        } finally {
+            client.shutdown();
+        }
+    }
+
+    @Test
+    @Timeout(30)
+    void withoutStickyServiceAsyncFuturesAreAlreadyComplete() {
+        GrowthBookClient client = new GrowthBookClient();
+        try {
+            CompletableFuture<Boolean> isOn = client.isOnAsync("nope", user("u1"));
+            assertTrue(isOn.isDone(), "no sticky service and no remote eval → nothing to wait for");
+            assertFalse(isOn.join());
+        } finally {
+            client.shutdown();
+        }
+    }
+
+    @Test
+    @Timeout(30)
+    void evaluationAndTrackingNeverRunOnTheStoreCompletionThread() throws Exception {
+        ForeignThreadStickyService service = new ForeignThreadStickyService();
+        List<String> trackingThreads = new CopyOnWriteArrayList<>();
+        TrackingCallbackWithUser tracking = new TrackingCallbackWithUser() {
+            @Override
+            public <ValueType> void onTrack(Experiment<ValueType> experiment,
+                                            ExperimentResult<ValueType> result,
+                                            UserContext userContext) {
+                trackingThreads.add(Thread.currentThread().getName());
+            }
+        };
+        GrowthBookClient client = new GrowthBookClient(stickyOptions(service, tracking));
+        try {
+            client.runAsync(experiment("exp-hop"), user("u1")).get(10, TimeUnit.SECONDS);
+
+            assertFalse(trackingThreads.isEmpty(), "tracking callback did not fire");
+            for (String threadName : trackingThreads) {
+                assertFalse(threadName.equals("store-io-thread"),
+                        "evaluation (and the user's tracking callback) ran on the store's completion thread");
+                assertTrue(threadName.startsWith("growthbook-async-"),
+                        "expected the SDK executor, got: " + threadName);
+            }
+        } finally {
+            client.shutdown();
+        }
+    }
+
+    @Test
+    @Timeout(30)
+    void cancellingOneCallerDoesNotAffectACoalescedOther() throws Exception {
+        ForeignThreadStickyService service = new ForeignThreadStickyService();
+        CountDownLatch fetchGate = new CountDownLatch(1);
+        service.fetchGate = fetchGate;
+        GrowthBookClient client = new GrowthBookClient(stickyOptions(service, null));
+        try {
+            CompletableFuture<ExperimentResult<String>> first = client.runAsync(experiment("exp-cancel"), user("u1"));
+            CompletableFuture<ExperimentResult<String>> second = client.runAsync(experiment("exp-cancel"), user("u1"));
+
+            first.cancel(true);
+            fetchGate.countDown();
+
+            assertNotNull(second.get(10, TimeUnit.SECONDS),
+                    "cancelling one caller must not poison the shared coalesced fetch");
+        } finally {
+            client.shutdown();
+        }
+    }
+
+    @Test
+    @Timeout(30)
+    void stickyFetchFailureCompletesTheFutureExceptionally() {
+        ForeignThreadStickyService service = new ForeignThreadStickyService();
+        service.failFetches = true;
+        GrowthBookClient client = new GrowthBookClient(stickyOptions(service, null));
+        try {
+            CompletableFuture<Boolean> future = client.isOnAsync("any", user("u1"));
+            ExecutionException error = assertThrows(ExecutionException.class,
+                    () -> future.get(10, TimeUnit.SECONDS));
+            assertNotNull(error.getCause());
+        } finally {
+            client.shutdown();
+        }
+    }
+
+    // ------------------------------------------------------------ initializeAsync
+
+    @Test
+    @Timeout(30)
+    void initializeAsyncLoadsFeaturesWithoutBlockingTheCaller() throws Exception {
+        HttpServer server = startFeatureServer("{\"features\":{\"new-home\":{\"defaultValue\":true}}}", null);
+        GrowthBookClient client = null;
+        try {
+            client = new GrowthBookClient(Options.builder()
+                    .apiHost("http://127.0.0.1:" + server.getAddress().getPort())
+                    .clientKey(CLIENT_KEY)
+                    .build());
+
+            assertTrue(client.initializeAsync().get(10, TimeUnit.SECONDS));
+            assertTrue(client.isOn("new-home", user("u1")));
+        } finally {
+            if (client != null) {
+                client.shutdown();
+            }
+            server.stop(0);
+        }
+    }
+
+    @Test
+    @Timeout(30)
+    void initializeAsyncCompletesFalseOnInvalidOptions() throws Exception {
+        GrowthBookClient client = new GrowthBookClient(Options.builder().build()); // no apiHost/clientKey
+        try {
+            assertFalse(client.initializeAsync().get(10, TimeUnit.SECONDS),
+                    "initializeAsync mirrors initialize()'s no-throw contract");
+        } finally {
+            client.shutdown();
+        }
+    }
+
+    @Test
+    @Timeout(30)
+    void shutdownDuringInitializeAsyncNeverLeavesTheFutureHanging() throws Exception {
+        CountDownLatch responseGate = new CountDownLatch(1);
+        HttpServer server = startFeatureServer("{\"features\":{}}", responseGate);
+        GrowthBookClient client = null;
+        try {
+            client = new GrowthBookClient(Options.builder()
+                    .apiHost("http://127.0.0.1:" + server.getAddress().getPort())
+                    .clientKey(CLIENT_KEY)
+                    .build());
+
+            CompletableFuture<Boolean> initializing = client.initializeAsync();
+            client.shutdown(); // cancels the in-flight enqueue()d call
+
+            assertFalse(initializing.get(10, TimeUnit.SECONDS),
+                    "a shutdown mid-initialize must complete the future (false), never hang it");
+        } finally {
+            responseGate.countDown();
+            if (client != null) {
+                client.shutdown();
+            }
+            server.stop(0);
+        }
+    }
+
+    @Test
+    @Timeout(30)
+    void shutdownIsIdempotent() {
+        GrowthBookClient client = new GrowthBookClient();
+        client.shutdown();
+        client.shutdown(); // second call returns immediately, no exception
+    }
+
+    private static HttpServer startFeatureServer(String body, CountDownLatch responseGate) throws IOException {
+        HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/api/features/" + CLIENT_KEY, exchange -> {
+            if (responseGate != null) {
+                try {
+                    responseGate.await(15, TimeUnit.SECONDS);
+                } catch (InterruptedException ignored) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+            byte[] responseBytes = body.getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(200, responseBytes.length);
+            try (OutputStream responseBody = exchange.getResponseBody()) {
+                responseBody.write(responseBytes);
+            }
+            exchange.close();
+        });
+        server.start();
+        return server;
+    }
+}


### PR DESCRIPTION
# CompletableFuture evaluation API, non-blocking initializeAsync, and virtual-thread-safe monitors

Stacked on #235 (async sticky bucket service).

## Summary

Adds the public async surface: 
- `CompletableFuture` twins of the primary evaluation methods, 
- a genuinely non-blocking `initializeAsync()` built on OkHttp `enqueue()` with scheduled (never slept) retry backoff, - removal of the monitors that blocked across I/O — safe for virtual-thread (Loom) deployments. 
 
Evaluation itself stays synchronous and CPU-only; the futures make the I/O at the edges awaitable.

## What's included

- **Async evaluation API** on `GrowthBookClient`: `evalFeatureAsync`, `isOnAsync`, `isOffAsync`, `getFeatureAsync(FeatureKey)`, `getFeatureValueAsync` (string + typed-key overloads), `runAsync`. The remaining typed-key conveniences compose (`getFeatureAsync(key, user).thenApply(FeatureResult::getValue)`). With no sticky service and no remote eval the returned futures are already complete — zero overhead.
  - **Threading contract** (Javadoc'd): completion runs on the client's executor, never on a store client's I/O thread. There is exactly one executor hop, at the foreign-completion boundary — a Lettuce/Netty event loop or OkHttp dispatcher never runs evaluation, the user's tracking callback, or caller continuations. The hop doubles as the defensive copy: `cancel()` detaches the caller's stage only, never the shared coalesced fetch or other callers.
  - Sync-path behavior unchanged: sync callers keep the zero-hop path.
- **`initializeAsync()`** — mirrors `initialize()`'s no-throw contract (completes `false` on failure, never exceptionally). The initial fetch goes through new repository internals: `GBFeaturesRepository.initializeAsync()`/`fetchFeaturesAsync()` using OkHttp `enqueue()` and a daemon scheduler for retry backoff — no thread (caller or pool) is parked through network round trips or the up-to-~15s of retry delays the blocking path sleeps. Same retry policy, cache-freshness skip, and cache-fallback failure handling as the sync path. Remote-eval mode keeps blocking initialization internally, offloaded wholesale.
  - **Hang-proof shutdown interplay**: the repository retains the in-flight `Call` and cancels it at shutdown; pending fetch futures are completed exceptionally, and scheduled retries are cancelled — an `initializeAsync()` future can never outlive `shutdown()` unresolved.
- **Virtual-thread-safe monitors** (JDK 21 consumers; pre-JDK-24 VTs pin carriers inside `synchronized`):
  - `shutdown()` — was `synchronized` while blocking for seconds (sticky flush, plugin close), stalling every synchronized member and pinning a carrier; now CAS-guarded and idempotent.
  - `ensureRemoteEvalReady()` — performed blocking HTTP inside `synchronized(this)` on the eval path; now a one-time-init future (one caller initializes outside locks, concurrent callers await; failures reset so the next call retries, preserving prior semantics).
  - `getRemoteEvalService()`/`getRemoteEvalCache()` — `synchronized` on the remote-eval eval hot path; now double-checked volatile reads with a `ReentrantLock` slow path.
- The client-owned executor is now created whenever the caller doesn't supply one (previously only with sticky bucketing) — construction is free (no threads until first submit; idle-timeout pool holds zero threads when quiet).

## Follow-ups

- Non-blocking remote-eval internals (enqueue for the remote-eval POST) — the async path offloads the existing blocking call.
- Callback/dedup hardening (`ExperimentTracker` sizing, untrack-on-failure) — next PR.
- README examples land with the release-facing docs PR.
