### PR TITLE
test: stickyBucket conformance cross-product and multi-threaded perf harness

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -166,6 +166,17 @@ tasks.register('runPerfHarness', JavaExec) {
     }
 }
 
+tasks.register('runStickyPerfHarness', JavaExec) {
+    group = 'verification'
+    description = 'Runs the multi-threaded sticky bucket performance harness with a simulated store.'
+    dependsOn testClasses
+    classpath = sourceSets.test.runtimeClasspath
+    mainClass = 'growthbook.sdk.java.perf.StickyBucketPerfHarness'
+    systemProperty 'stickyPerf.threads', project.findProperty('stickyPerfThreads') ?: '100'
+    systemProperty 'stickyPerf.requests', project.findProperty('stickyPerfRequests') ?: '2000'
+    systemProperty 'stickyPerf.latencyMs', project.findProperty('stickyPerfLatencyMs') ?: '5'
+}
+
 tasks.register('runTrackingPluginSmoke', JavaExec) {
     group = 'verification'
     description = 'Runs a local end-to-end smoke test for the GrowthBook tracking plugin.'

--- a/lib/src/test/java/growthbook/sdk/java/multiusermode/GrowthBookClientStickyBucketConformanceTest.java
+++ b/lib/src/test/java/growthbook/sdk/java/multiusermode/GrowthBookClientStickyBucketConformanceTest.java
@@ -1,0 +1,204 @@
+package growthbook.sdk.java.multiusermode;
+
+import com.google.common.reflect.TypeToken;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonNull;
+import com.google.gson.JsonObject;
+import growthbook.sdk.java.model.ExperimentResult;
+import growthbook.sdk.java.model.Feature;
+import growthbook.sdk.java.model.FeatureResult;
+import growthbook.sdk.java.model.StickyAssignmentsDocument;
+import growthbook.sdk.java.multiusermode.configurations.Options;
+import growthbook.sdk.java.multiusermode.configurations.UserContext;
+import growthbook.sdk.java.multiusermode.util.TransformationUtil;
+import growthbook.sdk.java.repository.FeatureSnapshot;
+import growthbook.sdk.java.repository.GBFeaturesRepository;
+import growthbook.sdk.java.stickyBucketing.AsyncStickyBucketService;
+import growthbook.sdk.java.stickyBucketing.InMemoryStickyBucketServiceImpl;
+import growthbook.sdk.java.stickyBucketing.SyncOffloadStickyBucketAdapter;
+import growthbook.sdk.java.testhelpers.TestCasesJsonHelper;
+import growthbook.sdk.java.util.GrowthBookJsonUtils;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.MockedStatic;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+/**
+ * Runs the shared cases.json {@code stickyBucket} corpus against the
+ * multi-user {@code GrowthBookClient} as a cross-product of service flavor
+ * (offloaded sync / async-native) and API (sync / {@code evalFeatureAsync}),
+ * with per-case test names. The legacy single-user runner
+ * ({@code EvaluateFeatureWithStickyBucketingFeatureTest}) keeps covering the
+ * {@code GrowthBook} class.
+ */
+class GrowthBookClientStickyBucketConformanceTest {
+
+    private enum ServiceFlavor { SYNC_OFFLOADED, ASYNC_NATIVE }
+
+    private enum Api { SYNC, ASYNC }
+
+    /** Minimal async-native in-memory store, mirroring InMemoryStickyBucketServiceImpl. */
+    private static final class AsyncInMemoryStickyService implements AsyncStickyBucketService {
+        private final InMemoryStickyBucketServiceImpl delegate = new InMemoryStickyBucketServiceImpl();
+
+        @Override
+        public CompletionStage<StickyAssignmentsDocument> getAssignments(String attributeName, String attributeValue) {
+            return java.util.concurrent.CompletableFuture.completedFuture(delegate.getAssignments(attributeName, attributeValue));
+        }
+
+        @Override
+        public CompletionStage<Void> saveAssignments(StickyAssignmentsDocument doc) {
+            delegate.saveAssignments(doc);
+            return java.util.concurrent.CompletableFuture.completedFuture(null);
+        }
+
+        StickyAssignmentsDocument stored(String key) {
+            String[] parts = key.split("\\|\\|", 2);
+            return delegate.getAssignments(parts[0], parts[1]);
+        }
+    }
+
+    static Stream<Arguments> stickyBucketCases() {
+        JsonArray cases = TestCasesJsonHelper.getInstance().getStickyBucketTestCases();
+        List<Arguments> arguments = new ArrayList<>();
+        for (int i = 0; i < cases.size(); i++) {
+            JsonArray testCase = cases.get(i).getAsJsonArray();
+            String description = testCase.get(0).getAsString();
+            for (ServiceFlavor flavor : ServiceFlavor.values()) {
+                for (Api api : Api.values()) {
+                    arguments.add(Arguments.of(description + " [" + flavor + "/" + api + "]", i, flavor, api));
+                }
+            }
+        }
+        return arguments.stream();
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("stickyBucketCases")
+    void conformance(String name, int caseIndex, ServiceFlavor flavor, Api api) throws Exception {
+        GrowthBookJsonUtils utils = GrowthBookJsonUtils.getInstance();
+        JsonArray testCase = TestCasesJsonHelper.getInstance()
+                .getStickyBucketTestCases().get(caseIndex).getAsJsonArray();
+
+        JsonElement featuresJson = testCase.get(1).getAsJsonObject().get("features");
+        JsonElement attributesJson = testCase.get(1).getAsJsonObject().get("attributes");
+        String featureKey = testCase.get(3).getAsJsonPrimitive().getAsString();
+
+        // Seed the store with the case's input documents.
+        InMemoryStickyBucketServiceImpl syncService = new InMemoryStickyBucketServiceImpl();
+        AsyncInMemoryStickyService asyncService = new AsyncInMemoryStickyService();
+        for (JsonElement element : testCase.get(2).getAsJsonArray()) {
+            StickyAssignmentsDocument doc = utils.gson.fromJson(element, StickyAssignmentsDocument.class);
+            syncService.saveAssignments(doc);
+            asyncService.saveAssignments(doc);
+        }
+
+        Options.OptionsBuilder optionsBuilder = Options.builder()
+                .apiHost("https://cdn.growthbook.io")
+                .clientKey("conformance-key");
+        if (flavor == ServiceFlavor.SYNC_OFFLOADED) {
+            optionsBuilder.stickyBucketService(syncService);
+        } else {
+            optionsBuilder.asyncStickyBucketService(asyncService);
+        }
+
+        Map<String, Feature<?>> parsedFeatures = featuresJson == null
+                ? new HashMap<>()
+                : TransformationUtil.transformFeatures(featuresJson.toString());
+
+        GBFeaturesRepository repository = mockRepository(parsedFeatures);
+        GBFeaturesRepository.GBFeaturesRepositoryBuilder builder = mockBuilder(repository);
+        GrowthBookClient client;
+        try (MockedStatic<GBFeaturesRepository> mockedStatic = mockStatic(GBFeaturesRepository.class)) {
+            mockedStatic.when(GBFeaturesRepository::builder).thenReturn(builder);
+            client = new GrowthBookClient(optionsBuilder.build());
+            client.initialize();
+        }
+
+        try {
+            UserContext user = UserContext.builder()
+                    .attributesJson(attributesJson == null ? "{}" : attributesJson.toString())
+                    .build();
+
+            FeatureResult<Object> actualFeatureResult;
+            if (api == Api.SYNC) {
+                actualFeatureResult = client.evalFeature(featureKey, Object.class, user);
+            } else {
+                actualFeatureResult = client.evalFeatureAsync(featureKey, Object.class, user)
+                        .get(10, TimeUnit.SECONDS);
+            }
+            client.flushStickyBucketSaves().get(10, TimeUnit.SECONDS);
+
+            ExperimentResult<Object> actualExperimentResult =
+                    actualFeatureResult == null ? null : actualFeatureResult.getExperimentResult();
+            ExperimentResult<Object> expectedExperimentResult = (testCase.get(4) instanceof JsonNull)
+                    ? null
+                    : utils.gson.fromJson(testCase.get(4).getAsJsonObject(), ExperimentResult.class);
+            assertEquals(expectedExperimentResult, actualExperimentResult,
+                    "experiment result mismatch for " + name);
+
+            // The persisted store must contain, for every expected document key,
+            // exactly the expected assignments (the case's expected map is the
+            // post-eval merged state for the addressed keys).
+            Map<String, StickyAssignmentsDocument> expectedDocs = utils.gson.fromJson(
+                    testCase.get(5), new TypeToken<HashMap<String, StickyAssignmentsDocument>>() { }.getType());
+            for (Map.Entry<String, StickyAssignmentsDocument> expected : expectedDocs.entrySet()) {
+                StickyAssignmentsDocument stored = flavor == ServiceFlavor.SYNC_OFFLOADED
+                        ? syncService.getAssignments(expected.getValue().getAttributeName(),
+                        expected.getValue().getAttributeValue())
+                        : asyncService.stored(expected.getKey());
+                assertNotNull(stored, "expected persisted doc missing: " + expected.getKey());
+                assertEquals(expected.getValue().getAssignments(), stored.getAssignments(),
+                        "persisted assignments mismatch for " + expected.getKey());
+            }
+        } finally {
+            client.shutdown();
+        }
+    }
+
+    private static GBFeaturesRepository mockRepository(Map<String, Feature<?>> parsedFeatures) {
+        GBFeaturesRepository repository = mock(GBFeaturesRepository.class);
+        when(repository.getInitialized()).thenReturn(true);
+        when(repository.getParsedFeatures()).thenReturn(parsedFeatures);
+        when(repository.getParsedSavedGroups()).thenReturn(new JsonObject());
+        when(repository.getFeatureSnapshot()).thenReturn(
+                FeatureSnapshot.of("{}", "{}", parsedFeatures, new JsonObject()));
+        return repository;
+    }
+
+    private static GBFeaturesRepository.GBFeaturesRepositoryBuilder mockBuilder(GBFeaturesRepository repository) {
+        GBFeaturesRepository.GBFeaturesRepositoryBuilder builder =
+                mock(GBFeaturesRepository.GBFeaturesRepositoryBuilder.class);
+        when(builder.apiHost(anyString())).thenReturn(builder);
+        when(builder.clientKey(anyString())).thenReturn(builder);
+        when(builder.decryptionKey(any())).thenReturn(builder);
+        when(builder.refreshStrategy(any())).thenReturn(builder);
+        when(builder.swrTtlSeconds(any())).thenReturn(builder);
+        when(builder.isCacheDisabled(anyBoolean())).thenReturn(builder);
+        when(builder.requestBodyForRemoteEval(any())).thenReturn(builder);
+        when(builder.cacheManager(any())).thenReturn(builder);
+        when(builder.backgroundFetchInterval(any())).thenReturn(builder);
+        when(builder.retryPolicy(any())).thenReturn(builder);
+        when(builder.build()).thenReturn(repository);
+        return builder;
+    }
+}

--- a/lib/src/test/java/growthbook/sdk/java/perf/StickyBucketPerfHarness.java
+++ b/lib/src/test/java/growthbook/sdk/java/perf/StickyBucketPerfHarness.java
@@ -1,0 +1,274 @@
+package growthbook.sdk.java.perf;
+
+import growthbook.sdk.java.model.Experiment;
+import growthbook.sdk.java.model.StickyAssignmentsDocument;
+import growthbook.sdk.java.model.VariationMeta;
+import growthbook.sdk.java.multiusermode.GrowthBookClient;
+import growthbook.sdk.java.multiusermode.configurations.Options;
+import growthbook.sdk.java.multiusermode.configurations.UserContext;
+import growthbook.sdk.java.stickyBucketing.AsyncStickyBucketService;
+import growthbook.sdk.java.stickyBucketing.StickyBucketService;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Multi-threaded harness demonstrating sticky bucket I/O behavior under load,
+ * mirroring the Python SDK's {@code tests/scripts/benchmark_async_client.py}
+ * scenarios. A simulated store latency (default 5 ms) stands in for Redis.
+ *
+ * <p>Run with: {@code ./gradlew :lib:runStickyPerfHarness}
+ * (properties: -PstickyPerfThreads, -PstickyPerfRequests, -PstickyPerfLatencyMs)
+ *
+ * <p>Context for the numbers: before the async sticky work, every evaluation
+ * performed one BLOCKING getAllAssignments per eval call on the request thread
+ * (plus a blocking save per new assignment), so throughput was capped at
+ * threads / latency with zero overlap. The scenarios below show the same work
+ * with offloaded+coalesced reads, the async API, and per-request prefetch.
+ */
+public final class StickyBucketPerfHarness {
+
+    private static final int THREADS = Integer.getInteger("stickyPerf.threads", 100);
+    private static final int REQUESTS = Integer.getInteger("stickyPerf.requests", 2_000);
+    private static final long LATENCY_MS = Long.getLong("stickyPerf.latencyMs", 5L);
+    private static final int EVALS_PER_REQUEST_PREFETCH = 10;
+
+    private StickyBucketPerfHarness() {
+    }
+
+    /** Async store completing after a scheduled delay — no threads parked. */
+    private static final class SimulatedAsyncStore implements AsyncStickyBucketService {
+        private final Map<String, StickyAssignmentsDocument> store = new ConcurrentHashMap<>();
+        private final ScheduledExecutorService timer;
+
+        SimulatedAsyncStore(ScheduledExecutorService timer) {
+            this.timer = timer;
+        }
+
+        private <T> CompletionStage<T> delayed(T value) {
+            CompletableFuture<T> future = new CompletableFuture<>();
+            timer.schedule(() -> future.complete(value), LATENCY_MS, TimeUnit.MILLISECONDS);
+            return future;
+        }
+
+        @Override
+        public CompletionStage<StickyAssignmentsDocument> getAssignments(String attributeName, String attributeValue) {
+            return delayed(store.get(getKey(attributeName, attributeValue)));
+        }
+
+        @Override
+        public CompletionStage<Void> saveAssignments(StickyAssignmentsDocument doc) {
+            store.put(getKey(doc.getAttributeName(), doc.getAttributeValue()), doc);
+            return delayed(null);
+        }
+
+        @Override
+        public CompletionStage<Map<String, StickyAssignmentsDocument>> getAllAssignments(Map<String, String> attributes) {
+            Map<String, StickyAssignmentsDocument> result = new ConcurrentHashMap<>();
+            for (Map.Entry<String, String> attribute : attributes.entrySet()) {
+                StickyAssignmentsDocument doc = store.get(getKey(attribute.getKey(), attribute.getValue()));
+                if (doc != null) {
+                    result.put(getKey(doc.getAttributeName(), doc.getAttributeValue()), doc);
+                }
+            }
+            return delayed(result);
+        }
+    }
+
+    /** Blocking store: one Thread.sleep round trip per batched call (offloaded by the client). */
+    private static final class SimulatedSyncStore implements StickyBucketService {
+        private final Map<String, StickyAssignmentsDocument> store = new ConcurrentHashMap<>();
+
+        private void roundTrip() {
+            try {
+                Thread.sleep(LATENCY_MS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+
+        @Override
+        public StickyAssignmentsDocument getAssignments(String attributeName, String attributeValue) {
+            roundTrip();
+            return store.get(attributeName + "||" + attributeValue);
+        }
+
+        @Override
+        public void saveAssignments(StickyAssignmentsDocument doc) {
+            roundTrip();
+            store.put(doc.getAttributeName() + "||" + doc.getAttributeValue(), doc);
+        }
+
+        @Override
+        public Map<String, StickyAssignmentsDocument> getAllAssignments(Map<String, String> attributes) {
+            roundTrip();
+            Map<String, StickyAssignmentsDocument> result = new ConcurrentHashMap<>();
+            for (Map.Entry<String, String> attribute : attributes.entrySet()) {
+                StickyAssignmentsDocument doc = store.get(attribute.getKey() + "||" + attribute.getValue());
+                if (doc != null) {
+                    result.put(doc.getAttributeName() + "||" + doc.getAttributeValue(), doc);
+                }
+            }
+            return result;
+        }
+    }
+
+    private static Experiment<String> experiment(String key) {
+        return Experiment.<String>builder()
+                .key(key)
+                .variations(new ArrayList<>(Arrays.asList("control", "treatment")))
+                .meta(new ArrayList<>(Arrays.asList(
+                        VariationMeta.builder().key("control").build(),
+                        VariationMeta.builder().key("treatment").build())))
+                .build();
+    }
+
+    private static UserContext user(String id) {
+        return UserContext.builder().attributesJson("{\"id\":\"" + id + "\"}").build();
+    }
+
+    public static void main(String[] args) throws Exception {
+        System.out.printf("threads=%d requests=%d simulated store latency=%dms%n%n",
+                THREADS, REQUESTS, LATENCY_MS);
+
+        ScheduledExecutorService timer = Executors.newScheduledThreadPool(2, runnable -> {
+            Thread thread = new Thread(runnable, "sim-store-timer");
+            thread.setDaemon(true);
+            return thread;
+        });
+
+        runSyncApiScenario("sync store / sync API / distinct users",
+                Options.builder().stickyBucketService(new SimulatedSyncStore())
+                        .stickyBucketIdentifierAttributes(Collections.singletonList("id")).build(),
+                true);
+        runSyncApiScenario("async store / sync API / distinct users",
+                asyncOptions(timer), true);
+        runSyncApiScenario("async store / sync API / hot user (coalesced)",
+                asyncOptions(timer), false);
+        runAsyncApiScenario("async store / async API / distinct users", asyncOptions(timer), timer);
+        runPrefetchScenario("async store / prefetch + " + EVALS_PER_REQUEST_PREFETCH + " evals per request",
+                asyncOptions(timer));
+
+        timer.shutdownNow();
+    }
+
+    private static Options asyncOptions(ScheduledExecutorService timer) {
+        return Options.builder()
+                .asyncStickyBucketService(new SimulatedAsyncStore(timer))
+                .stickyBucketIdentifierAttributes(Collections.singletonList("id"))
+                .build();
+    }
+
+    /** THREADS request threads each running blocking evaluations. */
+    private static void runSyncApiScenario(String name, Options options, boolean distinctUsers) throws Exception {
+        GrowthBookClient client = new GrowthBookClient(options);
+        List<Long> latenciesNanos = Collections.synchronizedList(new ArrayList<>(REQUESTS));
+        AtomicInteger next = new AtomicInteger();
+        CountDownLatch done = new CountDownLatch(THREADS);
+        long started = System.nanoTime();
+        for (int t = 0; t < THREADS; t++) {
+            Thread worker = new Thread(() -> {
+                int i;
+                while ((i = next.getAndIncrement()) < REQUESTS) {
+                    String userId = distinctUsers ? "user-" + i : "hot-user";
+                    long begin = System.nanoTime();
+                    client.run(experiment("exp-perf"), user(userId));
+                    latenciesNanos.add(System.nanoTime() - begin);
+                }
+                done.countDown();
+            });
+            worker.setDaemon(true);
+            worker.start();
+        }
+        done.await(10, TimeUnit.MINUTES);
+        long elapsed = System.nanoTime() - started;
+        client.shutdown();
+        report(name, elapsed, latenciesNanos);
+    }
+
+    /** One caller thread pipelining async evaluations with bounded in-flight. */
+    private static void runAsyncApiScenario(String name, Options options, ScheduledExecutorService timer) throws Exception {
+        GrowthBookClient client = new GrowthBookClient(options);
+        List<Long> latenciesNanos = Collections.synchronizedList(new ArrayList<>(REQUESTS));
+        Semaphore inflight = new Semaphore(THREADS);
+        CountDownLatch done = new CountDownLatch(REQUESTS);
+        long started = System.nanoTime();
+        for (int i = 0; i < REQUESTS; i++) {
+            inflight.acquire();
+            long begin = System.nanoTime();
+            client.runAsync(experiment("exp-perf"), user("user-" + i))
+                    .whenComplete((result, error) -> {
+                        latenciesNanos.add(System.nanoTime() - begin);
+                        inflight.release();
+                        done.countDown();
+                    });
+        }
+        done.await(10, TimeUnit.MINUTES);
+        long elapsed = System.nanoTime() - started;
+        client.shutdown();
+        report(name, elapsed, latenciesNanos);
+    }
+
+    /** JS-style pattern: prefetch once per request, then N evals with zero sticky I/O. */
+    private static void runPrefetchScenario(String name, Options options) throws Exception {
+        GrowthBookClient client = new GrowthBookClient(options);
+        List<Long> latenciesNanos = Collections.synchronizedList(new ArrayList<>(REQUESTS));
+        AtomicInteger next = new AtomicInteger();
+        AtomicLong evals = new AtomicLong();
+        CountDownLatch done = new CountDownLatch(THREADS);
+        long started = System.nanoTime();
+        for (int t = 0; t < THREADS; t++) {
+            Thread worker = new Thread(() -> {
+                int i;
+                while ((i = next.getAndIncrement()) < REQUESTS) {
+                    long begin = System.nanoTime();
+                    UserContext prefetched = client.prefetchStickyBuckets(user("user-" + i)).join();
+                    for (int e = 0; e < EVALS_PER_REQUEST_PREFETCH; e++) {
+                        client.run(experiment("exp-" + e), prefetched);
+                        evals.incrementAndGet();
+                    }
+                    latenciesNanos.add(System.nanoTime() - begin);
+                }
+                done.countDown();
+            });
+            worker.setDaemon(true);
+            worker.start();
+        }
+        done.await(10, TimeUnit.MINUTES);
+        long elapsed = System.nanoTime() - started;
+        client.shutdown();
+        System.out.printf("  (%d total evaluations across %d requests)%n", evals.get(), REQUESTS);
+        report(name, elapsed, latenciesNanos);
+    }
+
+    private static void report(String name, long elapsedNanos, List<Long> latenciesNanos) {
+        List<Long> sorted = new ArrayList<>(latenciesNanos);
+        Collections.sort(sorted);
+        double seconds = elapsedNanos / 1_000_000_000.0;
+        double throughput = sorted.size() / seconds;
+        System.out.printf("%-55s %,9.0f req/s  p50=%.1fms p95=%.1fms p99=%.1fms%n",
+                name, throughput,
+                percentileMs(sorted, 0.50), percentileMs(sorted, 0.95), percentileMs(sorted, 0.99));
+    }
+
+    private static double percentileMs(List<Long> sortedNanos, double percentile) {
+        if (sortedNanos.isEmpty()) {
+            return 0;
+        }
+        int index = Math.min(sortedNanos.size() - 1, (int) Math.floor(percentile * sortedNanos.size()));
+        return sortedNanos.get(index) / 1_000_000.0;
+    }
+}


### PR DESCRIPTION
# Conformance cross-product for the multi-user client and a multi-threaded sticky perf harness

Stacked on #237 (exposure tracking hardening).

## Summary

Validates the async sticky bucketing work against the shared cases.json corpus and demonstrates the performance behavior under load. 

The `stickyBucket` cases now run against the multi-user `GrowthBookClient` as a parametrized cross-product (per-case JUnit names), and a checked-in harness mirrors the Python SDK's benchmark scenarios.

## What's included

- **`GrowthBookClientStickyBucketConformanceTest`** — the 13 shared `stickyBucket` cases × {offloaded sync service, async-native service} × {sync API, `evalFeatureAsync()`} = 52 parametrized tests with per-case names (`@ParameterizedTest @MethodSource`), asserting both the experiment result and the persisted store state after `flushStickyBucketSaves()`. The legacy single-user runner keeps covering the `GrowthBook` class unchanged.
- **`StickyBucketPerfHarness`** (`./gradlew :lib:runStickyPerfHarness`, configurable threads/requests/latency) — mirrors `growthbook-python/tests/scripts/benchmark_async_client.py`: blocking vs async store, sync vs async API, hot-user coalescing, and the prefetch-per-request pattern, reporting throughput and p50/p95/p99.

Representative run (100 threads, 2000 requests, 5 ms simulated store latency):

| Scenario | Throughput | p50 |
|---|---|---|
| blocking store / sync API / distinct users | ~1,430 req/s | 70 ms |
| async store / sync API / distinct users | ~14,550 req/s | 6.7 ms |
| async store / sync API / hot user (coalesced) | ~13,290 req/s | 7.5 ms |
| async store / async API / distinct users | ~14,190 req/s | 7.0 ms |
| async store / prefetch + 10 evals per request | ~15,680 req/s (~157k evals/s) | 5.4 ms |

The blocking-store scenario is bounded by pool threads parked in store round trips — the documented reason to prefer `AsyncStickyBucketService` for network stores. (For context: before this work, every evaluation performed the blocking round trips on the request thread itself.)

## Test plan

- [x] Full suite `./gradlew :lib:test` — green (52 new conformance tests included)
- [x] `./gradlew :lib:runStickyPerfHarness` — completes, numbers above

## Out of scope (deliberately)

- Converting the remaining hand-rolled for-loop conformance suites (evalCondition, run, feature, ...) to `@ParameterizedTest` — worthwhile test-infrastructure cleanup, but unrelated to the async work; noted as a follow-up.
