### PR TITLE
fix: exposure tracking hardening — no lost exposures, right-sized dedup, callback isolation

### DIFF
--- a/lib/src/main/java/growthbook/sdk/java/evaluators/ExperimentEvaluator.java
+++ b/lib/src/main/java/growthbook/sdk/java/evaluators/ExperimentEvaluator.java
@@ -312,9 +312,7 @@ public class ExperimentEvaluator implements IExperimentEvaluator {
         }
 
         // Fire once per unique (hashAttribute, hashValue, experiment.key, variationId).
-        if (!alreadyTracked(experiment, result)) {
-            dispatchExperimentViewed(context, experiment, result);
-        }
+        trackExposure(context, experiment, result, context.isSuppressTrackingErrors());
 
         return result;
     }
@@ -417,21 +415,18 @@ public class ExperimentEvaluator implements IExperimentEvaluator {
                 log.debug("Skipping malformed remote evaluation tracking payload.");
                 continue;
             }
-            if (alreadyTracked(track.getExperiment(), track.getResult())) {
-                continue;
-            }
-            try {
-                dispatchExperimentViewed(context, track.getExperiment(), track.getResult());
-            } catch (RuntimeException e) {
-                log.warn("Tracking callback failed for remote evaluation payload.", e);
-            }
+            // Remote-eval track payloads always suppress callback failures
+            // (pre-existing behavior); the failed exposure is now also un-marked
+            // so it retries instead of being lost.
+            trackExposure(context, track.getExperiment(), track.getResult(), true);
         }
     }
 
     /**
      * Fires the user tracking callback and any registered plugins for a single exposure.
      * Plugin failures are isolated by {@link PluginRegistry}; a throwing user callback
-     * propagates to the caller.
+     * propagates to {@code trackExposure}, which un-marks the dedup key and either
+     * logs (multi-user client) or rethrows (legacy single-user contract).
      */
     private <ValueType> void dispatchExperimentViewed(
             EvaluationContext context,
@@ -448,13 +443,45 @@ public class ExperimentEvaluator implements IExperimentEvaluator {
         }
     }
 
-    private <ValueType> boolean alreadyTracked(Experiment<ValueType> experiment, ExperimentResult<ValueType> result) {
+    /**
+     * Deduped exposure delivery. When the callback throws, the dedup key is
+     * un-marked so the exposure is retried on a later evaluation instead of
+     * being lost forever (the tracker used to mark before dispatch and never
+     * un-mark). {@code suppressErrors} controls whether the exception is then
+     * logged (multi-user client — an analytics failure must not fail the
+     * assignment) or rethrown (legacy single-user contract).
+     */
+    private <ValueType> void trackExposure(EvaluationContext context,
+                                           Experiment<ValueType> experiment,
+                                           ExperimentResult<ValueType> result,
+                                           boolean suppressErrors) {
+        ExperimentTracker tracker = trackerFor(context);
         String key = trackingKey(experiment, result);
-        if (experimentTracker.isExperimentTracked(key)) {
-            return true;
+        if (tracker.isExperimentTracked(key)) {
+            return;
         }
-        experimentTracker.trackExperiment(key);
-        return false;
+        tracker.trackExperiment(key);
+        try {
+            dispatchExperimentViewed(context, experiment, result);
+        } catch (RuntimeException e) {
+            tracker.untrack(key);
+            if (suppressErrors) {
+                log.error("Tracking callback failed; the exposure will be retried on the next evaluation.", e);
+            } else {
+                throw e;
+            }
+        }
+    }
+
+    /**
+     * The multi-user client shares one right-sized tracker across evaluations
+     * (carried on the context); without it, each evaluator instance — including
+     * the fresh one allocated per prerequisite evaluation — dedupes against its
+     * own small local cache.
+     */
+    private ExperimentTracker trackerFor(EvaluationContext context) {
+        ExperimentTracker shared = context.getSharedExperimentTracker();
+        return shared != null ? shared : this.experimentTracker;
     }
 
     private <ValueType> String trackingKey(Experiment<ValueType> experiment, ExperimentResult<ValueType> result) {

--- a/lib/src/main/java/growthbook/sdk/java/evaluators/FeatureEvaluator.java
+++ b/lib/src/main/java/growthbook/sdk/java/evaluators/FeatureEvaluator.java
@@ -407,7 +407,15 @@ public class FeatureEvaluator implements IFeatureEvaluator {
     ) {
         FeatureUsageCallbackWithUser cb = context.getOptions().getFeatureUsageCallbackWithUser();
         if (cb != null) {
-            cb.onFeatureUsage(key, result, context.getUser());
+            try {
+                cb.onFeatureUsage(key, result, context.getUser());
+            } catch (RuntimeException e) {
+                if (!context.isSuppressTrackingErrors()) {
+                    throw e;
+                }
+                // Multi-user client: an analytics failure must not fail the evaluation.
+                log.error("Feature usage callback failed for key {}", key, e);
+            }
         }
         PluginRegistry registry = context.getPluginRegistry();
         if (registry != null) {

--- a/lib/src/main/java/growthbook/sdk/java/multiusermode/ExperimentTracker.java
+++ b/lib/src/main/java/growthbook/sdk/java/multiusermode/ExperimentTracker.java
@@ -4,17 +4,31 @@ import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 
 /**
- * A thread-safe LRU Cache implementation to keep track of the most recent experiments.
- * Uses Guava cache with a maximum size of 30 entries.
+ * A thread-safe LRU cache deduplicating experiment-exposure events by
+ * {@code hashAttribute + hashValue + experimentKey + variationId} (the same
+ * key composition as the JavaScript and Python SDKs).
+ *
+ * <p>Sizing matters: the multi-user client shares ONE tracker across all users,
+ * so the bound must comfortably exceed the number of concurrently active unique
+ * exposures — an undersized LRU evicts and re-fires exposures under load. Past
+ * the bound, an evicted exposure may legitimately fire again.
  */
 public class ExperimentTracker {
     private static final int MAX_EXPERIMENTS = 30;
 
     private final Cache<String, Boolean> trackedExperiments;
 
+    /** Evaluator-local tracker with the legacy 30-entry bound (single-user scope). */
     public ExperimentTracker() {
+        this(MAX_EXPERIMENTS);
+    }
+
+    /**
+     * @param maxSize maximum tracked exposures before least-recently-used eviction
+     */
+    public ExperimentTracker(int maxSize) {
         this.trackedExperiments = CacheBuilder.newBuilder()
-                .maximumSize(MAX_EXPERIMENTS)
+                .maximumSize(maxSize)
                 .build();
     }
 
@@ -24,6 +38,16 @@ public class ExperimentTracker {
 
     public boolean isExperimentTracked(String experimentId) {
         return trackedExperiments.getIfPresent(experimentId) != null;
+    }
+
+    /**
+     * Un-marks an exposure whose delivery failed, so it is retried on the next
+     * evaluation instead of being silently lost.
+     *
+     * @param experimentId the dedup key to un-mark
+     */
+    public void untrack(String experimentId) {
+        trackedExperiments.invalidate(experimentId);
     }
 
     public void clearTrackedExperiments() {

--- a/lib/src/main/java/growthbook/sdk/java/multiusermode/GrowthBookClient.java
+++ b/lib/src/main/java/growthbook/sdk/java/multiusermode/GrowthBookClient.java
@@ -88,6 +88,9 @@ public class GrowthBookClient {
     private final DiagnosticsProvider diagnosticsProvider;
     private final PluginRegistry pluginRegistry;
 
+    /** Exposure dedup shared across all of this client's evaluations; sized for multi-user traffic. */
+    private final ExperimentTracker exposureTracker = new ExperimentTracker(10_000);
+
     /** Owns all sticky bucket I/O; null when no sticky bucket service is configured. */
     @Nullable
     private final StickyBucketManager stickyBucketManager;
@@ -1087,6 +1090,12 @@ public class GrowthBookClient {
     /** Attaches this client's own plugin registry so events never route through another client's plugins. */
     private EvaluationContext withPluginRegistry(EvaluationContext context) {
         context.setPluginRegistry(this.pluginRegistry);
+        // One right-sized tracker for the whole client: the evaluator-local
+        // default (30 entries) thrashes under multi-user traffic and prerequisite
+        // evaluations would otherwise dedupe against separate caches.
+        context.setSharedExperimentTracker(this.exposureTracker);
+        // Analytics failures are logged and retried, never fail the assignment.
+        context.setSuppressTrackingErrors(true);
         return context;
     }
 

--- a/lib/src/main/java/growthbook/sdk/java/multiusermode/configurations/EvaluationContext.java
+++ b/lib/src/main/java/growthbook/sdk/java/multiusermode/configurations/EvaluationContext.java
@@ -46,6 +46,25 @@ public class EvaluationContext {
     @ToString.Exclude
     private StickyBucketDocWriter stickyBucketDocWriter;
 
+    /**
+     * Exposure-dedup tracker shared by the owning multi-user client across all
+     * of its evaluations (including prerequisite evaluations, which allocate
+     * fresh evaluator instances). Null → the evaluator's own local tracker
+     * (legacy single-user path).
+     */
+    @Nullable
+    @EqualsAndHashCode.Exclude
+    @ToString.Exclude
+    private growthbook.sdk.java.multiusermode.ExperimentTracker sharedExperimentTracker;
+
+    /**
+     * When true (set by the multi-user client), a throwing tracking callback is
+     * logged and its exposure retried instead of propagating out of evaluation —
+     * an analytics failure must not fail the assignment (JS/Python parity).
+     * False preserves the legacy single-user contract: the exception propagates.
+     */
+    private boolean suppressTrackingErrors;
+
     public EvaluationContext(GlobalContext global, UserContext user, StackContext stack, Options options) {
         this.global = global;
         this.user = user;

--- a/lib/src/test/java/growthbook/sdk/java/multiusermode/GrowthBookClientTrackingTest.java
+++ b/lib/src/test/java/growthbook/sdk/java/multiusermode/GrowthBookClientTrackingTest.java
@@ -1,0 +1,160 @@
+package growthbook.sdk.java.multiusermode;
+
+import growthbook.sdk.java.evaluators.ExperimentEvaluator;
+import growthbook.sdk.java.model.Experiment;
+import growthbook.sdk.java.model.ExperimentResult;
+import growthbook.sdk.java.model.FeatureResult;
+import growthbook.sdk.java.multiusermode.configurations.EvaluationContext;
+import growthbook.sdk.java.multiusermode.configurations.GlobalContext;
+import growthbook.sdk.java.multiusermode.configurations.Options;
+import growthbook.sdk.java.multiusermode.configurations.UserContext;
+import growthbook.sdk.java.multiusermode.usage.FeatureUsageCallbackWithUser;
+import growthbook.sdk.java.multiusermode.usage.TrackingCallbackWithUser;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Exposure-tracking hardening on the multi-user client: a throwing callback
+ * never fails the assignment and its exposure is retried (the dedup key is
+ * un-marked); dedup holds across many users (no 30-entry LRU thrash); the
+ * legacy single-user propagation contract is unchanged.
+ */
+class GrowthBookClientTrackingTest {
+
+    private static Experiment<String> experiment(String key) {
+        return Experiment.<String>builder()
+                .key(key)
+                .variations(new ArrayList<>(Arrays.asList("control", "treatment")))
+                .build();
+    }
+
+    private static UserContext user(String id) {
+        return UserContext.builder().attributesJson("{\"id\":\"" + id + "\"}").build();
+    }
+
+    @Test
+    @Timeout(30)
+    void failedTrackingCallbackDoesNotFailEvaluationAndIsRetried() {
+        AtomicInteger attempts = new AtomicInteger();
+        TrackingCallbackWithUser failsOnce = new TrackingCallbackWithUser() {
+            @Override
+            public <ValueType> void onTrack(Experiment<ValueType> experiment,
+                                            ExperimentResult<ValueType> result,
+                                            UserContext userContext) {
+                if (attempts.incrementAndGet() == 1) {
+                    throw new IllegalStateException("analytics backend down");
+                }
+            }
+        };
+        GrowthBookClient client = new GrowthBookClient(Options.builder()
+                .trackingCallBackWithUser(failsOnce)
+                .build());
+        try {
+            // First evaluation: the callback throws — the assignment must still succeed.
+            ExperimentResult<String> first = client.run(experiment("exp-retry"), user("u1"));
+            assertNotNull(first);
+            assertEquals(1, attempts.get());
+
+            // Same exposure again: the failed delivery was un-marked, so it retries.
+            client.run(experiment("exp-retry"), user("u1"));
+            assertEquals(2, attempts.get(), "failed exposure must be retried, not lost");
+
+            // Once delivered, the dedup holds.
+            client.run(experiment("exp-retry"), user("u1"));
+            assertEquals(2, attempts.get(), "delivered exposure must not re-fire");
+        } finally {
+            client.shutdown();
+        }
+    }
+
+    @Test
+    @Timeout(30)
+    void dedupHoldsAcrossManyUsers() {
+        Map<String, AtomicInteger> tracksByUser = new ConcurrentHashMap<>();
+        TrackingCallbackWithUser counting = new TrackingCallbackWithUser() {
+            @Override
+            public <ValueType> void onTrack(Experiment<ValueType> experiment,
+                                            ExperimentResult<ValueType> result,
+                                            UserContext userContext) {
+                tracksByUser.computeIfAbsent(result.getHashValue(), k -> new AtomicInteger()).incrementAndGet();
+            }
+        };
+        GrowthBookClient client = new GrowthBookClient(Options.builder()
+                .trackingCallBackWithUser(counting)
+                .build());
+        try {
+            // 100 distinct users — far past the old 30-entry evaluator-local LRU.
+            for (int i = 0; i < 100; i++) {
+                client.run(experiment("exp-dedup"), user("user-" + i));
+            }
+            assertEquals(100, tracksByUser.size());
+
+            // Second pass: with the old thrashing LRU these would all re-fire.
+            for (int i = 0; i < 100; i++) {
+                client.run(experiment("exp-dedup"), user("user-" + i));
+            }
+            for (Map.Entry<String, AtomicInteger> entry : tracksByUser.entrySet()) {
+                assertEquals(1, entry.getValue().get(),
+                        "exposure re-fired for " + entry.getKey() + " — dedup tracker thrashed");
+            }
+        } finally {
+            client.shutdown();
+        }
+    }
+
+    @Test
+    @Timeout(30)
+    void failedFeatureUsageCallbackDoesNotFailEvaluation() {
+        FeatureUsageCallbackWithUser throwing = new FeatureUsageCallbackWithUser() {
+            @Override
+            public <ValueType> void onFeatureUsage(String featureKey,
+                                                   FeatureResult<ValueType> result,
+                                                   UserContext userContext) {
+                throw new IllegalStateException("analytics backend down");
+            }
+        };
+        GrowthBookClient client = new GrowthBookClient(Options.builder()
+                .featureUsageCallbackWithUser(throwing)
+                .build());
+        try {
+            assertNotNull(client.evalFeature("missing-feature", Object.class, user("u1")),
+                    "a throwing feature usage callback must not fail evaluation on the multi-user client");
+        } finally {
+            client.shutdown();
+        }
+    }
+
+    @Test
+    @Timeout(30)
+    void legacyContextsKeepPropagatingCallbackExceptions() {
+        TrackingCallbackWithUser throwing = new TrackingCallbackWithUser() {
+            @Override
+            public <ValueType> void onTrack(Experiment<ValueType> experiment,
+                                            ExperimentResult<ValueType> result,
+                                            UserContext userContext) {
+                throw new IllegalStateException("analytics backend down");
+            }
+        };
+        Options options = Options.builder().trackingCallBackWithUser(throwing).build();
+        // A context WITHOUT the multi-user client's suppress flag — the legacy
+        // documented contract: the exception propagates out of evaluation.
+        EvaluationContext legacyContext = new EvaluationContext(
+                GlobalContext.builder().enabled(true).build(),
+                user("u1"),
+                new EvaluationContext.StackContext(),
+                options);
+
+        assertThrows(IllegalStateException.class,
+                () -> new ExperimentEvaluator().evaluateExperiment(experiment("exp-legacy"), legacyContext, null));
+    }
+}


### PR DESCRIPTION
# Exposure tracking hardening: no lost exposures, right-sized dedup, callback isolation

Stacked on #236 (async evaluation API).

## Summary

Fixes three exposure-loss/duplication defects in the multi-user client's tracking path and converges its callback-failure semantics with the JS and Python SDKs. 

Callback dispatch stays synchronous on the evaluating thread — deliberate, for durability; these changes are loss-prevention only.

## Behavior changes (multi-user client only; changelog-flagged)

- Tracking/usage callback exceptions are logged instead of propagating; failed exposures retry.
- Exposure dedup is client-wide and 10,000 entries instead of per-evaluator and 30.
